### PR TITLE
chore: release `0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## unreleased
+
+## `0.2.0` (2023-04-03)
 - added guard for the `limit` param of the `split` function to ensure it's not negative
 - renamed `Expression::as_value` to `Expression::resolve_constant`
 - `match` function now precompiles static regular expressions


### PR DESCRIPTION
This commit will be tagged with `0.2.0` after being merged. Note that crate versions are not being versioned yet, we are only using git tags for the entire repo.