### PR TITLE
feat(stdlib): introduce CTR-LE and CTR-BE encryption/decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - breaking change to `parse_nginx_log()` to make it compatible to more unstandardized events (https://github.com/vectordotdev/vrl/pull/249)
 - deprecated `to_timestamp` vrl function (https://github.com/vectordotdev/vrl/pull/285)
 - add support for resolving variables to `Expr::resolve_constant` (https://github.com/vectordotdev/vrl/pull/304)
+- introduce new encryption/decryption algorithm options (`"AES-*-CTR-BE"`, `"AES-*-CTR-LE"`) https://github.com/vectordotdev/vrl/pull/299
 
 ## `0.5.0` (2023-06-28)
 - added \0 (null) character literal to lex parser (https://github.com/vectordotdev/vrl/pull/259)

--- a/src/stdlib/decrypt.rs
+++ b/src/stdlib/decrypt.rs
@@ -6,7 +6,7 @@ use aes::cipher::{
     AsyncStreamCipher, BlockDecryptMut, KeyIvInit, StreamCipher,
 };
 use cfb_mode::Decryptor as Cfb;
-use ctr::Ctr64LE;
+use ctr::{Ctr64LE, Ctr64BE};
 use ofb::Ofb;
 
 use super::encrypt::{get_iv_bytes, get_key_bytes, is_valid_algorithm};
@@ -62,9 +62,12 @@ fn decrypt(ciphertext: Value, algorithm: Value, key: Value, iv: Value) -> Resolv
         "AES-256-OFB" => decrypt_keystream!(Ofb::<aes::Aes256>, ciphertext, key, iv),
         "AES-192-OFB" => decrypt_keystream!(Ofb::<aes::Aes192>, ciphertext, key, iv),
         "AES-128-OFB" => decrypt_keystream!(Ofb::<aes::Aes128>, ciphertext, key, iv),
-        "AES-256-CTR" => decrypt_keystream!(Ctr64LE::<aes::Aes256>, ciphertext, key, iv),
-        "AES-192-CTR" => decrypt_keystream!(Ctr64LE::<aes::Aes192>, ciphertext, key, iv),
-        "AES-128-CTR" => decrypt_keystream!(Ctr64LE::<aes::Aes128>, ciphertext, key, iv),
+        "AES-256-CTR" | "AES-256-CTR-LE" => decrypt_keystream!(Ctr64LE::<aes::Aes256>, ciphertext, key, iv),
+        "AES-192-CTR" | "AES-192-CTR-LE" => decrypt_keystream!(Ctr64LE::<aes::Aes192>, ciphertext, key, iv),
+        "AES-128-CTR" | "AES-128-CTR-LE" => decrypt_keystream!(Ctr64LE::<aes::Aes128>, ciphertext, key, iv),
+        "AES-256-CTR-BE" => decrypt_keystream!(Ctr64BE::<aes::Aes256>, ciphertext, key, iv),
+        "AES-192-CTR-BE" => decrypt_keystream!(Ctr64BE::<aes::Aes192>, ciphertext, key, iv),
+        "AES-128-CTR-BE" => decrypt_keystream!(Ctr64BE::<aes::Aes128>, ciphertext, key, iv),
         "AES-256-CBC-PKCS7" => decrypt_padded!(Aes256Cbc, Pkcs7, ciphertext, key, iv),
         "AES-192-CBC-PKCS7" => decrypt_padded!(Aes192Cbc, Pkcs7, ciphertext, key, iv),
         "AES-128-CBC-PKCS7" => decrypt_padded!(Aes128Cbc, Pkcs7, ciphertext, key, iv),
@@ -221,20 +224,38 @@ mod tests {
             tdef: TypeDef::bytes().fallible(),
         }
 
-        aes_256_ctr {
-            args: func_args![ciphertext: value!(b"\xd13\x92\x81\x9a^\x0e=<\x88\xdc\xe7/:]\x90\x9a\x99\xa7\xb6"), algorithm: "AES-256-CTR", key: "32_bytes_xxxxxxxxxxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+        aes_256_ctr_le {
+            args: func_args![ciphertext: value!(b"\xd13\x92\x81\x9a^\x0e=<\x88\xdc\xe7/:]\x90\x9a\x99\xa7\xb6"), algorithm: "AES-256-CTR-LE", key: "32_bytes_xxxxxxxxxxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
             want: Ok(value!("morethan1blockofdata")),
             tdef: TypeDef::bytes().fallible(),
         }
 
-        aes_192_ctr {
-            args: func_args![ciphertext: value!(b"U\xbd6\xdbZ\xbfa}&8\xebog\x19\x99x\x88\xb69n"), algorithm: "AES-192-CTR", key: "24_bytes_xxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+        aes_192_ctr_le {
+            args: func_args![ciphertext: value!(b"U\xbd6\xdbZ\xbfa}&8\xebog\x19\x99x\x88\xb69n"), algorithm: "AES-192-CTR-LE", key: "24_bytes_xxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
             want: Ok(value!("morethan1blockofdata")),
             tdef: TypeDef::bytes().fallible(),
         }
 
-        aes_128_ctr {
-            args: func_args![ciphertext: value!(b"\xfd\xf9\xef\x1f@e\xef\xd0Z\xc3\x0c'\xad]\x0e\xd2v\x04\x05\xee"), algorithm: "AES-128-CTR", key: "16_bytes_xxxxxxx", iv: "16_bytes_xxxxxxx"],
+        aes_128_ctr_le {
+            args: func_args![ciphertext: value!(b"\xfd\xf9\xef\x1f@e\xef\xd0Z\xc3\x0c'\xad]\x0e\xd2v\x04\x05\xee"), algorithm: "AES-128-CTR-LE", key: "16_bytes_xxxxxxx", iv: "16_bytes_xxxxxxx"],
+            want: Ok(value!("morethan1blockofdata")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        aes_256_ctr_be {
+            args: func_args![ciphertext: value!(b"\xd13\x92\x81\x9a^\x0e=<\x88\xdc\xe7/:]\x90k\xea\x1c\t"), algorithm: "AES-256-CTR-BE", key: "32_bytes_xxxxxxxxxxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+            want: Ok(value!("morethan1blockofdata")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        aes_192_ctr_be {
+            args: func_args![ciphertext: value!(b"U\xbd6\xdbZ\xbfa}&8\xebog\x19\x99x\x8a\xb3C\xfd"), algorithm: "AES-192-CTR-BE", key: "24_bytes_xxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+            want: Ok(value!("morethan1blockofdata")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        aes_128_ctr_be {
+            args: func_args![ciphertext: value!(b"\xfd\xf9\xef\x1f@e\xef\xd0Z\xc3\x0c'\xad]\x0e\xd2\xae\x15v\xab"), algorithm: "AES-128-CTR-BE", key: "16_bytes_xxxxxxx", iv: "16_bytes_xxxxxxx"],
             want: Ok(value!("morethan1blockofdata")),
             tdef: TypeDef::bytes().fallible(),
         }

--- a/src/stdlib/decrypt.rs
+++ b/src/stdlib/decrypt.rs
@@ -6,7 +6,7 @@ use aes::cipher::{
     AsyncStreamCipher, BlockDecryptMut, KeyIvInit, StreamCipher,
 };
 use cfb_mode::Decryptor as Cfb;
-use ctr::{Ctr64LE, Ctr64BE};
+use ctr::{Ctr64BE, Ctr64LE};
 use ofb::Ofb;
 
 use super::encrypt::{get_iv_bytes, get_key_bytes, is_valid_algorithm};
@@ -62,9 +62,15 @@ fn decrypt(ciphertext: Value, algorithm: Value, key: Value, iv: Value) -> Resolv
         "AES-256-OFB" => decrypt_keystream!(Ofb::<aes::Aes256>, ciphertext, key, iv),
         "AES-192-OFB" => decrypt_keystream!(Ofb::<aes::Aes192>, ciphertext, key, iv),
         "AES-128-OFB" => decrypt_keystream!(Ofb::<aes::Aes128>, ciphertext, key, iv),
-        "AES-256-CTR" | "AES-256-CTR-LE" => decrypt_keystream!(Ctr64LE::<aes::Aes256>, ciphertext, key, iv),
-        "AES-192-CTR" | "AES-192-CTR-LE" => decrypt_keystream!(Ctr64LE::<aes::Aes192>, ciphertext, key, iv),
-        "AES-128-CTR" | "AES-128-CTR-LE" => decrypt_keystream!(Ctr64LE::<aes::Aes128>, ciphertext, key, iv),
+        "AES-256-CTR" | "AES-256-CTR-LE" => {
+            decrypt_keystream!(Ctr64LE::<aes::Aes256>, ciphertext, key, iv)
+        }
+        "AES-192-CTR" | "AES-192-CTR-LE" => {
+            decrypt_keystream!(Ctr64LE::<aes::Aes192>, ciphertext, key, iv)
+        }
+        "AES-128-CTR" | "AES-128-CTR-LE" => {
+            decrypt_keystream!(Ctr64LE::<aes::Aes128>, ciphertext, key, iv)
+        }
         "AES-256-CTR-BE" => decrypt_keystream!(Ctr64BE::<aes::Aes256>, ciphertext, key, iv),
         "AES-192-CTR-BE" => decrypt_keystream!(Ctr64BE::<aes::Aes192>, ciphertext, key, iv),
         "AES-128-CTR-BE" => decrypt_keystream!(Ctr64BE::<aes::Aes128>, ciphertext, key, iv),

--- a/src/stdlib/encrypt.rs
+++ b/src/stdlib/encrypt.rs
@@ -5,7 +5,7 @@ use aes::cipher::{
     AsyncStreamCipher, BlockEncryptMut, KeyIvInit, StreamCipher,
 };
 use cfb_mode::Encryptor as Cfb;
-use ctr::{Ctr64LE, Ctr64BE};
+use ctr::{Ctr64BE, Ctr64LE};
 use ofb::Ofb;
 
 type Aes128Cbc = cbc::Encryptor<aes::Aes128>;
@@ -126,9 +126,15 @@ fn encrypt(plaintext: Value, algorithm: Value, key: Value, iv: Value) -> Resolve
         "AES-256-OFB" => encrypt_keystream!(Ofb::<aes::Aes256>, plaintext, key, iv),
         "AES-192-OFB" => encrypt_keystream!(Ofb::<aes::Aes192>, plaintext, key, iv),
         "AES-128-OFB" => encrypt_keystream!(Ofb::<aes::Aes128>, plaintext, key, iv),
-        "AES-256-CTR" | "AES-256-CTR-LE" => encrypt_keystream!(Ctr64LE::<aes::Aes256>, plaintext, key, iv),
-        "AES-192-CTR" | "AES-192-CTR-LE" => encrypt_keystream!(Ctr64LE::<aes::Aes192>, plaintext, key, iv),
-        "AES-128-CTR" | "AES-128-CTR-LE" => encrypt_keystream!(Ctr64LE::<aes::Aes128>, plaintext, key, iv),
+        "AES-256-CTR" | "AES-256-CTR-LE" => {
+            encrypt_keystream!(Ctr64LE::<aes::Aes256>, plaintext, key, iv)
+        }
+        "AES-192-CTR" | "AES-192-CTR-LE" => {
+            encrypt_keystream!(Ctr64LE::<aes::Aes192>, plaintext, key, iv)
+        }
+        "AES-128-CTR" | "AES-128-CTR-LE" => {
+            encrypt_keystream!(Ctr64LE::<aes::Aes128>, plaintext, key, iv)
+        }
         "AES-256-CTR-BE" => encrypt_keystream!(Ctr64BE::<aes::Aes256>, plaintext, key, iv),
         "AES-192-CTR-BE" => encrypt_keystream!(Ctr64BE::<aes::Aes192>, plaintext, key, iv),
         "AES-128-CTR-BE" => encrypt_keystream!(Ctr64BE::<aes::Aes128>, plaintext, key, iv),

--- a/src/stdlib/encrypt.rs
+++ b/src/stdlib/encrypt.rs
@@ -5,7 +5,7 @@ use aes::cipher::{
     AsyncStreamCipher, BlockEncryptMut, KeyIvInit, StreamCipher,
 };
 use cfb_mode::Encryptor as Cfb;
-use ctr::Ctr64LE;
+use ctr::{Ctr64LE, Ctr64BE};
 use ofb::Ofb;
 
 type Aes128Cbc = cbc::Encryptor<aes::Aes128>;
@@ -95,6 +95,12 @@ pub(crate) fn is_valid_algorithm(algorithm: Value) -> bool {
             | "AES-256-CTR"
             | "AES-192-CTR"
             | "AES-128-CTR"
+            | "AES-256-CTR-LE"
+            | "AES-192-CTR-LE"
+            | "AES-128-CTR-LE"
+            | "AES-256-CTR-BE"
+            | "AES-192-CTR-BE"
+            | "AES-128-CTR-BE"
             | "AES-256-CBC-PKCS7"
             | "AES-192-CBC-PKCS7"
             | "AES-128-CBC-PKCS7"
@@ -120,9 +126,12 @@ fn encrypt(plaintext: Value, algorithm: Value, key: Value, iv: Value) -> Resolve
         "AES-256-OFB" => encrypt_keystream!(Ofb::<aes::Aes256>, plaintext, key, iv),
         "AES-192-OFB" => encrypt_keystream!(Ofb::<aes::Aes192>, plaintext, key, iv),
         "AES-128-OFB" => encrypt_keystream!(Ofb::<aes::Aes128>, plaintext, key, iv),
-        "AES-256-CTR" => encrypt_keystream!(Ctr64LE::<aes::Aes256>, plaintext, key, iv),
-        "AES-192-CTR" => encrypt_keystream!(Ctr64LE::<aes::Aes192>, plaintext, key, iv),
-        "AES-128-CTR" => encrypt_keystream!(Ctr64LE::<aes::Aes128>, plaintext, key, iv),
+        "AES-256-CTR" | "AES-256-CTR-LE" => encrypt_keystream!(Ctr64LE::<aes::Aes256>, plaintext, key, iv),
+        "AES-192-CTR" | "AES-192-CTR-LE" => encrypt_keystream!(Ctr64LE::<aes::Aes192>, plaintext, key, iv),
+        "AES-128-CTR" | "AES-128-CTR-LE" => encrypt_keystream!(Ctr64LE::<aes::Aes128>, plaintext, key, iv),
+        "AES-256-CTR-BE" => encrypt_keystream!(Ctr64BE::<aes::Aes256>, plaintext, key, iv),
+        "AES-192-CTR-BE" => encrypt_keystream!(Ctr64BE::<aes::Aes192>, plaintext, key, iv),
+        "AES-128-CTR-BE" => encrypt_keystream!(Ctr64BE::<aes::Aes128>, plaintext, key, iv),
         "AES-256-CBC-PKCS7" => encrypt_padded!(Aes256Cbc, Pkcs7, plaintext, key, iv),
         "AES-192-CBC-PKCS7" => encrypt_padded!(Aes192Cbc, Pkcs7, plaintext, key, iv),
         "AES-128-CBC-PKCS7" => encrypt_padded!(Aes128Cbc, Pkcs7, plaintext, key, iv),
@@ -279,21 +288,39 @@ mod tests {
             tdef: TypeDef::bytes().fallible(),
         }
 
-        aes_256_ctr {
-            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-256-CTR", key: "32_bytes_xxxxxxxxxxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+        aes_256_ctr_le {
+            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-256-CTR-LE", key: "32_bytes_xxxxxxxxxxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
             want: Ok(value!(b"\xd13\x92\x81\x9a^\x0e=<\x88\xdc\xe7/:]\x90\x9a\x99\xa7\xb6")),
             tdef: TypeDef::bytes().fallible(),
         }
 
-        aes_192_ctr {
-            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-192-CTR", key: "24_bytes_xxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+        aes_192_ctr_le {
+            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-192-CTR-LE", key: "24_bytes_xxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
             want: Ok(value!(b"U\xbd6\xdbZ\xbfa}&8\xebog\x19\x99x\x88\xb69n")),
             tdef: TypeDef::bytes().fallible(),
         }
 
-        aes_128_ctr {
-            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-128-CTR", key: "16_bytes_xxxxxxx", iv: "16_bytes_xxxxxxx"],
+        aes_128_ctr_le {
+            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-128-CTR-LE", key: "16_bytes_xxxxxxx", iv: "16_bytes_xxxxxxx"],
             want: Ok(value!(b"\xfd\xf9\xef\x1f@e\xef\xd0Z\xc3\x0c'\xad]\x0e\xd2v\x04\x05\xee")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        aes_256_ctr_be {
+            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-256-CTR-BE", key: "32_bytes_xxxxxxxxxxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+            want: Ok(value!(b"\xd13\x92\x81\x9a^\x0e=<\x88\xdc\xe7/:]\x90k\xea\x1c\t")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        aes_192_ctr_be {
+            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-192-CTR-BE", key: "24_bytes_xxxxxxxxxxxxxxx", iv: "16_bytes_xxxxxxx"],
+            want: Ok(value!(b"U\xbd6\xdbZ\xbfa}&8\xebog\x19\x99x\x8a\xb3C\xfd")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        aes_128_ctr_be {
+            args: func_args![plaintext: value!("morethan1blockofdata"), algorithm: "AES-128-CTR-BE", key: "16_bytes_xxxxxxx", iv: "16_bytes_xxxxxxx"],
+            want: Ok(value!(b"\xfd\xf9\xef\x1f@e\xef\xd0Z\xc3\x0c'\xad]\x0e\xd2\xae\x15v\xab")),
             tdef: TypeDef::bytes().fallible(),
         }
 


### PR DESCRIPTION
Fixes https://github.com/vectordotdev/vrl/issues/298

I am not sure how to mark "AES-*-CTR" as deprecated, but this PR introduces "AES-*-CTR-LE" and "AES-*-CTR-BE" encryption/decryption. "AES-*-CTR" is treated as "AES-*-CTR-LE".