### PR TITLE
chore: prepare for 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## unreleased
+## `0.6.0` (2023-07-17)
+
+#### Bug Fixes
+
 - enquote values containing `=` in `encode_logfmt` vrl function (https://github.com/vectordotdev/vector/issues/17855)
 - breaking change to `parse_nginx_log()` to make it compatible to more unstandardized events (https://github.com/vectordotdev/vrl/pull/249)
+
+#### Features
+
 - deprecated `to_timestamp` vrl function (https://github.com/vectordotdev/vrl/pull/285)
 - add support for chacha20poly1305, xchacha20poly1305, xsalsa20poly1305 algorithms for encryption/decryption (https://github.com/vectordotdev/vrl/pull/293)
 - add support for resolving variables to `Expr::resolve_constant` (https://github.com/vectordotdev/vrl/pull/304)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,7 +2951,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vrl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
I didn't setup `git-cliff` yet, I manually grouped the changes.