### PR TITLE
chore: remove `getrandom` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,7 +448,7 @@ grok = { version = "2", optional = true }
 onig = { version = "6.4", default-features = false, optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 
-# Dependencies use for WASM
+# Dependencies used for WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1", features = ["v4", "js"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,7 +386,6 @@ data-encoding = { version = "2.3.3", optional = true }
 dyn-clone = { version = "1.0.11", default-features = false, optional = true }
 exitcode = {version = "1", optional = true }
 flate2 = { version = "1.0.25", default-features = false, features = ["default"], optional = true }
-getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", optional = true }
 hmac = { version = "0.12.1", optional = true }
 indexmap = { version = "~1.9.2", default-features = false, optional = true}
@@ -426,7 +425,6 @@ tracing = { version = "0.1.34", default-features = false, optional = true }
 uaparser = { version = "0.6.0", default-features = false, optional = true }
 utf8-width = { version = "0.1.6", optional = true }
 url = { version = "2", optional = true }
-uuid = { version = "1", features = ["v4"], optional = true }
 snafu = { version = "0.7", optional = true }
 webbrowser = { version = "0.8", default-features = false, optional = true }
 woothee = { version = "0.13.0", optional = true }
@@ -442,12 +440,17 @@ cbc = { version = "0.1.2", optional = true, features = ["alloc"] }
 cfb-mode = { version = "0.8.2", optional = true }
 ofb = { version = "0.6.1", optional = true }
 
-# Dependencies that don't work in WASM
+# Dependencies used for non-WASM
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dns-lookup = { version = "1.0.8", optional = true }
 hostname = { version = "0.3", optional = true }
 grok = { version = "2", optional = true }
 onig = { version = "6.4", default-features = false, optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
+
+# Dependencies use for WASM
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1", features = ["v4", "js"], optional = true }
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
This was the only required dependency. It's only needed for compiling with WASM. Instead of depending on it directly, the "js" feature flag is used with the `uuid` crate.