### PR TITLE
feat: give access to the program result type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - fixed a panic when arithmetic overflows. It now always wraps (only in debug builds). (https://github.com/vectordotdev/vrl/pull/252)
 - `ingress_upstreaminfo` log format has been added to `parse_nginx_log` function (https://github.com/vectordotdev/vrl/pull/193)
 - fixed type definitions for side-effects inside of queries (https://github.com/vectordotdev/vrl/pull/258)
-- changed the return type of `Program::final_type_state` to give access to the type definitions of both the target and program result
+- changed the return type of `Program::final_type_state` to give access to the type definitions of both the target and program result (https://github.com/vectordotdev/vrl/pull/262)
 
 ## `0.4.0` (2023-05-11)
 - consolidated all crates into the root `vrl` crate. The external API stayed the same, with the exception of macros, which are now all exported at the root of the `vrl` crate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - fixed a panic when arithmetic overflows. It now always wraps (only in debug builds). (https://github.com/vectordotdev/vrl/pull/252)
 - `ingress_upstreaminfo` log format has been added to `parse_nginx_log` function (https://github.com/vectordotdev/vrl/pull/193)
 - fixed type definitions for side-effects inside of queries (https://github.com/vectordotdev/vrl/pull/258)
-- changed the return type of `Program::final_type_state` to give access to the type definitions of both the target and program result (https://github.com/vectordotdev/vrl/pull/262)
+- replaced `Program::final_type_state` with `Program::final_type_info` to give access to the type definitions of both the target and program result (https://github.com/vectordotdev/vrl/pull/262)
 
 ## `0.4.0` (2023-05-11)
 - consolidated all crates into the root `vrl` crate. The external API stayed the same, with the exception of macros, which are now all exported at the root of the `vrl` crate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed a panic when arithmetic overflows. It now always wraps (only in debug builds). (https://github.com/vectordotdev/vrl/pull/252)
 - `ingress_upstreaminfo` log format has been added to `parse_nginx_log` function (https://github.com/vectordotdev/vrl/pull/193)
 - fixed type definitions for side-effects inside of queries (https://github.com/vectordotdev/vrl/pull/258)
+- changed the return type of `Program::final_type_state` to give access to the type definitions of both the target and program result
 
 ## `0.4.0` (2023-05-11)
 - consolidated all crates into the root `vrl` crate. The external API stayed the same, with the exception of macros, which are now all exported at the root of the `vrl` crate.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,6 +3,7 @@ adler,https://github.com/jonas-schievink/adler,0BSD OR MIT OR Apache-2.0,Jonas S
 aes,https://github.com/RustCrypto/block-ciphers,MIT OR Apache-2.0,RustCrypto Developers
 ahash,https://github.com/tkaitchuck/ahash,MIT OR Apache-2.0,Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
 aho-corasick,https://github.com/BurntSushi/aho-corasick,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+android-tzdata,https://github.com/RumovZ/android-tzdata,MIT OR Apache-2.0,RumovZ
 android_system_properties,https://github.com/nical/android_system_properties,MIT OR Apache-2.0,Nicolas Silva <nical@fastmail.com>
 ansi_term,https://github.com/ogham/rust-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>"
 anstream,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The anstream Authors

--- a/lib/fuzz/src/main.rs
+++ b/lib/fuzz/src/main.rs
@@ -45,7 +45,7 @@ fn fuzz(src: &str) {
         let mut ctx = Context::new(&mut target, &mut state, &timezone);
         if let Ok(_value) = result.program.resolve(&mut ctx) {
             let type_state = result.program.final_type_state();
-            let expected_kind = type_state.external.target_kind();
+            let expected_kind = type_state.state.external.target_kind();
             let actual_kind = Kind::from(target.value);
             if let Err(path) = expected_kind.is_superset(&actual_kind) {
                 panic!("Value doesn't match at path: '{}'\n\nType at path = {:?}\n\nDefinition at path = {:?}",

--- a/lib/fuzz/src/main.rs
+++ b/lib/fuzz/src/main.rs
@@ -44,7 +44,7 @@ fn fuzz(src: &str) {
         let timezone = TimeZone::default();
         let mut ctx = Context::new(&mut target, &mut state, &timezone);
         if let Ok(_value) = result.program.resolve(&mut ctx) {
-            let type_state = result.program.final_type_state();
+            let type_state = result.program.final_type_info();
             let expected_kind = type_state.state.external.target_kind();
             let actual_kind = Kind::from(target.value);
             if let Err(path) = expected_kind.is_superset(&actual_kind) {

--- a/lib/fuzz/src/main.rs
+++ b/lib/fuzz/src/main.rs
@@ -44,8 +44,8 @@ fn fuzz(src: &str) {
         let timezone = TimeZone::default();
         let mut ctx = Context::new(&mut target, &mut state, &timezone);
         if let Ok(_value) = result.program.resolve(&mut ctx) {
-            let type_state = result.program.final_type_info();
-            let expected_kind = type_state.state.external.target_kind();
+            let type_info = result.program.final_type_info();
+            let expected_kind = type_info.state.external.target_kind();
             let actual_kind = Kind::from(target.value);
             if let Err(path) = expected_kind.is_superset(&actual_kind) {
                 panic!("Value doesn't match at path: '{}'\n\nType at path = {:?}\n\nDefinition at path = {:?}",

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -177,7 +177,7 @@ fn resolve(
         }
     };
 
-    *state = program.final_type_state().state;
+    *state = program.final_type_info().state;
     execute(runtime, &program, target, timezone, vrl_runtime)
 }
 

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -177,7 +177,7 @@ fn resolve(
         }
     };
 
-    *state = program.final_type_state();
+    *state = program.final_type_state().state;
     execute(runtime, &program, target, timezone, vrl_runtime)
 }
 

--- a/src/compiler/expression/assignment.rs
+++ b/src/compiler/expression/assignment.rs
@@ -770,7 +770,7 @@ mod test {
         assert_eq!(
             result
                 .program
-                .final_type_state()
+                .final_type_info()
                 .state
                 .external
                 .target()
@@ -796,7 +796,7 @@ mod test {
         assert_eq!(
             result
                 .program
-                .final_type_state()
+                .final_type_info()
                 .state
                 .external
                 .metadata_kind(),
@@ -820,7 +820,7 @@ mod test {
         assert_eq!(
             result
                 .program
-                .final_type_state()
+                .final_type_info()
                 .state
                 .local
                 .variable(&"foo".to_string().into())
@@ -847,7 +847,7 @@ mod test {
         assert_eq!(
             result
                 .program
-                .final_type_state()
+                .final_type_info()
                 .state
                 .local
                 .variable(&"foo".to_string().into())

--- a/src/compiler/expression/assignment.rs
+++ b/src/compiler/expression/assignment.rs
@@ -771,6 +771,7 @@ mod test {
             result
                 .program
                 .final_type_state()
+                .state
                 .external
                 .target()
                 .type_def
@@ -793,7 +794,12 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            result.program.final_type_state().external.metadata_kind(),
+            result
+                .program
+                .final_type_state()
+                .state
+                .external
+                .metadata_kind(),
             &Kind::integer()
         );
     }
@@ -815,6 +821,7 @@ mod test {
             result
                 .program
                 .final_type_state()
+                .state
                 .local
                 .variable(&"foo".to_string().into())
                 .unwrap()
@@ -841,6 +848,7 @@ mod test {
             result
                 .program
                 .final_type_state()
+                .state
                 .local
                 .variable(&"foo".to_string().into())
                 .unwrap()

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -1,6 +1,6 @@
 use crate::path::OwnedTargetPath;
 
-use super::state::TypeState;
+use super::state::{TypeInfo, TypeState};
 use super::{expression::Block, Context, Expression, Resolved};
 
 #[derive(Debug, Clone)]
@@ -20,8 +20,8 @@ impl Program {
 
     /// Retrieves the state of the type system after the program runs.
     #[must_use]
-    pub fn final_type_state(&self) -> TypeState {
-        self.expressions.type_info(&self.initial_state).state
+    pub fn final_type_state(&self) -> TypeInfo {
+        self.expressions.type_info(&self.initial_state)
     }
 
     /// Get detailed information about the program, as collected by the VRL

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -20,7 +20,7 @@ impl Program {
 
     /// Retrieves the state of the type system after the program runs.
     #[must_use]
-    pub fn final_type_state(&self) -> TypeInfo {
+    pub fn final_type_info(&self) -> TypeInfo {
         self.expressions.type_info(&self.initial_state)
     }
 


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vrl/issues/240

The type definition of both the result and target of VRL programs is known, but only the target was exposed to users. This gives access to both. It is a minor breaking change.

This is useful for things such as Vector VRL conditions to be able to verify at compile time that programs return a boolean. It will also help with fuzz testing.