### PR TITLE
chore: remove `vrl` as a dev-dependency of the `stdlib` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ expr-literal = ["compiler/expr-literal"]
 expr-op = ["compiler/expr-op"]
 expr-query = ["compiler/expr-query"]
 expr-unary = ["compiler/expr-unary"]
-test = ["compiler/test"]
 
 [dependencies]
 bytes = "1.4.0"
@@ -59,7 +58,6 @@ vrl-core = { path = "lib/core" }
 
 [dev-dependencies]
 criterion = "0.4"
-indoc = "2"
 serde_json = "1"
 vrl-stdlib = { path = "lib/stdlib" }
 vrl-core = { path = "lib/core", features = ["test"]}

--- a/lib/compiler/src/test_util.rs
+++ b/lib/compiler/src/test_util.rs
@@ -128,7 +128,7 @@ macro_rules! __prep_bench_or_test {
             $func.compile(
                 $state,
                 &mut $crate::function::FunctionCompileContext::new(
-                    vrl::diagnostic::Span::new(0, 0),
+                    vrl_diagnostic::Span::new(0, 0),
                     config,
                 ),
                 $args.into(),

--- a/lib/stdlib/Cargo.toml
+++ b/lib/stdlib/Cargo.toml
@@ -78,7 +78,7 @@ criterion = "0.4"
 tracing-test = "0.2"
 value = { path = "../value", features = ["test"] }
 vrl-core = { path = "../core", features = ["test"] }
-vrl = { path = "../.." , features = ["test"]}
+vrl-compiler = { path = "../compiler", features = ["test"] }
 
 [features]
 default = [

--- a/lib/stdlib/benches/benches.rs
+++ b/lib/stdlib/benches/benches.rs
@@ -4,7 +4,8 @@ use ::value::{btreemap, Value};
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
 use regex::Regex;
-use vrl::prelude::*;
+use vrl_compiler::{bench_function, func_args, value};
+use vrl_stdlib::prelude::*;
 
 criterion_group!(
     name = benches;

--- a/lib/stdlib/src/del.rs
+++ b/lib/stdlib/src/del.rs
@@ -260,7 +260,7 @@ mod tests {
         let tz = TimeZone::default();
         for (object, exp, func) in cases {
             let mut object: Value = object.into();
-            let mut runtime_state = vrl::state::RuntimeState::default();
+            let mut runtime_state = state::RuntimeState::default();
             let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
             let got = func
                 .resolve(&mut ctx)

--- a/lib/stdlib/src/merge.rs
+++ b/lib/stdlib/src/merge.rs
@@ -115,10 +115,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ::value::btreemap;
-    use vrl::value::Kind;
-
     use super::*;
+    use ::value::btreemap;
 
     test_function! [
         merge => Merge;

--- a/lib/stdlib/src/to_timestamp.rs
+++ b/lib/stdlib/src/to_timestamp.rs
@@ -267,17 +267,15 @@ impl FunctionExpression for ToTimestampFn {
 #[cfg(test)]
 #[allow(overflowing_literals)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use vrl::prelude::expression::Literal;
-    use vrl_core::TimeZone;
-
     use super::*;
+    use std::collections::BTreeMap;
+    use vrl_compiler::expression::Literal;
+    use vrl_core::TimeZone;
 
     #[test]
     fn out_of_range_integer() {
         let mut object: Value = BTreeMap::new().into();
-        let mut runtime_state = vrl::state::RuntimeState::default();
+        let mut runtime_state = state::RuntimeState::default();
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
         let f = ToTimestampFn {
@@ -291,7 +289,7 @@ mod tests {
     #[test]
     fn out_of_range_float() {
         let mut object: Value = BTreeMap::new().into();
-        let mut runtime_state = vrl::state::RuntimeState::default();
+        let mut runtime_state = state::RuntimeState::default();
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
         let f = ToTimestampFn {

--- a/lib/stdlib/src/unnest.rs
+++ b/lib/stdlib/src/unnest.rs
@@ -187,7 +187,6 @@ mod tests {
     use super::*;
     use ::value::btreemap;
     use lookup_lib::lookup_v2::parse_value_path;
-    use vrl::state::TypeState;
     use vrl_core::TimeZone;
 
     #[test]
@@ -450,7 +449,7 @@ mod tests {
         let tz = TimeZone::default();
         for (object, expected, func, expected_typedef) in cases {
             let mut object = object.clone();
-            let mut runtime_state = vrl::state::RuntimeState::default();
+            let mut runtime_state = state::RuntimeState::default();
             let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
 
             let got_typedef = func.type_def(&state);

--- a/lib/stdlib/src/uuid_v4.rs
+++ b/lib/stdlib/src/uuid_v4.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn uuid_v4() {
-        let mut state = vrl::state::RuntimeState::default();
+        let mut state = state::RuntimeState::default();
         let mut object: Value = Value::Object(BTreeMap::new());
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut state, &tz);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 pub mod prelude;
+
 pub use compiler::expression::query;
 pub use compiler::{
     compile, compile_with_external, compile_with_state, function,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::module_name_repetitions)]
 
 pub mod prelude;
-
 pub use compiler::expression::query;
 pub use compiler::{
     compile, compile_with_external, compile_with_state, function,


### PR DESCRIPTION
This is the last `vrl` dependency in VRL.