### PR TITLE
chore: make clippy fail on warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
           cd lib/tests
           cargo run
       - name: Clippy
-        run: cargo clippy --workspace --all-targets
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/lib/stdlib/benches/benches.rs
+++ b/lib/stdlib/benches/benches.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use ::value::{btreemap, Value};
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};


### PR DESCRIPTION
closes https://github.com/vectordotdev/vrl/issues/154

This makes clippy fail CI if a warning is generated. I'm not entirely sure this makes sense for a library, since dependency updates could introduce arbitrary warnings and cause CI to fail, but we will try it out and remove it / pick a different strategy if it doesn't work out.