### PR TITLE
enhancement: add `random_bytes` to the web playground

### DIFF
--- a/lib/web-playground/Cargo.toml
+++ b/lib/web-playground/Cargo.toml
@@ -121,6 +121,7 @@ features = [
     "parse_user_agent",
     "parse_xml",
     "push",
+    "random_bytes",
     "random_bool",
     "random_int",
     "random_float",


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vrl/issues/16

Since the other random functions (e.g. `random_bool`) seem to work on the playground now, `random_bytes` should also work.