### PR TITLE
chore: remove deprecated `FieldBuf` from `Field`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - fixed a type definition bug for assignments where the right-hand side of the assignment expression resolved to the `never` type
+- removed the deprecated `FieldBuf` from `Field`
 
 ## `0.2.0` (2023-04-03)
 - added guard for the `limit` param of the `split` function to ensure it's not negative

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -230,14 +230,14 @@ impl From<OwnedValuePath> for String {
             .enumerate()
             .map(|(i, segment)| match segment {
                 OwnedSegment::Field(field) => {
-                    serialize_field(field.as_ref(), (i != 0).then_some("."))
+                    serialize_field_with_separator(field.as_ref(), (i != 0).then_some("."))
                 }
                 OwnedSegment::Index(index) => format!("[{}]", index),
                 OwnedSegment::Coalesce(fields) => {
                     let mut output = String::new();
                     let (last, fields) = fields.split_last().expect("coalesce must not be empty");
                     for field in fields {
-                        let field_output = serialize_field(
+                        let field_output = serialize_field_with_separator(
                             field.as_ref(),
                             Some(if coalesce_i == 0 {
                                 if i == 0 {
@@ -252,7 +252,10 @@ impl From<OwnedValuePath> for String {
                         coalesce_i += 1;
                         output.push_str(&field_output);
                     }
-                    output += &serialize_field(last.as_ref(), (coalesce_i != 0).then_some("|"));
+                    output += &serialize_field_with_separator(
+                        last.as_ref(),
+                        (coalesce_i != 0).then_some("|"),
+                    );
                     output += ")";
                     output
                 }
@@ -262,7 +265,7 @@ impl From<OwnedValuePath> for String {
     }
 }
 
-fn serialize_field(field: &str, separator: Option<&str>) -> String {
+fn serialize_field_with_separator(field: &str, separator: Option<&str>) -> String {
     // These characters should match the ones from the parser, implemented in `JitLookup`
     let needs_quotes = field
         .chars()

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -230,14 +230,14 @@ impl From<OwnedValuePath> for String {
             .enumerate()
             .map(|(i, segment)| match segment {
                 OwnedSegment::Field(field) => {
-                    serialize_field_with_separator(field.as_ref(), (i != 0).then_some("."))
+                    serialize_field(field.as_ref(), (i != 0).then_some("."))
                 }
                 OwnedSegment::Index(index) => format!("[{}]", index),
                 OwnedSegment::Coalesce(fields) => {
                     let mut output = String::new();
                     let (last, fields) = fields.split_last().expect("coalesce must not be empty");
                     for field in fields {
-                        let field_output = serialize_field_with_separator(
+                        let field_output = serialize_field(
                             field.as_ref(),
                             Some(if coalesce_i == 0 {
                                 if i == 0 {
@@ -252,10 +252,7 @@ impl From<OwnedValuePath> for String {
                         coalesce_i += 1;
                         output.push_str(&field_output);
                     }
-                    output += &serialize_field_with_separator(
-                        last.as_ref(),
-                        (coalesce_i != 0).then_some("|"),
-                    );
+                    output += &serialize_field(last.as_ref(), (coalesce_i != 0).then_some("|"));
                     output += ")";
                     output
                 }
@@ -265,7 +262,7 @@ impl From<OwnedValuePath> for String {
     }
 }
 
-fn serialize_field_with_separator(field: &str, separator: Option<&str>) -> String {
+fn serialize_field(field: &str, separator: Option<&str>) -> String {
     // These characters should match the ones from the parser, implemented in `JitLookup`
     let needs_quotes = field
         .chars()

--- a/lib/value/Cargo.toml
+++ b/lib/value/Cargo.toml
@@ -15,6 +15,7 @@ ordered-float = { version = "3.6.0", default-features = false }
 regex = { version = "1.7.2", default-features = false, features = ["std", "perf"]}
 snafu = { version = "0.7.4", default-features = false }
 tracing = { version = "0.1.34", default-features = false, features = ["attributes"] }
+once_cell = { version = "1.17" }
 
 # Optional
 async-graphql = { version = "5.0.6", default-features = false, optional = true }

--- a/lib/value/src/kind/collection/field.rs
+++ b/lib/value/src/kind/collection/field.rs
@@ -1,20 +1,23 @@
 use crate::kind::collection::{CollectionKey, CollectionRemove};
 use crate::kind::Collection;
-use lookup::lookup_v2::OwnedSegment;
+use lookup::lookup_v2::{self, OwnedSegment};
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct Field(lookup::FieldBuf);
+pub struct Field(String);
 
 impl std::fmt::Display for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        let needs_quotes = field
+            .chars()
+            .any(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '_' | '@'));
+        write!(f, "{}", lookup_v2::serialize_field(&self.0))
     }
 }
 
 impl CollectionKey for Field {
     fn to_segment(&self) -> OwnedSegment {
-        OwnedSegment::Field(self.0.name.clone())
+        OwnedSegment::Field(self.0.clone())
     }
 }
 
@@ -35,9 +38,9 @@ impl CollectionRemove for Collection<Field> {
 }
 
 impl std::ops::Deref for Field {
-    type Target = lookup::FieldBuf;
+    type Target = String;
 
-    fn deref(&self) -> &Self::Target {
+    fn deref(&self) -> &String {
         &self.0
     }
 }
@@ -50,36 +53,6 @@ impl From<&str> for Field {
 
 impl From<String> for Field {
     fn from(field: String) -> Self {
-        Self(field.into())
-    }
-}
-
-impl From<lookup::FieldBuf> for Field {
-    fn from(field: lookup::FieldBuf) -> Self {
         Self(field)
-    }
-}
-
-impl From<Field> for lookup::FieldBuf {
-    fn from(field: Field) -> Self {
-        field.0
-    }
-}
-
-impl From<lookup::Field<'_>> for Field {
-    fn from(field: lookup::Field<'_>) -> Self {
-        (&field).into()
-    }
-}
-
-impl From<&lookup::Field<'_>> for Field {
-    fn from(field: &lookup::Field<'_>) -> Self {
-        Self(field.as_field_buf())
-    }
-}
-
-impl<'a> From<&'a Field> for lookup::Field<'a> {
-    fn from(field: &'a Field) -> Self {
-        (&field.0).into()
     }
 }

--- a/lib/value/src/kind/collection/field.rs
+++ b/lib/value/src/kind/collection/field.rs
@@ -1,17 +1,27 @@
 use crate::kind::collection::{CollectionKey, CollectionRemove};
 use crate::kind::Collection;
-use lookup::lookup_v2::{self, OwnedSegment};
+use lookup::lookup_v2::OwnedSegment;
+use once_cell::sync::Lazy;
+use regex::Regex;
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Field(String);
 
+static VALID_FIELD: Lazy<Regex> =
+    Lazy::new(|| Regex::new("^[0-9]*[a-zA-Z_@][0-9a-zA-Z_@]*$").unwrap());
+
 impl std::fmt::Display for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let needs_quotes = field
-            .chars()
-            .any(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '_' | '@'));
-        write!(f, "{}", lookup_v2::serialize_field(&self.0))
+        // This can eventually just parse the field and see if it's valid, but the
+        // parser is currently lenient in what it accepts so it doesn't catch all errors that
+        // should be quoted
+        let needs_quotes = !VALID_FIELD.is_match(&self.0);
+        if needs_quotes {
+            write!(f, "\"{}\"", self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
     }
 }
 

--- a/lib/value/src/kind/debug.rs
+++ b/lib/value/src/kind/debug.rs
@@ -34,7 +34,7 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
             for (field, field_kind) in fields.known() {
                 let mut field_tree = BTreeMap::new();
                 insert_kind(&mut field_tree, field_kind, show_unknown);
-                object_tree.insert(field.name.clone(), Value::Object(field_tree));
+                object_tree.insert(field.to_string(), Value::Object(field_tree));
             }
             tree.insert("object".to_owned(), Value::Object(object_tree));
             if show_unknown {


### PR DESCRIPTION
`Field` is just a newtype wrapper around the value of a field, which is just a String. The only thing somewhat complicated here was the `Display` impl. Ideally this would re-use the path parsing logic to detect if quotes are needed when displaying the value, but the parser is currently lenient in what it accepts so not all "invalid" field values would be quoted correctly. The regex matcher was re-used from `FieldBuf`. This is not something that's used in performance critical code.