### PR TITLE
chore: migrate `Field` from the deprecated `FieldBuf` to `OwnedSegment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - fixed a type definition bug for assignments where the right-hand side of the assignment expression resolved to the `never` type
+- migrated `Field` from the deprecated `FieldBuf` to `OwnedSegment`
 
 ## `0.2.0` (2023-04-03)
 - added guard for the `limit` param of the `split` function to ensure it's not negative

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -262,6 +262,17 @@ impl From<OwnedValuePath> for String {
     }
 }
 
+impl Display for OwnedSegment {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // This isn't the most efficient method, but it re-uses existing code
+        // Displaying is likely not in a hot path
+        let path = OwnedValuePath {
+            segments: vec![self.clone()],
+        };
+        Display::fmt(&path, f)
+    }
+}
+
 fn serialize_field(field: &str, separator: Option<&str>) -> String {
     // These characters should match the ones from the parser, implemented in `JitLookup`
     let needs_quotes = field
@@ -358,6 +369,12 @@ impl From<Vec<String>> for OwnedSegment {
 impl<'a> From<&'a str> for OwnedSegment {
     fn from(field: &'a str) -> Self {
         OwnedSegment::field(field)
+    }
+}
+
+impl From<String> for OwnedSegment {
+    fn from(field: String) -> Self {
+        OwnedSegment::Field(field)
     }
 }
 

--- a/lib/value/src/kind/collection/field.rs
+++ b/lib/value/src/kind/collection/field.rs
@@ -1,10 +1,11 @@
 use crate::kind::collection::{CollectionKey, CollectionRemove};
 use crate::kind::Collection;
 use lookup::lookup_v2::OwnedSegment;
+// use lookup::OwnedValuePath;
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct Field(lookup::FieldBuf);
+pub struct Field(OwnedSegment);
 
 impl std::fmt::Display for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -14,16 +15,17 @@ impl std::fmt::Display for Field {
 
 impl CollectionKey for Field {
     fn to_segment(&self) -> OwnedSegment {
-        OwnedSegment::Field(self.0.name.clone())
+        self.0.clone()
+        // OwnedSegment::Field(self.0.name.clone())
     }
 }
 
 impl Field {
-    /// Get a `str` representation of the field.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
+    // Get a `str` representation of the field.
+    // #[must_use]
+    // pub fn as_str(&self) -> &str {
+    //     self.0.as_str()
+    // }
 }
 
 impl CollectionRemove for Collection<Field> {
@@ -35,7 +37,7 @@ impl CollectionRemove for Collection<Field> {
 }
 
 impl std::ops::Deref for Field {
-    type Target = lookup::FieldBuf;
+    type Target = OwnedSegment;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -48,38 +50,42 @@ impl From<&str> for Field {
     }
 }
 
+// impl From<OwnedSegment> for Field {
+
+// }
+
 impl From<String> for Field {
     fn from(field: String) -> Self {
         Self(field.into())
     }
 }
 
-impl From<lookup::FieldBuf> for Field {
-    fn from(field: lookup::FieldBuf) -> Self {
-        Self(field)
-    }
-}
+// impl From<lookup::FieldBuf> for Field {
+//     fn from(field: lookup::FieldBuf) -> Self {
+//         Self(field)
+//     }
+// }
 
-impl From<Field> for lookup::FieldBuf {
-    fn from(field: Field) -> Self {
-        field.0
-    }
-}
+// impl From<Field> for lookup::FieldBuf {
+//     fn from(field: Field) -> Self {
+//         field.0
+//     }
+// }
 
-impl From<lookup::Field<'_>> for Field {
-    fn from(field: lookup::Field<'_>) -> Self {
-        (&field).into()
-    }
-}
+// impl From<lookup::Field<'_>> for Field {
+//     fn from(field: lookup::Field<'_>) -> Self {
+//         (&field).into()
+//     }
+// }
 
-impl From<&lookup::Field<'_>> for Field {
-    fn from(field: &lookup::Field<'_>) -> Self {
-        Self(field.as_field_buf())
-    }
-}
+// impl From<&lookup::Field<'_>> for Field {
+//     fn from(field: &lookup::Field<'_>) -> Self {
+//         Self(field.as_field_buf())
+//     }
+// }
 
-impl<'a> From<&'a Field> for lookup::Field<'a> {
-    fn from(field: &'a Field) -> Self {
-        (&field.0).into()
-    }
-}
+// impl<'a> From<&'a Field> for lookup::Field<'a> {
+//     fn from(field: &'a Field) -> Self {
+//         (&field.0).into()
+//     }
+// }

--- a/lib/value/src/kind/collection/field.rs
+++ b/lib/value/src/kind/collection/field.rs
@@ -1,7 +1,6 @@
 use crate::kind::collection::{CollectionKey, CollectionRemove};
 use crate::kind::Collection;
 use lookup::lookup_v2::OwnedSegment;
-// use lookup::OwnedValuePath;
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
@@ -16,16 +15,7 @@ impl std::fmt::Display for Field {
 impl CollectionKey for Field {
     fn to_segment(&self) -> OwnedSegment {
         self.0.clone()
-        // OwnedSegment::Field(self.0.name.clone())
     }
-}
-
-impl Field {
-    // Get a `str` representation of the field.
-    // #[must_use]
-    // pub fn as_str(&self) -> &str {
-    //     self.0.as_str()
-    // }
 }
 
 impl CollectionRemove for Collection<Field> {
@@ -50,42 +40,8 @@ impl From<&str> for Field {
     }
 }
 
-// impl From<OwnedSegment> for Field {
-
-// }
-
 impl From<String> for Field {
     fn from(field: String) -> Self {
         Self(field.into())
     }
 }
-
-// impl From<lookup::FieldBuf> for Field {
-//     fn from(field: lookup::FieldBuf) -> Self {
-//         Self(field)
-//     }
-// }
-
-// impl From<Field> for lookup::FieldBuf {
-//     fn from(field: Field) -> Self {
-//         field.0
-//     }
-// }
-
-// impl From<lookup::Field<'_>> for Field {
-//     fn from(field: lookup::Field<'_>) -> Self {
-//         (&field).into()
-//     }
-// }
-
-// impl From<&lookup::Field<'_>> for Field {
-//     fn from(field: &lookup::Field<'_>) -> Self {
-//         Self(field.as_field_buf())
-//     }
-// }
-
-// impl<'a> From<&'a Field> for lookup::Field<'a> {
-//     fn from(field: &'a Field) -> Self {
-//         (&field.0).into()
-//     }
-// }

--- a/lib/value/src/kind/crud/get.rs
+++ b/lib/value/src/kind/crud/get.rs
@@ -2,7 +2,6 @@
 
 use crate::Kind;
 use lookup::lookup_v2::{BorrowedSegment, ValuePath};
-use std::borrow::Cow;
 
 impl Kind {
     /// Returns the type of a value that is retrieved from a certain path.
@@ -27,11 +26,11 @@ impl Kind {
         self.get_recursive(path.segment_iter())
     }
 
-    fn get_field(&self, field: Cow<'_, str>) -> Self {
+    fn get_field(&self, field: &str) -> Self {
         self.as_object().map_or_else(Self::undefined, |object| {
             let mut kind = object
                 .known()
-                .get(&field.into_owned().into())
+                .get(&field.into())
                 .cloned()
                 .unwrap_or_else(|| object.unknown_kind());
 
@@ -53,7 +52,7 @@ impl Kind {
 
         match iter.next() {
             Some(BorrowedSegment::Field(field) | BorrowedSegment::CoalesceEnd(field)) => {
-                self.get_field(field).get_recursive(iter)
+                self.get_field(field.as_ref()).get_recursive(iter)
             }
             Some(BorrowedSegment::Index(mut index)) => {
                 if let Some(array) = self.as_array() {
@@ -119,7 +118,7 @@ impl Kind {
                 }
             }
             Some(BorrowedSegment::CoalesceField(field)) => {
-                let field_kind = self.get_field(field);
+                let field_kind = self.get_field(field.as_ref());
 
                 // The remaining segments if this match succeeded.
                 #[allow(clippy::needless_collect)]

--- a/lib/value/src/kind/debug.rs
+++ b/lib/value/src/kind/debug.rs
@@ -34,7 +34,7 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
             for (field, field_kind) in fields.known() {
                 let mut field_tree = BTreeMap::new();
                 insert_kind(&mut field_tree, field_kind, show_unknown);
-                object_tree.insert(field.name.clone(), Value::Object(field_tree));
+                object_tree.insert(format!("{field}"), Value::Object(field_tree));
             }
             tree.insert("object".to_owned(), Value::Object(object_tree));
             if show_unknown {


### PR DESCRIPTION
The `Field` type used in `Collection` was migrated from the deprecated `FieldBuf` to `OwnedSegment`.