### PR TITLE
enhancement: Expand usage of `resolve_constant` and add support for variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - enquote values containing `=` in `encode_logfmt` vrl function (https://github.com/vectordotdev/vector/issues/17855)
 - breaking change to `parse_nginx_log()` to make it compatible to more unstandardized events (https://github.com/vectordotdev/vrl/pull/249)
 - deprecated `to_timestamp` vrl function (https://github.com/vectordotdev/vrl/pull/285)
+- add support for resolving variables to `Expr::resolve_constant` (https://github.com/vectordotdev/vrl/pull/304)
 
 ## `0.5.0` (2023-06-28)
 - added \0 (null) character literal to lex parser (https://github.com/vectordotdev/vrl/pull/259)

--- a/lib/tests/tests/diagnostics/function_static_expression_needed.vrl
+++ b/lib/tests/tests/diagnostics/function_static_expression_needed.vrl
@@ -1,15 +1,16 @@
 # result:
 #
-# error[E610]: function compilation error: error[E402] this argument must be a static expression
+# error[E610]: function compilation error: error[E403] invalid argument
 #   ┌─ :3:1
 #   │
 # 3 │ redact("hello 4916155524184782 world", [foo])
 #   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #   │ │
-#   │ expected static expression for argument "filters"
-#   │ received: variable call
+#   │ invalid argument "filters"
+#   │ error: unknown filter name
+#   │ received: { "type": "credit_card" }
 #   │
-#   = learn more about error code 402 at https://errors.vrl.dev/402
+#   = learn more about error code 403 at https://errors.vrl.dev/403
 #   = see language documentation at https://vrl.dev
 #   = try your code in the VRL REPL, learn more at https://vrl.dev/examples
 

--- a/lib/tests/tests/expressions/assignment/infallible_mixed.vrl
+++ b/lib/tests/tests/expressions/assignment/infallible_mixed.vrl
@@ -1,5 +1,5 @@
 # result: [{ "ok": 1.0 }, null]
-
-foo = 1
-.ok, err = 1 / foo
+.x = 1
+.ok, err = 1 / .x
+del(.x)
 [., err]

--- a/lib/tests/tests/expressions/assignment/infallible_mixed_path.vrl
+++ b/lib/tests/tests/expressions/assignment/infallible_mixed_path.vrl
@@ -1,5 +1,6 @@
 # result: [{ "ok": { "foo": [null, null, 1.0] } }, { "bar": { "baz": null } }]
 
-foo = 1
-.ok.foo[2], err.bar.baz = 1 / foo
+.x = 1
+.ok.foo[2], err.bar.baz = 1 / .x
+del(.x)
 [., err]

--- a/lib/tests/tests/expressions/assignment/infallible_ok_return_value.vrl
+++ b/lib/tests/tests/expressions/assignment/infallible_ok_return_value.vrl
@@ -1,4 +1,4 @@
 # result: 1.0
 
-foo = 1
-ok, err = 1 / foo
+.x = 1
+ok, err = 1 / .x

--- a/lib/tests/tests/expressions/equality/eq.vrl
+++ b/lib/tests/tests/expressions/equality/eq.vrl
@@ -1,4 +1,4 @@
 # result: [true, false, false, false]
 
 foo = 4
-[1 == 1, 0 == 1, "true" == true, (5 / foo ?? 0) == 0]
+[1 == 1, 0 == 1, "true" == true, (5 / foo) == 0]

--- a/lib/tests/tests/expressions/equality/ne.vrl
+++ b/lib/tests/tests/expressions/equality/ne.vrl
@@ -1,4 +1,4 @@
 # result: [false, true, true, true]
 
 foo = 4
-[1 != 1, 0 != 1, "true" != true, (5 / foo ?? 0) != 0]
+[1 != 1, 0 != 1, "true" != true, (5 / foo) != 0]

--- a/lib/tests/tests/internal/short_circuit.vrl
+++ b/lib/tests/tests/internal/short_circuit.vrl
@@ -4,6 +4,7 @@
 # The rhs condition should never trigger in these cases.
 true || (.foo = true)
 false && (.bar = true)
-foo = 1
-5 / foo ?? (.baz = true)
+.x = 1
+5 / .x ?? (.baz = true)
+del(.x)
 .

--- a/src/compiler/expression/array.rs
+++ b/src/compiler/expression/array.rs
@@ -36,10 +36,10 @@ impl Expression for Array {
             .map(Value::Array)
     }
 
-    fn resolve_constant(&self) -> Option<Value> {
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
         self.inner
             .iter()
-            .map(Expr::resolve_constant)
+            .map(|x| x.resolve_constant(state))
             .collect::<Option<Vec<_>>>()
             .map(Value::Array)
     }

--- a/src/compiler/expression/assignment.rs
+++ b/src/compiler/expression/assignment.rs
@@ -541,7 +541,9 @@ where
         match &self {
             Variant::Single { target, expr } => {
                 let expr_result = expr.apply_type_info(&mut state);
-                target.insert_type_def(&mut state, expr_result.clone(), expr.resolve_constant());
+
+                let const_value = expr.resolve_constant(&state);
+                target.insert_type_def(&mut state, expr_result.clone(), const_value);
                 TypeInfo::new(state, expr_result)
             }
             Variant::Infallible {
@@ -557,7 +559,9 @@ where
                     .clone()
                     .union(TypeDef::from(default.kind()))
                     .infallible();
-                ok.insert_type_def(&mut state, ok_type, expr.resolve_constant());
+
+                let const_value = expr.resolve_constant(&state);
+                ok.insert_type_def(&mut state, ok_type, const_value);
 
                 // The "err" type is either the error message "bytes" or "null" (not undefined).
                 let err_type = TypeDef::from(Kind::bytes().or_null());

--- a/src/compiler/expression/container.rs
+++ b/src/compiler/expression/container.rs
@@ -38,14 +38,14 @@ impl Expression for Container {
         }
     }
 
-    fn resolve_constant(&self) -> Option<Value> {
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
         use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
-            Group(v) => v.resolve_constant(),
-            Block(v) => v.resolve_constant(),
-            Array(v) => v.resolve_constant(),
-            Object(v) => v.resolve_constant(),
+            Group(v) => v.resolve_constant(state),
+            Block(v) => v.resolve_constant(state),
+            Array(v) => v.resolve_constant(state),
+            Object(v) => v.resolve_constant(state),
         }
     }
 

--- a/src/compiler/expression/function_call.rs
+++ b/src/compiler/expression/function_call.rs
@@ -310,7 +310,7 @@ impl<'a> Builder<'a> {
                                 // the ind of the target of the closure.
                                 VariableKind::Target => (
                                     target.type_info(state).result,
-                                    target.resolve_constant(&state),
+                                    target.resolve_constant(state),
                                 ),
 
                                 // The variable kind is expected to be equal to

--- a/src/compiler/expression/function_call.rs
+++ b/src/compiler/expression/function_call.rs
@@ -308,9 +308,10 @@ impl<'a> Builder<'a> {
 
                                 // The variable kind is expected to be equal to
                                 // the ind of the target of the closure.
-                                VariableKind::Target => {
-                                    (target.type_info(state).result, target.resolve_constant())
-                                }
+                                VariableKind::Target => (
+                                    target.type_info(state).result,
+                                    target.resolve_constant(&state),
+                                ),
 
                                 // The variable kind is expected to be equal to
                                 // the reduced kind of all values within the

--- a/src/compiler/expression/literal.rs
+++ b/src/compiler/expression/literal.rs
@@ -51,7 +51,7 @@ impl Expression for Literal {
         Ok(self.to_value())
     }
 
-    fn resolve_constant(&self) -> Option<Value> {
+    fn resolve_constant(&self, _state: &TypeState) -> Option<Value> {
         Some(self.to_value())
     }
 

--- a/src/compiler/expression/object.rs
+++ b/src/compiler/expression/object.rs
@@ -37,10 +37,10 @@ impl Expression for Object {
             .map(Value::Object)
     }
 
-    fn resolve_constant(&self) -> Option<Value> {
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
         self.inner
             .iter()
-            .map(|(key, expr)| expr.resolve_constant().map(|v| (key.clone(), v)))
+            .map(|(key, expr)| expr.resolve_constant(state).map(|v| (key.clone(), v)))
             .collect::<Option<BTreeMap<_, _>>>()
             .map(Value::Object)
     }

--- a/src/compiler/expression/op.rs
+++ b/src/compiler/expression/op.rs
@@ -127,10 +127,11 @@ impl Expression for Op {
     fn type_info(&self, state: &TypeState) -> TypeInfo {
         use crate::value::Kind as K;
         use ast::Opcode::{Add, And, Div, Eq, Err, Ge, Gt, Le, Lt, Merge, Mul, Ne, Or, Sub};
+        let original_state = state.clone();
 
         let mut state = state.clone();
         let mut lhs_def = self.lhs.apply_type_info(&mut state);
-        let lhs_value = self.lhs.resolve_constant();
+        let lhs_value = self.lhs.resolve_constant(&original_state);
 
         // TODO: this is incorrect, but matches the existing behavior of the compiler
         // see: https://github.com/vectordotdev/vector/issues/13789
@@ -228,7 +229,7 @@ impl Expression for Op {
                 let td = TypeDef::float();
 
                 // Division is infallible if the rhs is a literal normal float or integer.
-                match self.rhs.resolve_constant() {
+                match self.rhs.resolve_constant(&state) {
                     Some(value) if lhs_def.is_float() || lhs_def.is_integer() => match value {
                         Value::Float(v) if v.is_normal() => td.infallible(),
                         Value::Integer(v) if v != 0 => td.infallible(),

--- a/src/compiler/expression/query.rs
+++ b/src/compiler/expression/query.rs
@@ -127,7 +127,9 @@ impl Expression for Query {
 
     fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
         match self.target {
-            Target::Internal(ref variable) => variable.resolve_constant(state),
+            Target::Internal(ref variable) => variable
+                .resolve_constant(state)
+                .and_then(|v| v.get(self.path()).cloned()),
             _ => None,
         }
     }

--- a/src/compiler/expression/query.rs
+++ b/src/compiler/expression/query.rs
@@ -20,22 +20,27 @@ impl Query {
     // TODO:
     // - error when trying to index into object
     // - error when trying to path into array
+    #[must_use]
     pub fn new(target: Target, path: OwnedValuePath) -> Self {
         Query { target, path }
     }
 
+    #[must_use]
     pub fn path(&self) -> &OwnedValuePath {
         &self.path
     }
 
+    #[must_use]
     pub fn target(&self) -> &Target {
         &self.target
     }
 
+    #[must_use]
     pub fn is_external(&self) -> bool {
         matches!(self.target, Target::External(_))
     }
 
+    #[must_use]
     pub fn external_path(&self) -> Option<OwnedTargetPath> {
         match self.target {
             Target::External(prefix) => Some(OwnedTargetPath {
@@ -46,6 +51,7 @@ impl Query {
         }
     }
 
+    #[must_use]
     pub fn as_variable(&self) -> Option<&Variable> {
         match &self.target {
             Target::Internal(variable) => Some(variable),
@@ -53,6 +59,7 @@ impl Query {
         }
     }
 
+    #[must_use]
     pub fn variable_ident(&self) -> Option<&Ident> {
         match &self.target {
             Target::Internal(v) => Some(v.ident()),
@@ -60,6 +67,7 @@ impl Query {
         }
     }
 
+    #[must_use]
     pub fn expression_target(&self) -> Option<&dyn Expression> {
         match &self.target {
             Target::FunctionCall(expr) => Some(expr),

--- a/src/compiler/expression/query.rs
+++ b/src/compiler/expression/query.rs
@@ -117,11 +117,9 @@ impl Expression for Query {
         Ok(value.get(&self.path).cloned().unwrap_or(Value::Null))
     }
 
-    fn resolve_constant(&self) -> Option<Value> {
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
         match self.target {
-            Target::Internal(ref variable) => {
-                variable.value().and_then(|v| v.get(self.path())).cloned()
-            }
+            Target::Internal(ref variable) => variable.resolve_constant(state),
             _ => None,
         }
     }

--- a/src/compiler/expression/variable.rs
+++ b/src/compiler/expression/variable.rs
@@ -13,31 +13,24 @@ use crate::compiler::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Variable {
     ident: Ident,
-    value: Option<Value>,
 }
 
 impl Variable {
     pub(crate) fn new(span: Span, ident: Ident, local: &LocalEnv) -> Result<Self, Error> {
-        let value = if let Some(variable) = local.variable(&ident) {
-            variable.value.as_ref().cloned()
-        } else {
+        if local.variable(&ident).is_none() {
             let idents = local
                 .variable_idents()
                 .map(std::clone::Clone::clone)
                 .collect::<Vec<_>>();
 
             return Err(Error::undefined(ident, span, idents));
-        };
+        }
 
-        Ok(Self { ident, value })
+        Ok(Self { ident })
     }
 
     pub fn ident(&self) -> &Ident {
         &self.ident
-    }
-
-    pub fn value(&self) -> Option<&Value> {
-        self.value.as_ref()
     }
 }
 
@@ -48,6 +41,13 @@ impl Expression for Variable {
             .variable(&self.ident)
             .cloned()
             .unwrap_or(Value::Null))
+    }
+
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
+        state
+            .local
+            .variable(self.ident())
+            .and_then(|details| details.value.clone())
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {
@@ -144,5 +144,27 @@ impl DiagnosticMessage for Error {
                 vec
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::compiler::type_def::Details;
+
+    use super::*;
+
+    #[test]
+    fn test_resolve_const() {
+        let mut state = TypeState::default();
+        state.local.insert_variable(
+            Ident::new("foo"),
+            Details {
+                type_def: TypeDef::integer(),
+                value: Some(Value::Integer(42)),
+            },
+        );
+
+        let var = Variable::new((0, 0).into(), Ident::new("foo"), &state.local).unwrap();
+        assert_eq!(var.resolve_constant(&state), Some(Value::Integer(42)));
     }
 }

--- a/src/compiler/expression/variable.rs
+++ b/src/compiler/expression/variable.rs
@@ -29,6 +29,7 @@ impl Variable {
         Ok(Self { ident })
     }
 
+    #[must_use]
     pub fn ident(&self) -> &Ident {
         &self.ident
     }

--- a/src/stdlib/chunks.rs
+++ b/src/stdlib/chunks.rs
@@ -59,7 +59,7 @@ impl Function for Chunks {
 
     fn compile(
         &self,
-        _state: &TypeState,
+        state: &TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -68,7 +68,7 @@ impl Function for Chunks {
 
         // chunk_size is converted to a usize, so if a user-supplied Value::Integer (i64) is
         // larger than the platform's usize::MAX, it could fail to convert.
-        if let Some(literal) = chunk_size.resolve_constant() {
+        if let Some(literal) = chunk_size.resolve_constant(state) {
             if let Some(integer) = literal.as_integer() {
                 if integer < 1 {
                     return Err(function::Error::InvalidArgument {
@@ -108,8 +108,8 @@ impl FunctionExpression for ChunksFn {
         chunks(value, chunk_size)
     }
 
-    fn type_def(&self, _state: &TypeState) -> TypeDef {
-        let not_literal = self.chunk_size.resolve_constant().is_none();
+    fn type_def(&self, state: &TypeState) -> TypeDef {
+        let not_literal = self.chunk_size.resolve_constant(state).is_none();
 
         TypeDef::array(Collection::from_unknown(Kind::bytes())).with_fallibility(not_literal)
     }

--- a/src/stdlib/decrypt.rs
+++ b/src/stdlib/decrypt.rs
@@ -126,7 +126,7 @@ impl Function for Decrypt {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -135,7 +135,7 @@ impl Function for Decrypt {
         let key = arguments.required("key");
         let iv = arguments.required("iv");
 
-        if let Some(algorithm) = algorithm.resolve_constant() {
+        if let Some(algorithm) = algorithm.resolve_constant(state) {
             if !is_valid_algorithm(algorithm.clone()) {
                 return Err(function::Error::InvalidArgument {
                     keyword: "algorithm",

--- a/src/stdlib/del.rs
+++ b/src/stdlib/del.rs
@@ -179,7 +179,7 @@ impl Expression for DelFn {
         let compact: Option<bool> = self
             .compact
             .as_ref()
-            .and_then(|compact| compact.resolve_constant())
+            .and_then(|compact| compact.resolve_constant(&state))
             .and_then(|compact| compact.as_boolean());
 
         if let Some(compact) = compact {

--- a/src/stdlib/encode_percent.rs
+++ b/src/stdlib/encode_percent.rs
@@ -101,13 +101,13 @@ impl Function for EncodePercent {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let ascii_set = arguments
-            .optional_enum("ascii_set", &ascii_sets())?
+            .optional_enum("ascii_set", &ascii_sets(), state)?
             .unwrap_or_else(|| value!("NON_ALPHANUMERIC"))
             .try_bytes()
             .expect("ascii_set not bytes");

--- a/src/stdlib/encrypt.rs
+++ b/src/stdlib/encrypt.rs
@@ -184,7 +184,7 @@ impl Function for Encrypt {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -193,7 +193,7 @@ impl Function for Encrypt {
         let key = arguments.required("key");
         let iv = arguments.required("iv");
 
-        if let Some(algorithm) = algorithm.resolve_constant() {
+        if let Some(algorithm) = algorithm.resolve_constant(state) {
             if !is_valid_algorithm(algorithm.clone()) {
                 return Err(function::Error::InvalidArgument {
                     keyword: "algorithm",

--- a/src/stdlib/from_unix_timestamp.rs
+++ b/src/stdlib/from_unix_timestamp.rs
@@ -73,14 +73,14 @@ impl Function for FromUnixTimestamp {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 
         let unit = arguments
-            .optional_enum("unit", Unit::all_value().as_slice())?
+            .optional_enum("unit", Unit::all_value().as_slice(), state)?
             .map(|s| {
                 Unit::from_str(&s.try_bytes_utf8_lossy().expect("unit not bytes"))
                     .expect("validated enum")

--- a/src/stdlib/hmac.rs
+++ b/src/stdlib/hmac.rs
@@ -113,12 +113,12 @@ impl FunctionExpression for HmacFn {
         hmac(value, key, algorithm)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
         let valid_algorithms = vec!["SHA1", "SHA-224", "SHA-256", "SHA-384", "SHA-512"];
 
         let mut valid_static_algo = false;
         if let Some(algorithm) = self.algorithm.as_ref() {
-            if let Some(algorithm) = algorithm.resolve_constant() {
+            if let Some(algorithm) = algorithm.resolve_constant(state) {
                 if let Ok(algorithm) = algorithm.try_bytes_utf8_lossy() {
                     let algorithm = algorithm.to_uppercase();
                     valid_static_algo = valid_algorithms.contains(&algorithm.as_str());

--- a/src/stdlib/is_json.rs
+++ b/src/stdlib/is_json.rs
@@ -93,12 +93,12 @@ impl Function for IsJson {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let variant = arguments.optional_enum("variant", &variants())?;
+        let variant = arguments.optional_enum("variant", &variants(), state)?;
 
         match variant {
             Some(raw_variant) => {

--- a/src/stdlib/log.rs
+++ b/src/stdlib/log.rs
@@ -71,7 +71,7 @@ impl Function for Log {
     #[cfg(not(target_arch = "wasm32"))]
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -85,7 +85,7 @@ impl Function for Log {
 
         let value = arguments.required("value");
         let level = arguments
-            .optional_enum("level", &levels)?
+            .optional_enum("level", &levels, state)?
             .unwrap_or_else(|| "info".into())
             .try_bytes()
             .expect("log level not bytes");

--- a/src/stdlib/match.rs
+++ b/src/stdlib/match.rs
@@ -52,14 +52,14 @@ impl Function for Match {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
 
-        match pattern.resolve_constant() {
+        match pattern.resolve_constant(state) {
             Some(pattern) => {
                 let pattern = pattern
                     .try_regex()

--- a/src/stdlib/match_any.rs
+++ b/src/stdlib/match_any.rs
@@ -46,7 +46,7 @@ impl Function for MatchAny {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -56,7 +56,7 @@ impl Function for MatchAny {
         let mut re_strings = Vec::with_capacity(patterns.len());
         for expr in patterns {
             let value =
-                expr.resolve_constant()
+                expr.resolve_constant(state)
                     .ok_or(function::Error::ExpectedStaticExpression {
                         keyword: "patterns",
                         expr,

--- a/src/stdlib/match_datadog_query.rs
+++ b/src/stdlib/match_datadog_query.rs
@@ -44,12 +44,12 @@ impl Function for MatchDatadogQuery {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let query_value = arguments.required_literal("query")?.to_value();
+        let query_value = arguments.required_literal("query", state)?;
 
         // Query should always be a string.
         let query = query_value

--- a/src/stdlib/mod_func.rs
+++ b/src/stdlib/mod_func.rs
@@ -63,9 +63,9 @@ impl FunctionExpression for ModFn {
         r#mod(value, modulus)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
         // Division is infallible if the rhs is a literal normal float or a literal non-zero integer.
-        match self.modulus.resolve_constant() {
+        match self.modulus.resolve_constant(state) {
             Some(value) if value.is_float() || value.is_integer() => match value {
                 Value::Float(v) if v.is_normal() => TypeDef::float().infallible(),
                 Value::Float(_) => TypeDef::float().fallible(),

--- a/src/stdlib/parse_apache_log.rs
+++ b/src/stdlib/parse_apache_log.rs
@@ -65,13 +65,13 @@ impl Function for ParseApacheLog {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments
-            .required_enum("format", &variants())?
+            .required_enum("format", &variants(), state)?
             .try_bytes()
             .expect("format not bytes");
 

--- a/src/stdlib/parse_grok.rs
+++ b/src/stdlib/parse_grok.rs
@@ -127,15 +127,14 @@ impl Function for ParseGrok {
     #[cfg(not(target_arch = "wasm32"))]
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 
         let pattern = arguments
-            .required_literal("pattern")?
-            .to_value()
+            .required_literal("pattern", state)?
             .try_bytes_utf8_lossy()
             .expect("grok pattern not bytes")
             .into_owned();

--- a/src/stdlib/parse_groks.rs
+++ b/src/stdlib/parse_groks.rs
@@ -125,7 +125,7 @@ impl Function for ParseGroks {
     #[cfg(not(target_arch = "wasm32"))]
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -138,7 +138,7 @@ impl Function for ParseGroks {
             .into_iter()
             .map(|expr| {
                 let pattern = expr
-                    .resolve_constant()
+                    .resolve_constant(state)
                     .ok_or(function::Error::ExpectedStaticExpression {
                         keyword: "patterns",
                         expr,
@@ -156,7 +156,7 @@ impl Function for ParseGroks {
             .into_iter()
             .map(|(key, expr)| {
                 let alias = expr
-                    .resolve_constant()
+                    .resolve_constant(state)
                     .ok_or(function::Error::ExpectedStaticExpression {
                         keyword: "aliases",
                         expr,

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -136,7 +136,7 @@ impl Function for ParseKeyValue {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -151,7 +151,7 @@ impl Function for ParseKeyValue {
             .unwrap_or_else(|| expr!(" "));
 
         let whitespace = arguments
-            .optional_enum("whitespace", &Whitespace::all_value())?
+            .optional_enum("whitespace", &Whitespace::all_value(), state)?
             .map(|s| {
                 Whitespace::from_str(&s.try_bytes_utf8_lossy().expect("whitespace not bytes"))
                     .expect("validated enum")

--- a/src/stdlib/parse_nginx_log.rs
+++ b/src/stdlib/parse_nginx_log.rs
@@ -61,13 +61,13 @@ impl Function for ParseNginxLog {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments
-            .required_enum("format", &variants())?
+            .required_enum("format", &variants(), state)?
             .try_bytes()
             .expect("format not bytes");
 

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -43,12 +43,12 @@ impl Function for ParseRegex {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required_regex("pattern")?;
+        let pattern = arguments.required_regex("pattern", state)?;
         let numeric_groups = arguments
             .optional("numeric_groups")
             .unwrap_or_else(|| expr!(false));
@@ -78,6 +78,16 @@ impl Function for ParseRegex {
                 "0": "8.7.6.5 - zorp",
                 "1": "8.7.6.5",
                 "2": "zorp",
+                "host": "8.7.6.5",
+                "user": "zorp"
+            }"# }),
+            },
+            Example {
+                title: "match with variable",
+                source: r#"
+                variable = r'^(?P<host>[\w\.]+) - (?P<user>[\w]+)';
+                parse_regex!("8.7.6.5 - zorp", variable)"#,
+                result: Ok(indoc! { r#"{
                 "host": "8.7.6.5",
                 "user": "zorp"
             }"# }),

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -43,12 +43,12 @@ impl Function for ParseRegexAll {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required_regex("pattern")?;
+        let pattern = arguments.required_regex("pattern", state)?;
         let numeric_groups = arguments
             .optional("numeric_groups")
             .unwrap_or_else(|| expr!(false));
@@ -86,6 +86,17 @@ impl Function for ParseRegexAll {
                 "0": "peaches and peas",
                 "1": "peaches",
                 "2": "peas"}]"# }),
+            },
+            Example {
+                title: "match with variables",
+                source: r#"
+                variable = r'(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)';
+                parse_regex_all!("apples and carrots, peaches and peas", variable)"#,
+                result: Ok(indoc! { r#"[
+               {"fruit": "apples",
+                "veg": "carrots"},
+               {"fruit": "peaches",
+                "veg": "peas"}]"# }),
             },
         ]
     }

--- a/src/stdlib/parse_user_agent.rs
+++ b/src/stdlib/parse_user_agent.rs
@@ -86,14 +86,14 @@ impl Function for ParseUserAgent {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 
         let mode = arguments
-            .optional_enum("mode", &Mode::all_value())?
+            .optional_enum("mode", &Mode::all_value(), state)?
             .map(|s| {
                 Mode::from_str(&s.try_bytes_utf8_lossy().expect("mode not bytes"))
                     .expect("validated enum")

--- a/src/stdlib/random_bytes.rs
+++ b/src/stdlib/random_bytes.rs
@@ -40,13 +40,13 @@ impl Function for RandomBytes {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let length = arguments.required("length");
 
-        if let Some(literal) = length.resolve_constant() {
+        if let Some(literal) = length.resolve_constant(state) {
             // check if length is valid
             let _: usize =
                 get_length(literal.clone()).map_err(|err| function::Error::InvalidArgument {
@@ -82,8 +82,8 @@ impl FunctionExpression for RandomBytesFn {
         random_bytes(length)
     }
 
-    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match self.length.resolve_constant() {
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        match self.length.resolve_constant(state) {
             None => TypeDef::bytes().fallible(),
             Some(value) => {
                 if get_length(value).is_ok() {

--- a/src/stdlib/random_float.rs
+++ b/src/stdlib/random_float.rs
@@ -64,14 +64,14 @@ impl Function for RandomFloat {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let min = arguments.required("min");
         let max = arguments.required("max");
 
-        if let (Some(min), Some(max)) = (min.resolve_constant(), max.resolve_constant()) {
+        if let (Some(min), Some(max)) = (min.resolve_constant(state), max.resolve_constant(state)) {
             // check if range is valid
             let _: Range<f64> =
                 get_range(min, max.clone()).map_err(|err| function::Error::InvalidArgument {
@@ -99,8 +99,11 @@ impl FunctionExpression for RandomFloatFn {
         random_float(min, max)
     }
 
-    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match (self.min.resolve_constant(), self.max.resolve_constant()) {
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        match (
+            self.min.resolve_constant(state),
+            self.max.resolve_constant(state),
+        ) {
             (Some(min), Some(max)) => {
                 if get_range(min, max).is_ok() {
                     TypeDef::float().infallible()

--- a/src/stdlib/random_int.rs
+++ b/src/stdlib/random_int.rs
@@ -59,14 +59,14 @@ impl Function for RandomInt {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let min = arguments.required("min");
         let max = arguments.required("max");
 
-        if let (Some(min), Some(max)) = (min.resolve_constant(), max.resolve_constant()) {
+        if let (Some(min), Some(max)) = (min.resolve_constant(state), max.resolve_constant(state)) {
             // check if range is valid
             let _: Range<i64> =
                 get_range(min, max.clone()).map_err(|err| function::Error::InvalidArgument {
@@ -94,8 +94,11 @@ impl FunctionExpression for RandomIntFn {
         random_int(min, max)
     }
 
-    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        match (self.min.resolve_constant(), self.max.resolve_constant()) {
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        match (
+            self.min.resolve_constant(state),
+            self.max.resolve_constant(state),
+        ) {
             (Some(min), Some(max)) => {
                 if get_range(min, max).is_ok() {
                     TypeDef::integer()

--- a/src/stdlib/redact.rs
+++ b/src/stdlib/redact.rs
@@ -58,7 +58,7 @@ impl Function for Redact {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
@@ -68,7 +68,7 @@ impl Function for Redact {
             .required_array("filters")?
             .into_iter()
             .map(|expr| {
-                expr.resolve_constant()
+                expr.resolve_constant(state)
                     .ok_or(function::Error::ExpectedStaticExpression {
                         keyword: "filters",
                         expr,

--- a/src/stdlib/sha2.rs
+++ b/src/stdlib/sha2.rs
@@ -67,13 +67,13 @@ impl Function for Sha2 {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let variant = arguments
-            .optional_enum("variant", &variants())?
+            .optional_enum("variant", &variants(), state)?
             .unwrap_or_else(|| value!("SHA-512/256"))
             .try_bytes()
             .expect("variant not bytes");

--- a/src/stdlib/sha3.rs
+++ b/src/stdlib/sha3.rs
@@ -63,13 +63,13 @@ impl Function for Sha3 {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let variant = arguments
-            .optional_enum("variant", &variants())?
+            .optional_enum("variant", &variants(), state)?
             .unwrap_or_else(|| value!("SHA3-512"))
             .try_bytes()
             .expect("variant not bytes");

--- a/src/stdlib/to_timestamp.rs
+++ b/src/stdlib/to_timestamp.rs
@@ -102,14 +102,14 @@ impl Function for ToTimestamp {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 
         let unit = arguments
-            .optional_enum("unit", Unit::all_value().as_slice())?
+            .optional_enum("unit", Unit::all_value().as_slice(), state)?
             .map(|s| {
                 Unit::from_str(&s.try_bytes_utf8_lossy().expect("unit not bytes"))
                     .expect("validated enum")

--- a/src/stdlib/to_unix_timestamp.rs
+++ b/src/stdlib/to_unix_timestamp.rs
@@ -56,14 +56,14 @@ impl Function for ToUnixTimestamp {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 
         let unit = arguments
-            .optional_enum("unit", Unit::all_value().as_slice())?
+            .optional_enum("unit", Unit::all_value().as_slice(), state)?
             .map(|s| {
                 Unit::from_str(&s.try_bytes_utf8_lossy().expect("unit not bytes"))
                     .expect("validated enum")


### PR DESCRIPTION
related: https://github.com/vectordotdev/vrl/issues/151
closes: https://github.com/vectordotdev/vrl/issues/114

`Expr::resolve_constant` tries to resolve an expression with only compile-time information. This implementation has been improved to also resolve variables if the value of the variable is known at compile-time.

This is something that is useful for `ArgumentList` functions, such as `ArgumentList::required_regex`, so for example a variable with a literal regex can be used where a literal regex is required.

All of the `ArgumentList::*` functions were updated to use `Expr::resolve_constant` where approriate, so they can also resolve literal variables (and any other improvements that may come with the `resolve_const` function in the future).

There was also an internal refactor for the `resolve_constant` function. The `TypeState` is the "source of truth" for compile-time information, including variables with known values. The `Variable` expression also included this. This was removed and now the `TypeState` is always used.