### PR TITLE
feat(stdlib): Precompile static regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - added guard for the `limit` param of the `split` function to ensure it's not negative
+- `match` function now precompiles static regular expressions
 
 ## `0.1.0` (2023-03-27)
 - VRL was split from the Vector repo

--- a/lib/stdlib/src/match.rs
+++ b/lib/stdlib/src/match.rs
@@ -1,9 +1,15 @@
 use ::value::Value;
+use regex::Regex;
 use vrl::prelude::*;
 
 fn match_(value: Value, pattern: Value) -> Resolved {
     let string = value.try_bytes_utf8_lossy()?;
     let pattern = pattern.try_regex()?;
+    Ok(pattern.is_match(&string).into())
+}
+
+fn match_static(value: Value, pattern: &Regex) -> Resolved {
+    let string = value.try_bytes_utf8_lossy()?;
     Ok(pattern.is_match(&string).into())
 }
 
@@ -54,7 +60,20 @@ impl Function for Match {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
 
-        Ok(MatchFn { value, pattern }.as_expr())
+        match pattern.as_value() {
+            Some(pattern) => {
+                let pattern = pattern
+                    .try_regex()
+                    .map_err(|e| Box::new(e) as Box<dyn DiagnosticMessage>)?;
+
+                let pattern = Regex::new(pattern.as_str()).map_err(|e| {
+                    Box::new(ExpressionError::from(e.to_string())) as Box<dyn DiagnosticMessage>
+                })?;
+
+                Ok(MatchStaticFn { value, pattern }.as_expr())
+            }
+            None => Ok(MatchFn { value, pattern }.as_expr()),
+        }
     }
 }
 
@@ -70,6 +89,24 @@ impl FunctionExpression for MatchFn {
         let pattern = self.pattern.resolve(ctx)?;
 
         match_(value, pattern)
+    }
+
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MatchStaticFn {
+    value: Box<dyn Expression>,
+    pattern: Regex,
+}
+
+impl FunctionExpression for MatchStaticFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+
+        match_static(value, &self.pattern)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

### Motivation

I'd like to reduce the load of Vector using complicated patterns for match functions, e.g., complex multiline regexes. The `match_any` accepts only static regexes and precompiles them into regex set. Thus, for complicated patterns, `match_any` can outperform simple `match`.

### Overview

This PR implements the idea that static and dynamic arguments can be distinguished at the compile time, and all static regular expressions can be precompiled. 

The same approach can be applied to the `match_array` function in the future (probably in the scope of another PR).

### Additional info 

For example, the first line always starts with a date/time when detecting a multiline.

```yaml
starts_when: '^\[?((((19|20)([2468][048]|[13579][26]|0[48])|2000)-02-29|((19|20)[0-9]{2}-(0[4678]|1[02])-(0[1-9]|[12][0-9]|30)|(19|20)[0-9]{2}-(0[1359]|11)-(0[1-9]|[12][0-9]|3[01])|(19|20)[0-9]{2}-02-(0[1-9]|1[0-9]|2[0-8])))\s([01][0-9]|2[0-3]):([012345][0-9]):([012345][0-9])|20\d\d-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(0[1-9]|[1-2][0-9]|3[01])\s([01][0-9]|2[0-3]):([012345][0-9]):([012345][0-9])|(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+([01][0-9]|2[0-3]):([012345][0-9]):([012345][0-9])|(?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?|\p{L}{2}\s\d{1,2}\s\p{L}{3}\s\d{4}\s([01][0-9]|2[0-3]):([012345][0-9]):([012345][0-9]))'
``` 

Original PR https://github.com/vectordotdev/vector/pull/16920