### PR TITLE
chore(compiler): Add accessor to resolve optionally-constant expressions

### DIFF
--- a/lib/compiler/src/function.rs
+++ b/lib/compiler/src/function.rs
@@ -239,6 +239,7 @@ impl ArgumentList {
     /// If the argument exists and is either a literal or a variable containing a known literal,
     /// return that literal; otherwise return the optional expression.
     #[cfg(feature = "expr-literal")]
+    #[must_use]
     pub fn optional_resolve_literal(&self, keyword: &'static str) -> Option<Expr> {
         self.optional_expr(keyword).map(|expr| match expr {
             literal @ Expr::Literal(_) => literal,
@@ -253,6 +254,7 @@ impl ArgumentList {
     }
 
     #[cfg(not(feature = "expr-literal"))]
+    #[must_use]
     pub fn optional_resolve_literal(&self, keyword: &'static str) -> Option<Expr> {
         Some(crate::expression::Noop)
     }


### PR DESCRIPTION
This is a bit of an RFC to see if this approach makes sense. I saw this potential opportunity while looking at something else. This accessor would enable writing functions that could compile down to a fixed path if the parameter was a literal. For example, the `hmac` function takes an algorithm, and if that name is known at compile time we can skip looking up the name for each event processed.