### PR TITLE
chore: add basic CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v3
       - name: Run tests
         run: cargo test -all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test Suite
+
+concurrency:
+  # For pull requests, cancel running workflows, for master, run all
+  #
+  # `github.event.number` exists for pull requests, otherwise fall back to SHA
+  # for master
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: full
+  RUST_TEST_THREADS: 1
+  TEST_LOG: vector=debug
+  VERBOSE: true
+  CI: true
+  PROFILE: debug
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: cargo test -all
+      - name: Check code style
+        run: cargo fmt --check --all
+      - name: Run VRL tests
+        run: |
+          cd lib/tests
+          cargo run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run tests
-        run: cargo test -all
+        run: cargo test --all
       - name: Check code style
         run: cargo fmt --check --all
       - name: Run VRL tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,13 @@
 name: Test Suite
 
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches:
+      - master
+
 concurrency:
   # For pull requests, cancel running workflows, for master, run all
   #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   RUST_BACKTRACE: full
-  RUST_TEST_THREADS: 1
   TEST_LOG: vector=debug
   VERBOSE: true
   CI: true

--- a/lib/stdlib/src/encode_zstd.rs
+++ b/lib/stdlib/src/encode_zstd.rs
@@ -88,34 +88,3 @@ impl FunctionExpression for EncodeZstdFn {
         TypeDef::bytes().infallible()
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use base64::Engine;
-
-    fn decode_base64(text: &str) -> Vec<u8> {
-        let engine = base64::engine::GeneralPurpose::new(
-            &base64::alphabet::STANDARD,
-            base64::engine::general_purpose::GeneralPurposeConfig::new(),
-        );
-
-        engine.decode(text).expect("Cannot decode from Base64")
-    }
-
-    test_function![
-        encode_zstd => EncodeZstd;
-
-        with_defaults {
-            args: func_args![value: value!("you_have_successfully_decoded_me.congratulations.you_are_breathtaking.")],
-            want: Ok(value!(decode_base64("KLUv/QBY/QEAYsQOFKClbQBedqXsb96EWDax/f/F/z+gNU4ZTInaUeAj82KqPFjUzKqhcfDqAIsLvAsnY1bI/N2mHzDixRQA").as_bytes())),
-            tdef: TypeDef::bytes().infallible(),
-        }
-
-        with_custom_compression_level {
-            args: func_args![value: value!("you_have_successfully_decoded_me.congratulations.you_are_breathtaking."), compression_level: 22],
-            want: Ok(value!(decode_base64("KLUv/QCIFQIAIkQOFKClbQBedqXsb96EWDYp/f+l/x+hNU4ZrER9FNiRKw8WtVk1GgevDjBxgXdhyZgVMn+3aQ+Y2GIKAQBBAwUF").as_bytes())),
-            tdef: TypeDef::bytes().infallible(),
-        }
-    ];
-}

--- a/lib/stdlib/src/lib.rs
+++ b/lib/stdlib/src/lib.rs
@@ -9,6 +9,7 @@
     unused_comparisons
 )]
 #![allow(
+    deprecated,
     clippy::cast_possible_truncation, // allowed in initial deny commit
     clippy::cast_precision_loss, // allowed in initial deny commit
     clippy::cast_sign_loss, // allowed in initial deny commit

--- a/lib/tests/tests/functions/zstd.vrl
+++ b/lib/tests/tests/functions/zstd.vrl
@@ -1,0 +1,5 @@
+# result: true
+
+msg = "you_have_successfully_decoded_me.congratulations.you_are_breathtaking."
+assert_eq!(decode_zstd!(encode_zstd(msg, compression_level: 22)), msg);
+assert_eq!(decode_zstd!(encode_zstd(msg)), msg);

--- a/lib/value/src/lib.rs
+++ b/lib/value/src/lib.rs
@@ -23,6 +23,7 @@
     unused
 )]
 #![allow(
+    deprecated,
     clippy::cast_lossless,
     clippy::cargo_common_metadata,
     clippy::single_match_else,


### PR DESCRIPTION
- adds some basic CI tests (more will come later)
- fixed some failing tests since `Cargo.lock` was removed (since this is a library)
   - zstd tests asserts exact binary output, which changed with a version bump (tests changed to assert it can still decode)
   - deprecations are allowed, since minor version bumps can fail CI. A different approach may be needed here in the future.