### PR TITLE
Fix always rebuilding because of build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ use std::{
 fn main() {
     read_grok_patterns();
 
-    println!("cargo:rerun-if-changed=src/parser.lalrpop");
+    println!("cargo:rerun-if-changed=src/parser/parser.lalrpop");
     lalrpop::Configuration::new()
         .always_use_colors()
         .process_dir("src/datadog/grok")


### PR DESCRIPTION
Hi, noticed that `vrl` crate was always rebuilding.

Found out the `cargo:rerun-if-changed` had wrong path. Fixed it.