### PR TITLE
fix(vrl): Add guard for limit in split() fn to be positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- added guard for the `limit` param of the `split` function to ensure it's not negative
 
 ## `0.1.0` (2023-03-27)
 - VRL was split from the Vector repo

--- a/lib/stdlib/src/split.rs
+++ b/lib/stdlib/src/split.rs
@@ -3,7 +3,10 @@ use vrl::prelude::*;
 
 fn split(value: Value, limit: Value, pattern: Value) -> Resolved {
     let string = value.try_bytes_utf8_lossy()?;
-    let limit = limit.try_integer()? as usize;
+    let limit = match limit.try_integer()? {
+        x if x < 0 => 0,
+        x => x as usize,
+    };
     match pattern {
         Value::Regex(pattern) => Ok(pattern
             .splitn(string.as_ref(), limit)
@@ -170,5 +173,40 @@ mod test {
              tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
          }
 
+        limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: 2
+            ],
+            want: Ok(value!(["This", "is a long string."])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        over_length_limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: 2000
+            ],
+            want: Ok(value!(["This", "is", "a", "long", "string."])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        zero_limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: 0
+            ],
+            want: Ok(value!([])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        negative_limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: -1
+            ],
+            want: Ok(value!([])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
     ];
 }


### PR DESCRIPTION
Note: This was migrated to the VRL repo from https://github.com/vectordotdev/vector/pull/16874

Fixes: https://github.com/vectordotdev/vrl/issues/34

- adds guard for limit to be a positive value (following [similar behavior of truncate](https://github.com/vectordotdev/vector/blob/master/lib/vrl/stdlib/src/truncate.rs#L7) to treat negative values as 0)
- adds unit tests around limit values

Before:
```
$ split("This is a long string", " ",  -10000)
["This", "is", "a", "long", "string"]
```

After:
```
$ split("This is a long string", " ",  0)
[]

$ split("This is a long string", " ",  -10000)
[]
```
