### PR TITLE
fix(encode_logfmt): correctly handle values with equal signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- enquote values containing `=` in `encode_logfmt` vrl function (https://github.com/vectordotdev/vector/issues/17855)
 - breaking change to `parse_nginx_log()` to make it compatible to more unstandardized events (https://github.com/vectordotdev/vrl/pull/249)
 - deprecated `to_timestamp` vrl function (https://github.com/vectordotdev/vrl/pull/285)
 

--- a/src/core/encode_key_value.rs
+++ b/src/core/encode_key_value.rs
@@ -99,7 +99,9 @@ fn encode_field(output: &mut String, key: &str, value: &str, key_value_delimiter
 }
 
 fn encode_string(output: &mut String, str: &str) {
-    let needs_quoting = str.chars().any(|c| c.is_whitespace() || c == '"');
+    let needs_quoting = str
+        .chars()
+        .any(|c| c.is_whitespace() || c == '"' || c == '=');
 
     if needs_quoting {
         output.write_char('"').unwrap();
@@ -568,6 +570,24 @@ mod tests {
             )
             .unwrap(),
             r#"lvl=info msg="{\"key\":\"value\"}""#
+        );
+    }
+
+    #[test]
+    fn string_with_equal_sign() {
+        assert_eq!(
+            &to_string::<Value>(
+                &btreemap! {
+                    "lvl" => "info",
+                    "msg" => "="
+                },
+                &[],
+                "=",
+                " ",
+                true
+            )
+            .unwrap(),
+            r#"lvl=info msg="=""#
         );
     }
 


### PR DESCRIPTION
Fixes: https://github.com/vectordotdev/vector/issues/17855