### PR TITLE
chore(codecs): Update syslog_loose to properly handle escapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "syslog_loose"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb75f176928530867b2a659e470f9c9ff71904695bab6556f7ad30f9039efd"
+checksum = "acf5252d1adec0a489a0225f867c1a7fd445e41674530a396d0629cff0c4b211"
 dependencies = [
  "chrono",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
-syslog_loose = { version = "0.18", optional = true }
+syslog_loose = { version = "0.19", optional = true }
 termcolor = {version = "1", optional = true }
 thiserror ={ version =  "1", optional = true }
 tracing = { version = "0.1.34", default-features = false, optional = true }

--- a/src/stdlib/parse_syslog.rs
+++ b/src/stdlib/parse_syslog.rs
@@ -1,7 +1,7 @@
 use crate::compiler::prelude::*;
 use chrono::{DateTime, Datelike, Utc};
 use std::collections::BTreeMap;
-use syslog_loose::{IncompleteDate, Message, ProcId, Protocol};
+use syslog_loose::{IncompleteDate, Message, ProcId, Protocol, Variant};
 
 pub(crate) fn parse_syslog(value: Value, ctx: &Context) -> Resolved {
     let message = value.try_bytes_utf8_lossy()?;
@@ -9,7 +9,12 @@ pub(crate) fn parse_syslog(value: Value, ctx: &Context) -> Resolved {
         TimeZone::Local => None,
         TimeZone::Named(tz) => Some(*tz),
     };
-    let parsed = syslog_loose::parse_message_with_year_exact_tz(&message, resolve_year, timezone)?;
+    let parsed = syslog_loose::parse_message_with_year_exact_tz(
+        &message,
+        resolve_year,
+        timezone,
+        Variant::Either,
+    )?;
     Ok(message_to_value(parsed))
 }
 


### PR DESCRIPTION
Fixes #228 

Syslog wasn't parsing escapes in the SD fields properly as per https://github.com/StephenWakely/syslog-loose/issues/18.

That is now fixed in the Syslog parser, so this updates the library version. For the interested the PR that fixed it in the library is https://github.com/StephenWakely/syslog-loose/pull/21.

This is also updated in [Vector](https://github.com/vectordotdev/vector/pull/18114).