### PR TITLE
chore: remove Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,7 +266,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -572,29 +612,38 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.13"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
+checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex 0.3.3",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.12"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -608,12 +657,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clipboard-win"
@@ -644,6 +690,21 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -837,7 +898,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -854,7 +915,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -1108,13 +1169,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1249,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1470,7 +1531,7 @@ checksum = "20cc83c51f04b1ad3b24cbac53d2ec1a138d699caabe05d315cb8538e8624d01"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -1500,19 +1561,19 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1543,7 +1604,7 @@ dependencies = [
  "log",
  "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1646,9 +1707,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
 
 [[package]]
 name = "lock_api"
@@ -1983,9 +2044,9 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2425,13 +2486,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -2539,16 +2609,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2630,9 +2700,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -2650,20 +2720,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -2805,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
 
 [[package]]
 name = "static_assertions"
@@ -2898,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2919,15 +2989,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3017,7 +3087,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -3097,13 +3167,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "pin-project-lite",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3394,7 +3464,7 @@ dependencies = [
 name = "vrl-cli"
 version = "0.1.0"
 dependencies = [
- "clap 4.1.13",
+ "clap 4.2.0",
  "exitcode",
  "indoc",
  "lookup",
@@ -3545,7 +3615,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "chrono-tz",
- "clap 4.1.13",
+ "clap 4.2.0",
  "glob",
  "lookup",
  "prettydiff",
@@ -3744,21 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
 ]
 
 [[package]]

--- a/lib/compiler/src/expression/array.rs
+++ b/lib/compiler/src/expression/array.rs
@@ -36,10 +36,10 @@ impl Expression for Array {
             .map(Value::Array)
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         self.inner
             .iter()
-            .map(Expr::as_value)
+            .map(Expr::resolve_constant)
             .collect::<Option<Vec<_>>>()
             .map(Value::Array)
     }

--- a/lib/compiler/src/expression/assignment.rs
+++ b/lib/compiler/src/expression/assignment.rs
@@ -536,7 +536,7 @@ where
         match &self {
             Variant::Single { target, expr } => {
                 let expr_result = expr.apply_type_info(&mut state);
-                target.insert_type_def(&mut state, expr_result.clone(), expr.as_value());
+                target.insert_type_def(&mut state, expr_result.clone(), expr.resolve_constant());
                 TypeInfo::new(state, expr_result)
             }
             Variant::Infallible {
@@ -552,7 +552,7 @@ where
                     .clone()
                     .union(TypeDef::from(default.kind()))
                     .infallible();
-                ok.insert_type_def(&mut state, ok_type, expr.as_value());
+                ok.insert_type_def(&mut state, ok_type, expr.resolve_constant());
 
                 // The "err" type is either the error message "bytes" or "null" (not undefined).
                 let err_type = TypeDef::from(Kind::bytes().or_null());

--- a/lib/compiler/src/expression/container.rs
+++ b/lib/compiler/src/expression/container.rs
@@ -38,14 +38,14 @@ impl Expression for Container {
         }
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
-            Group(v) => v.as_value(),
-            Block(v) => v.as_value(),
-            Array(v) => v.as_value(),
-            Object(v) => v.as_value(),
+            Group(v) => v.resolve_constant(),
+            Block(v) => v.resolve_constant(),
+            Array(v) => v.resolve_constant(),
+            Object(v) => v.resolve_constant(),
         }
     }
 

--- a/lib/compiler/src/expression/function_call.rs
+++ b/lib/compiler/src/expression/function_call.rs
@@ -309,7 +309,7 @@ impl<'a> Builder<'a> {
                                 // The variable kind is expected to be equal to
                                 // the ind of the target of the closure.
                                 VariableKind::Target => {
-                                    (target.type_info(state).result, target.as_value())
+                                    (target.type_info(state).result, target.resolve_constant())
                                 }
 
                                 // The variable kind is expected to be equal to

--- a/lib/compiler/src/expression/literal.rs
+++ b/lib/compiler/src/expression/literal.rs
@@ -51,7 +51,7 @@ impl Expression for Literal {
         Ok(self.to_value())
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         Some(self.to_value())
     }
 

--- a/lib/compiler/src/expression/object.rs
+++ b/lib/compiler/src/expression/object.rs
@@ -37,10 +37,10 @@ impl Expression for Object {
             .map(Value::Object)
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         self.inner
             .iter()
-            .map(|(key, expr)| expr.as_value().map(|v| (key.clone(), v)))
+            .map(|(key, expr)| expr.resolve_constant().map(|v| (key.clone(), v)))
             .collect::<Option<BTreeMap<_, _>>>()
             .map(Value::Object)
     }

--- a/lib/compiler/src/expression/op.rs
+++ b/lib/compiler/src/expression/op.rs
@@ -129,7 +129,7 @@ impl Expression for Op {
 
         let mut state = state.clone();
         let mut lhs_def = self.lhs.apply_type_info(&mut state);
-        let lhs_value = self.lhs.as_value();
+        let lhs_value = self.lhs.resolve_constant();
 
         // TODO: this is incorrect, but matches the existing behavior of the compiler
         // see: https://github.com/vectordotdev/vector/issues/13789
@@ -227,7 +227,7 @@ impl Expression for Op {
                 let td = TypeDef::float();
 
                 // Division is infallible if the rhs is a literal normal float or integer.
-                match self.rhs.as_value() {
+                match self.rhs.resolve_constant() {
                     Some(value) if lhs_def.is_float() || lhs_def.is_integer() => match value {
                         Value::Float(v) if v.is_normal() => td.infallible(),
                         Value::Integer(v) if v != 0 => td.infallible(),

--- a/lib/compiler/src/expression/query.rs
+++ b/lib/compiler/src/expression/query.rs
@@ -117,7 +117,7 @@ impl Expression for Query {
         Ok(value.get(&self.path).cloned().unwrap_or(Value::Null))
     }
 
-    fn as_value(&self) -> Option<Value> {
+    fn resolve_constant(&self) -> Option<Value> {
         match self.target {
             Target::Internal(ref variable) => {
                 variable.value().and_then(|v| v.get(self.path())).cloned()

--- a/lib/compiler/src/function.rs
+++ b/lib/compiler/src/function.rs
@@ -290,7 +290,7 @@ impl ArgumentList {
         variants: &[Value],
     ) -> Result<Option<Value>, Error> {
         self.optional_literal(keyword)?
-            .and_then(|literal| literal.as_value())
+            .and_then(|literal| literal.resolve_constant())
             .map(|value| {
                 variants
                     .iter()

--- a/lib/stdlib/src/chunks.rs
+++ b/lib/stdlib/src/chunks.rs
@@ -70,7 +70,7 @@ impl Function for Chunks {
 
         // chunk_size is converted to a usize, so if a user-supplied Value::Integer (i64) is
         // larger than the platform's usize::MAX, it could fail to convert.
-        if let Some(literal) = chunk_size.as_value() {
+        if let Some(literal) = chunk_size.resolve_constant() {
             if let Some(integer) = literal.as_integer() {
                 if integer < 1 {
                     return Err(vrl::function::Error::InvalidArgument {
@@ -111,7 +111,7 @@ impl FunctionExpression for ChunksFn {
     }
 
     fn type_def(&self, _state: &TypeState) -> TypeDef {
-        let not_literal = self.chunk_size.as_value().is_none();
+        let not_literal = self.chunk_size.resolve_constant().is_none();
 
         TypeDef::array(Collection::from_unknown(Kind::bytes())).with_fallibility(not_literal)
     }

--- a/lib/stdlib/src/decrypt.rs
+++ b/lib/stdlib/src/decrypt.rs
@@ -136,7 +136,7 @@ impl Function for Decrypt {
         let key = arguments.required("key");
         let iv = arguments.required("iv");
 
-        if let Some(algorithm) = algorithm.as_value() {
+        if let Some(algorithm) = algorithm.resolve_constant() {
             if !is_valid_algorithm(algorithm.clone()) {
                 return Err(vrl::function::Error::InvalidArgument {
                     keyword: "algorithm",

--- a/lib/stdlib/src/del.rs
+++ b/lib/stdlib/src/del.rs
@@ -181,7 +181,7 @@ impl Expression for DelFn {
         let compact: Option<bool> = self
             .compact
             .as_ref()
-            .and_then(|compact| compact.as_value())
+            .and_then(|compact| compact.resolve_constant())
             .and_then(|compact| compact.as_boolean());
 
         if let Some(compact) = compact {

--- a/lib/stdlib/src/encrypt.rs
+++ b/lib/stdlib/src/encrypt.rs
@@ -195,7 +195,7 @@ impl Function for Encrypt {
         let key = arguments.required("key");
         let iv = arguments.required("iv");
 
-        if let Some(algorithm) = algorithm.as_value() {
+        if let Some(algorithm) = algorithm.resolve_constant() {
             if !is_valid_algorithm(algorithm.clone()) {
                 return Err(vrl::function::Error::InvalidArgument {
                     keyword: "algorithm",

--- a/lib/stdlib/src/hmac.rs
+++ b/lib/stdlib/src/hmac.rs
@@ -118,7 +118,7 @@ impl FunctionExpression for HmacFn {
 
         let mut valid_static_algo = false;
         if let Some(algorithm) = self.algorithm.as_ref() {
-            if let Some(algorithm) = algorithm.as_value() {
+            if let Some(algorithm) = algorithm.resolve_constant() {
                 if let Ok(algorithm) = algorithm.try_bytes_utf8_lossy() {
                     let algorithm = algorithm.to_uppercase();
                     valid_static_algo = valid_algorithms.contains(&algorithm.as_str());

--- a/lib/stdlib/src/match_any.rs
+++ b/lib/stdlib/src/match_any.rs
@@ -56,12 +56,12 @@ impl Function for MatchAny {
 
         let mut re_strings = Vec::with_capacity(patterns.len());
         for expr in patterns {
-            let value = expr
-                .as_value()
-                .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                    keyword: "patterns",
-                    expr,
-                })?;
+            let value =
+                expr.resolve_constant()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "patterns",
+                        expr,
+                    })?;
 
             let re = value
                 .try_regex()

--- a/lib/stdlib/src/mod_func.rs
+++ b/lib/stdlib/src/mod_func.rs
@@ -66,7 +66,7 @@ impl FunctionExpression for ModFn {
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
         // Division is infallible if the rhs is a literal normal float or a literal non-zero integer.
-        match self.modulus.as_value() {
+        match self.modulus.resolve_constant() {
             Some(value) if value.is_float() || value.is_integer() => match value {
                 Value::Float(v) if v.is_normal() => TypeDef::float().infallible(),
                 Value::Float(_) => TypeDef::float().fallible(),

--- a/lib/stdlib/src/parse_groks.rs
+++ b/lib/stdlib/src/parse_groks.rs
@@ -109,7 +109,7 @@ impl Function for ParseGroks {
             .into_iter()
             .map(|expr| {
                 let pattern = expr
-                    .as_value()
+                    .resolve_constant()
                     .ok_or(vrl::function::Error::ExpectedStaticExpression {
                         keyword: "patterns",
                         expr,
@@ -127,7 +127,7 @@ impl Function for ParseGroks {
             .into_iter()
             .map(|(key, expr)| {
                 let alias = expr
-                    .as_value()
+                    .resolve_constant()
                     .ok_or(vrl::function::Error::ExpectedStaticExpression {
                         keyword: "aliases",
                         expr,

--- a/lib/stdlib/src/random_bytes.rs
+++ b/lib/stdlib/src/random_bytes.rs
@@ -47,7 +47,7 @@ impl Function for RandomBytes {
     ) -> Compiled {
         let length = arguments.required("length");
 
-        if let Some(literal) = length.as_value() {
+        if let Some(literal) = length.resolve_constant() {
             // check if length is valid
             let _ = get_length(literal.clone()).map_err(|err| {
                 vrl::function::Error::InvalidArgument {
@@ -85,7 +85,7 @@ impl FunctionExpression for RandomBytesFn {
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match self.length.as_value() {
+        match self.length.resolve_constant() {
             None => TypeDef::bytes().fallible(),
             Some(value) => {
                 if get_length(value).is_ok() {

--- a/lib/stdlib/src/random_float.rs
+++ b/lib/stdlib/src/random_float.rs
@@ -72,7 +72,7 @@ impl Function for RandomFloat {
         let min = arguments.required("min");
         let max = arguments.required("max");
 
-        if let (Some(min), Some(max)) = (min.as_value(), max.as_value()) {
+        if let (Some(min), Some(max)) = (min.resolve_constant(), max.resolve_constant()) {
             // check if range is valid
             let _ = get_range(min, max.clone()).map_err(|err| {
                 vrl::function::Error::InvalidArgument {
@@ -102,7 +102,7 @@ impl FunctionExpression for RandomFloatFn {
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match (self.min.as_value(), self.max.as_value()) {
+        match (self.min.resolve_constant(), self.max.resolve_constant()) {
             (Some(min), Some(max)) => {
                 if get_range(min, max).is_ok() {
                     TypeDef::float().infallible()

--- a/lib/stdlib/src/random_int.rs
+++ b/lib/stdlib/src/random_int.rs
@@ -67,7 +67,7 @@ impl Function for RandomInt {
         let min = arguments.required("min");
         let max = arguments.required("max");
 
-        if let (Some(min), Some(max)) = (min.as_value(), max.as_value()) {
+        if let (Some(min), Some(max)) = (min.resolve_constant(), max.resolve_constant()) {
             // check if range is valid
             let _ = get_range(min, max.clone()).map_err(|err| {
                 vrl::function::Error::InvalidArgument {
@@ -97,7 +97,7 @@ impl FunctionExpression for RandomIntFn {
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match (self.min.as_value(), self.max.as_value()) {
+        match (self.min.resolve_constant(), self.max.resolve_constant()) {
             (Some(min), Some(max)) => {
                 if get_range(min, max).is_ok() {
                     TypeDef::integer()

--- a/lib/stdlib/src/redact.rs
+++ b/lib/stdlib/src/redact.rs
@@ -70,7 +70,7 @@ impl Function for Redact {
             .required_array("filters")?
             .into_iter()
             .map(|expr| {
-                expr.as_value()
+                expr.resolve_constant()
                     .ok_or(vrl::function::Error::ExpectedStaticExpression {
                         keyword: "filters",
                         expr,


### PR DESCRIPTION
Libraries should not commit the lock file. This was added to `.gitignore` but not actually removed.