### PR TITLE
chore: rename `Expression:as_value()` to `Expression::resolve_constant()`

### DIFF
--- a/lib/compiler/src/expression/array.rs
+++ b/lib/compiler/src/expression/array.rs
@@ -36,10 +36,10 @@ impl Expression for Array {
             .map(Value::Array)
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         self.inner
             .iter()
-            .map(Expr::as_value)
+            .map(Expr::resolve_constant)
             .collect::<Option<Vec<_>>>()
             .map(Value::Array)
     }

--- a/lib/compiler/src/expression/assignment.rs
+++ b/lib/compiler/src/expression/assignment.rs
@@ -536,7 +536,7 @@ where
         match &self {
             Variant::Single { target, expr } => {
                 let expr_result = expr.apply_type_info(&mut state);
-                target.insert_type_def(&mut state, expr_result.clone(), expr.as_value());
+                target.insert_type_def(&mut state, expr_result.clone(), expr.resolve_constant());
                 TypeInfo::new(state, expr_result)
             }
             Variant::Infallible {
@@ -552,7 +552,7 @@ where
                     .clone()
                     .union(TypeDef::from(default.kind()))
                     .infallible();
-                ok.insert_type_def(&mut state, ok_type, expr.as_value());
+                ok.insert_type_def(&mut state, ok_type, expr.resolve_constant());
 
                 // The "err" type is either the error message "bytes" or "null" (not undefined).
                 let err_type = TypeDef::from(Kind::bytes().or_null());

--- a/lib/compiler/src/expression/container.rs
+++ b/lib/compiler/src/expression/container.rs
@@ -38,14 +38,14 @@ impl Expression for Container {
         }
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
-            Group(v) => v.as_value(),
-            Block(v) => v.as_value(),
-            Array(v) => v.as_value(),
-            Object(v) => v.as_value(),
+            Group(v) => v.resolve_constant(),
+            Block(v) => v.resolve_constant(),
+            Array(v) => v.resolve_constant(),
+            Object(v) => v.resolve_constant(),
         }
     }
 

--- a/lib/compiler/src/expression/function_call.rs
+++ b/lib/compiler/src/expression/function_call.rs
@@ -309,7 +309,7 @@ impl<'a> Builder<'a> {
                                 // The variable kind is expected to be equal to
                                 // the ind of the target of the closure.
                                 VariableKind::Target => {
-                                    (target.type_info(state).result, target.as_value())
+                                    (target.type_info(state).result, target.resolve_constant())
                                 }
 
                                 // The variable kind is expected to be equal to

--- a/lib/compiler/src/expression/literal.rs
+++ b/lib/compiler/src/expression/literal.rs
@@ -51,7 +51,7 @@ impl Expression for Literal {
         Ok(self.to_value())
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         Some(self.to_value())
     }
 

--- a/lib/compiler/src/expression/object.rs
+++ b/lib/compiler/src/expression/object.rs
@@ -37,10 +37,10 @@ impl Expression for Object {
             .map(Value::Object)
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         self.inner
             .iter()
-            .map(|(key, expr)| expr.as_value().map(|v| (key.clone(), v)))
+            .map(|(key, expr)| expr.resolve_constant().map(|v| (key.clone(), v)))
             .collect::<Option<BTreeMap<_, _>>>()
             .map(Value::Object)
     }

--- a/lib/compiler/src/expression/op.rs
+++ b/lib/compiler/src/expression/op.rs
@@ -129,7 +129,7 @@ impl Expression for Op {
 
         let mut state = state.clone();
         let mut lhs_def = self.lhs.apply_type_info(&mut state);
-        let lhs_value = self.lhs.as_value();
+        let lhs_value = self.lhs.resolve_constant();
 
         // TODO: this is incorrect, but matches the existing behavior of the compiler
         // see: https://github.com/vectordotdev/vector/issues/13789
@@ -227,7 +227,7 @@ impl Expression for Op {
                 let td = TypeDef::float();
 
                 // Division is infallible if the rhs is a literal normal float or integer.
-                match self.rhs.as_value() {
+                match self.rhs.resolve_constant() {
                     Some(value) if lhs_def.is_float() || lhs_def.is_integer() => match value {
                         Value::Float(v) if v.is_normal() => td.infallible(),
                         Value::Integer(v) if v != 0 => td.infallible(),

--- a/lib/compiler/src/expression/query.rs
+++ b/lib/compiler/src/expression/query.rs
@@ -117,7 +117,7 @@ impl Expression for Query {
         Ok(value.get(&self.path).cloned().unwrap_or(Value::Null))
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         match self.target {
             Target::Internal(ref variable) => {
                 variable.value().and_then(|v| v.get(self.path())).cloned()

--- a/lib/compiler/src/function.rs
+++ b/lib/compiler/src/function.rs
@@ -290,7 +290,7 @@ impl ArgumentList {
         variants: &[Value],
     ) -> Result<Option<Value>, Error> {
         self.optional_literal(keyword)?
-            .and_then(|literal| literal.as_value())
+            .and_then(|literal| literal.resolve_constant())
             .map(|value| {
                 variants
                     .iter()

--- a/lib/stdlib/src/chunks.rs
+++ b/lib/stdlib/src/chunks.rs
@@ -70,7 +70,7 @@ impl Function for Chunks {
 
         // chunk_size is converted to a usize, so if a user-supplied Value::Integer (i64) is
         // larger than the platform's usize::MAX, it could fail to convert.
-        if let Some(literal) = chunk_size.as_value() {
+        if let Some(literal) = chunk_size.resolve_constant() {
             if let Some(integer) = literal.as_integer() {
                 if integer < 1 {
                     return Err(vrl::function::Error::InvalidArgument {
@@ -111,7 +111,7 @@ impl FunctionExpression for ChunksFn {
     }
 
     fn type_def(&self, _state: &TypeState) -> TypeDef {
-        let not_literal = self.chunk_size.as_value().is_none();
+        let not_literal = self.chunk_size.resolve_constant().is_none();
 
         TypeDef::array(Collection::from_unknown(Kind::bytes())).with_fallibility(not_literal)
     }

--- a/lib/stdlib/src/decrypt.rs
+++ b/lib/stdlib/src/decrypt.rs
@@ -136,7 +136,7 @@ impl Function for Decrypt {
         let key = arguments.required("key");
         let iv = arguments.required("iv");
 
-        if let Some(algorithm) = algorithm.as_value() {
+        if let Some(algorithm) = algorithm.resolve_constant() {
             if !is_valid_algorithm(algorithm.clone()) {
                 return Err(vrl::function::Error::InvalidArgument {
                     keyword: "algorithm",

--- a/lib/stdlib/src/del.rs
+++ b/lib/stdlib/src/del.rs
@@ -181,7 +181,7 @@ impl Expression for DelFn {
         let compact: Option<bool> = self
             .compact
             .as_ref()
-            .and_then(|compact| compact.as_value())
+            .and_then(|compact| compact.resolve_constant())
             .and_then(|compact| compact.as_boolean());
 
         if let Some(compact) = compact {

--- a/lib/stdlib/src/encrypt.rs
+++ b/lib/stdlib/src/encrypt.rs
@@ -195,7 +195,7 @@ impl Function for Encrypt {
         let key = arguments.required("key");
         let iv = arguments.required("iv");
 
-        if let Some(algorithm) = algorithm.as_value() {
+        if let Some(algorithm) = algorithm.resolve_constant() {
             if !is_valid_algorithm(algorithm.clone()) {
                 return Err(vrl::function::Error::InvalidArgument {
                     keyword: "algorithm",

--- a/lib/stdlib/src/hmac.rs
+++ b/lib/stdlib/src/hmac.rs
@@ -118,7 +118,7 @@ impl FunctionExpression for HmacFn {
 
         let mut valid_static_algo = false;
         if let Some(algorithm) = self.algorithm.as_ref() {
-            if let Some(algorithm) = algorithm.as_value() {
+            if let Some(algorithm) = algorithm.resolve_constant() {
                 if let Ok(algorithm) = algorithm.try_bytes_utf8_lossy() {
                     let algorithm = algorithm.to_uppercase();
                     valid_static_algo = valid_algorithms.contains(&algorithm.as_str());

--- a/lib/stdlib/src/match_any.rs
+++ b/lib/stdlib/src/match_any.rs
@@ -56,12 +56,12 @@ impl Function for MatchAny {
 
         let mut re_strings = Vec::with_capacity(patterns.len());
         for expr in patterns {
-            let value = expr
-                .as_value()
-                .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                    keyword: "patterns",
-                    expr,
-                })?;
+            let value =
+                expr.resolve_constant()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "patterns",
+                        expr,
+                    })?;
 
             let re = value
                 .try_regex()

--- a/lib/stdlib/src/mod_func.rs
+++ b/lib/stdlib/src/mod_func.rs
@@ -66,7 +66,7 @@ impl FunctionExpression for ModFn {
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
         // Division is infallible if the rhs is a literal normal float or a literal non-zero integer.
-        match self.modulus.as_value() {
+        match self.modulus.resolve_constant() {
             Some(value) if value.is_float() || value.is_integer() => match value {
                 Value::Float(v) if v.is_normal() => TypeDef::float().infallible(),
                 Value::Float(_) => TypeDef::float().fallible(),

--- a/lib/stdlib/src/parse_groks.rs
+++ b/lib/stdlib/src/parse_groks.rs
@@ -109,7 +109,7 @@ impl Function for ParseGroks {
             .into_iter()
             .map(|expr| {
                 let pattern = expr
-                    .as_value()
+                    .resolve_constant()
                     .ok_or(vrl::function::Error::ExpectedStaticExpression {
                         keyword: "patterns",
                         expr,
@@ -127,7 +127,7 @@ impl Function for ParseGroks {
             .into_iter()
             .map(|(key, expr)| {
                 let alias = expr
-                    .as_value()
+                    .resolve_constant()
                     .ok_or(vrl::function::Error::ExpectedStaticExpression {
                         keyword: "aliases",
                         expr,

--- a/lib/stdlib/src/random_bytes.rs
+++ b/lib/stdlib/src/random_bytes.rs
@@ -47,7 +47,7 @@ impl Function for RandomBytes {
     ) -> Compiled {
         let length = arguments.required("length");
 
-        if let Some(literal) = length.as_value() {
+        if let Some(literal) = length.resolve_constant() {
             // check if length is valid
             let _ = get_length(literal.clone()).map_err(|err| {
                 vrl::function::Error::InvalidArgument {
@@ -85,7 +85,7 @@ impl FunctionExpression for RandomBytesFn {
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match self.length.as_value() {
+        match self.length.resolve_constant() {
             None => TypeDef::bytes().fallible(),
             Some(value) => {
                 if get_length(value).is_ok() {

--- a/lib/stdlib/src/random_float.rs
+++ b/lib/stdlib/src/random_float.rs
@@ -72,7 +72,7 @@ impl Function for RandomFloat {
         let min = arguments.required("min");
         let max = arguments.required("max");
 
-        if let (Some(min), Some(max)) = (min.as_value(), max.as_value()) {
+        if let (Some(min), Some(max)) = (min.resolve_constant(), max.resolve_constant()) {
             // check if range is valid
             let _ = get_range(min, max.clone()).map_err(|err| {
                 vrl::function::Error::InvalidArgument {
@@ -102,7 +102,7 @@ impl FunctionExpression for RandomFloatFn {
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match (self.min.as_value(), self.max.as_value()) {
+        match (self.min.resolve_constant(), self.max.resolve_constant()) {
             (Some(min), Some(max)) => {
                 if get_range(min, max).is_ok() {
                     TypeDef::float().infallible()

--- a/lib/stdlib/src/random_int.rs
+++ b/lib/stdlib/src/random_int.rs
@@ -67,7 +67,7 @@ impl Function for RandomInt {
         let min = arguments.required("min");
         let max = arguments.required("max");
 
-        if let (Some(min), Some(max)) = (min.as_value(), max.as_value()) {
+        if let (Some(min), Some(max)) = (min.resolve_constant(), max.resolve_constant()) {
             // check if range is valid
             let _ = get_range(min, max.clone()).map_err(|err| {
                 vrl::function::Error::InvalidArgument {
@@ -97,7 +97,7 @@ impl FunctionExpression for RandomIntFn {
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match (self.min.as_value(), self.max.as_value()) {
+        match (self.min.resolve_constant(), self.max.resolve_constant()) {
             (Some(min), Some(max)) => {
                 if get_range(min, max).is_ok() {
                     TypeDef::integer()

--- a/lib/stdlib/src/redact.rs
+++ b/lib/stdlib/src/redact.rs
@@ -70,7 +70,7 @@ impl Function for Redact {
             .required_array("filters")?
             .into_iter()
             .map(|expr| {
-                expr.as_value()
+                expr.resolve_constant()
                     .ok_or(vrl::function::Error::ExpectedStaticExpression {
                         keyword: "filters",
                         expr,


### PR DESCRIPTION
I don't think it was clear what the `as_value` function really did. Renaming it should help.