### PR TITLE
Added null escape to lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- added \0 (null) character literal to lex parser
 - added the `timezone` argument to the `format_timestamp` vrl function.
 - removed feature flags for each individual VRL function.
 - fixed a panic when arithmetic overflows. It now always wraps (only in debug builds).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ provide everything you need to get started.
    GitHub account (only applicable to outside contributors).
 3. [Create a new Git branch][urls.create_branch].
 4. Make your changes.
-5. Add and/or update unit tests to cover your changes.
+5. Add and/or update tests to cover your changes.
 6. Add a one line summary of changes to the "unreleased" section of `CHANGELOG.md`.
 7. [Submit the branch as a pull request][urls.submit_pr] to the repo. A team member should
    comment and/or review your pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ provide everything you need to get started.
    GitHub account (only applicable to outside contributors).
 3. [Create a new Git branch][urls.create_branch].
 4. Make your changes.
-5. Add a one line summary of changes to the "unreleased" section of `CHANGELOG.md`.
-6. [Submit the branch as a pull request][urls.submit_pr] to the repo. A team member should
+5. Add and/or update unit tests to cover your changes.
+6. Add a one line summary of changes to the "unreleased" section of `CHANGELOG.md`.
+7. [Submit the branch as a pull request][urls.submit_pr] to the repo. A team member should
    comment and/or review your pull request.
 
 

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -1243,7 +1243,7 @@ impl<'input> Lexer<'input> {
     /// Returns Ok if the next char is a valid escape code.
     fn escape_code(&mut self, start: usize) -> Result<(), Error> {
         match self.bump() {
-            Some((_, '\n' | '\'' | '"' | '\\' | 'n' | 'r' | 't' | '{' | '}')) => Ok(()),
+            Some((_, '\n' | '\'' | '"' | '\\' | 'n' | 'r' | 't' | '{' | '}' | '0')) => Ok(()),
             Some((start, ch)) => Err(Error::EscapeChar {
                 start,
                 ch: Some(ch),
@@ -1308,6 +1308,7 @@ fn unescape_string_literal(mut s: &str) -> String {
                 b'n' => '\n',
                 b'r' => '\r',
                 b't' => '\t',
+                b'\0' => '\0',
                 b'{' => '{',
                 _ => unimplemented!("invalid escape"),
             };
@@ -1485,14 +1486,15 @@ mod test {
         use StringLiteral as L;
 
         test(
-            data(r#"foo "bar\"\n" baz "" "\t" "\"\"""#),
+            data(r#"foo "bar\"\n" baz "" "\t" "\"\"" "null \0""#),
             vec![
-                (r#"~~~                             "#, Identifier("foo")),
-                (r#"    ~~~~~~~~~                   "#, L(S("bar\\\"\\n"))),
-                (r#"              ~~~               "#, Identifier("baz")),
-                (r#"                  ~~            "#, L(S(""))),
-                (r#"                     ~~~~       "#, L(S("\\t"))),
-                (r#"                          ~~~~~~"#, L(S(r#"\"\""#))),
+                (r#"~~~                                       "#, Identifier("foo")),
+                (r#"    ~~~~~~~~~                             "#, L(S("bar\\\"\\n"))),
+                (r#"              ~~~                         "#, Identifier("baz")),
+                (r#"                  ~~                      "#, L(S(""))),
+                (r#"                     ~~~~                 "#, L(S("\\t"))),
+                (r#"                          ~~~~~~          "#, L(S(r#"\"\""#))),
+                (r#"                                 ~~~~~~~~~"#, L(S("null \\0"))),
             ],
         );
         assert_eq!(TemplateString(vec![StringSegment::Literal(r#""""#.to_string(), Span::new(1, 5))]), StringLiteralToken(r#"\"\""#).template(Span::new(0, 6)));

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -1308,7 +1308,7 @@ fn unescape_string_literal(mut s: &str) -> String {
                 b'n' => '\n',
                 b'r' => '\r',
                 b't' => '\t',
-                b'\0' => '\0',
+                b'0' => '\0',
                 b'{' => '{',
                 _ => unimplemented!("invalid escape"),
             };


### PR DESCRIPTION
New PR (previous one -> https://github.com/vectordotdev/vrl/pull/219), had to make a new one because of conflicts.

Partially solves https://github.com/vectordotdev/vrl/issues/148

added supported null \0 escape character to new lexer
