### PR TITLE
chore: remove `vrl` as a dependency of the `tests` crate

### DIFF
--- a/lib/tests/Cargo.toml
+++ b/lib/tests/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 lookup = { path = "../lookup" }
 stdlib = { package = "vrl-stdlib", path = "../stdlib" }
-# vrl = { path = "../.." }
 vrl-diagnostic = { path = "../diagnostic" }
 vrl-compiler = { path = "../compiler" }
 vrl-core = { path = "../core" }

--- a/lib/tests/Cargo.toml
+++ b/lib/tests/Cargo.toml
@@ -8,7 +8,10 @@ publish = false
 [dependencies]
 lookup = { path = "../lookup" }
 stdlib = { package = "vrl-stdlib", path = "../stdlib" }
-vrl = { path = "../.." }
+# vrl = { path = "../.." }
+vrl-diagnostic = { path = "../diagnostic" }
+vrl-compiler = { path = "../compiler" }
+vrl-core = { path = "../core" }
 value = { path = "../value" }
 
 ansi_term = "0.12"

--- a/lib/tests/src/main.rs
+++ b/lib/tests/src/main.rs
@@ -1,9 +1,10 @@
+use vrl_compiler::{CompileConfig, VrlRuntime};
+use vrl_core::TimeZone;
 use vrl_tests::{get_tests_from_functions, run_tests, Test, TestConfig};
 
 use chrono_tz::Tz;
 use clap::Parser;
 use glob::glob;
-use vrl::{CompileConfig, TimeZone, VrlRuntime};
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/lib/tests/src/test.rs
+++ b/lib/tests/src/test.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fs, path::Path};
 use ::value::Value;
 use lookup::lookup_v2::parse_value_path;
 use lookup::OwnedTargetPath;
-use vrl::function::Example;
+use vrl_compiler::function::Example;
 
 #[derive(Debug)]
 pub struct Test {


### PR DESCRIPTION
This is a continuation of work to remove dependencies on the `vrl` crate to avoid circular dependencies when the root `vrl` crate starts re-exporting this functionality.