### PR TITLE
fix(typedef): Fix type definitions for assignments where the RHS is `never`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- fixed a type definition bug for assignments where the right-hand side of the assignment expression resolved to the `never` type
 
 ## `0.2.0` (2023-04-03)
 - added guard for the `limit` param of the `split` function to ensure it's not negative

--- a/lib/compiler/src/type_def.rs
+++ b/lib/compiler/src/type_def.rs
@@ -352,15 +352,11 @@ impl TypeDef {
 
     #[must_use]
     pub fn with_type_inserted(self, path: &LookupBuf, other: Self) -> Self {
-        if path.is_root() {
-            other
-        } else {
-            let mut kind = self.kind;
-            kind.insert(path, other.kind);
-            Self {
-                fallible: self.fallible || other.fallible,
-                kind,
-            }
+        let mut kind = self.kind;
+        kind.insert(path, other.kind);
+        Self {
+            fallible: self.fallible || other.fallible,
+            kind,
         }
     }
 

--- a/lib/value/src/kind/crud/insert.rs
+++ b/lib/value/src/kind/crud/insert.rs
@@ -31,10 +31,9 @@ impl Kind {
         mut iter: impl Iterator<Item = BorrowedSegment<'b>> + Clone,
         kind: Self,
     ) {
-        if self.is_never() || kind.is_never() {
-            // If `self` or `kind` is `never`, the program would have already terminated
+        if kind.is_never() {
+            // If `kind` is `never`, the program would have already terminated
             // so this assignment can't happen.
-            *self = Self::never();
             return;
         }
 
@@ -658,9 +657,9 @@ mod tests {
                 "insert into never",
                 TestCase {
                     this: Kind::never(),
-                    path: parse_value_path(".x").unwrap(),
+                    path: parse_value_path(".").unwrap(),
                     kind: Kind::bytes(),
-                    expected: Kind::never(),
+                    expected: Kind::bytes(),
                 },
             ),
             (
@@ -669,7 +668,7 @@ mod tests {
                     this: Kind::object(Collection::empty()),
                     path: parse_value_path(".x").unwrap(),
                     kind: Kind::never(),
-                    expected: Kind::never(),
+                    expected: Kind::object(Collection::empty()),
                 },
             ),
             (


### PR DESCRIPTION
For assignments where the right hand side is `never`, such as the example below, the assignment will never actually happen so the type definition should not be updated. Previously, it was set to `never` which was incorrect.
```coffee
. = abort
```