### PR TITLE
fix: typedefs with query side-effects

### DIFF
--- a/lib/tests/tests/expressions/query/container_side_effect.vrl
+++ b/lib/tests/tests/expressions/query/container_side_effect.vrl
@@ -1,0 +1,7 @@
+# result: {"type": { "bytes": true }, "value": "foo"}
+. = 3
+{. = "foo"}.x
+{
+    "value": .,
+    "type": type_def(.)
+}

--- a/lib/tests/tests/expressions/query/function_side_effect.vrl
+++ b/lib/tests/tests/expressions/query/function_side_effect.vrl
@@ -1,0 +1,7 @@
+# result: {"type": { "null": true }, "value": null}
+. = 3
+del(.).x
+{
+    "value": .,
+    "type": type_def(.)
+}

--- a/src/compiler/state.rs
+++ b/src/compiler/state.rs
@@ -17,6 +17,13 @@ impl TypeInfo {
             result,
         }
     }
+
+    pub fn map_result(self, f: impl FnOnce(TypeDef) -> TypeDef) -> Self {
+        Self {
+            state: self.state,
+            result: f(self.result),
+        }
+    }
 }
 
 impl From<&TypeState> for TypeState {


### PR DESCRIPTION
closes https://github.com/vectordotdev/vrl/issues/239

queries in VRL can query both functions and "containers" (arbitrary code blocks), which can contain side-effects. These side-effects were not captured in the type definition.