### PR TITLE
fix: VRL tests glob now returns all tests locally

### DIFF
--- a/lib/tests/src/main.rs
+++ b/lib/tests/src/main.rs
@@ -1,10 +1,9 @@
 use vrl::compiler::{CompileConfig, TimeZone, VrlRuntime};
-use vrl::test::{get_tests_from_functions, run_tests, Test, TestConfig};
+use vrl::test::{get_tests_from_functions, run_tests, test_dir, Test, TestConfig};
 
 use chrono_tz::Tz;
 use clap::Parser;
 use glob::glob;
-
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -87,8 +86,12 @@ fn main() {
     );
 }
 
+fn test_glob_pattern() -> String {
+    test_dir().join("**/*.vrl").to_str().unwrap().to_string()
+}
+
 fn get_tests(cmd: &Cmd) -> Vec<Test> {
-    glob("tests/**/*.vrl")
+    glob(test_glob_pattern().as_str())
         .expect("valid pattern")
         .filter_map(|entry| {
             let path = entry.ok()?;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -16,7 +16,8 @@ use crate::compiler::{
 use crate::diagnostic::Formatter;
 pub use test::Test;
 
-use std::{collections::BTreeMap, str::FromStr, time::Instant};
+use std::path::{PathBuf, MAIN_SEPARATOR};
+use std::{collections::BTreeMap, env, str::FromStr, time::Instant};
 
 use crate::value::Secrets;
 use crate::value::Value;
@@ -30,6 +31,19 @@ pub struct TestConfig {
     pub timings: bool,
     pub runtime: VrlRuntime,
     pub timezone: TimeZone,
+}
+pub fn test_dir() -> PathBuf {
+    PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
+}
+
+pub fn test_prefix() -> String {
+    let mut prefix = test_dir().join("tests").to_string_lossy().to_string();
+    prefix.push(MAIN_SEPARATOR);
+    prefix
+}
+
+pub fn example_vrl_path() -> PathBuf {
+    test_dir().join("tests").join("example.vrl")
 }
 
 pub fn get_tests_from_functions(functions: Vec<Box<dyn Function>>) -> Vec<Test> {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -75,6 +75,7 @@ pub fn run_tests<T>(
     compile_config_provider: impl Fn() -> (CompileConfig, T),
     finalize_config: impl Fn(T),
 ) {
+    let total_count = tests.len();
     let mut failed_count = 0;
     let mut category = "".to_owned();
 
@@ -308,23 +309,24 @@ pub fn run_tests<T>(
             }
         }
     }
-    print_result(failed_count)
+    print_result(total_count, failed_count)
 }
 
-fn print_result(failed_count: usize) {
+fn print_result(total_count: usize, failed_count: usize) {
     let code = i32::from(failed_count > 0);
 
     println!("\n");
 
     if failed_count > 0 {
         println!(
-            "  Overall result: {}\n\n    Number failed: {}\n",
+            "Overall result: {}\n\n  Number failed: {}\n  Number passed: {}",
             Colour::Red.bold().paint("FAILED"),
-            failed_count
+            failed_count,
+            total_count - failed_count
         );
     } else {
         println!(
-            "  Overall result: {}\n",
+            "Overall result: {}\n  Number passed: {total_count}",
             Colour::Green.bold().paint("SUCCESS")
         );
     }

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, fs, path::Path};
 use crate::compiler::function::Example;
 use crate::path::parse_value_path;
 use crate::path::OwnedTargetPath;
+use crate::test::{example_vrl_path, test_prefix};
 use crate::value::Value;
 
 #[derive(Debug)]
@@ -168,21 +169,20 @@ impl Test {
 }
 
 fn test_category(path: &Path) -> String {
-    if path.as_os_str() == "tests/example.vrl" {
-        return "".to_owned();
+    if path == example_vrl_path() {
+        return "uncategorized".to_owned();
     }
 
-    path.to_string_lossy()
-        .strip_prefix("tests/")
+    let stripped_path = path
+        .to_string_lossy()
+        .strip_prefix(test_prefix().as_str())
         .expect("test")
+        .to_string();
+
+    stripped_path
+        .clone()
         .rsplit_once('/')
-        .map_or(
-            path.to_string_lossy()
-                .strip_prefix("tests/")
-                .unwrap()
-                .to_owned(),
-            |x| x.0.to_owned(),
-        )
+        .map_or(stripped_path.to_owned(), |x| x.0.to_owned())
 }
 
 fn test_name(path: &Path) -> String {

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -182,7 +182,7 @@ fn test_category(path: &Path) -> String {
     stripped_path
         .clone()
         .rsplit_once('/')
-        .map_or(stripped_path.to_owned(), |x| x.0.to_owned())
+        .map_or(stripped_path, |x| x.0.to_owned())
 }
 
 fn test_name(path: &Path) -> String {


### PR DESCRIPTION
Currently the test discovery depends on the current working dir. The goal of this PR is to make it work independently of where the tests are run.

On master branch:
``` 
cd /path/to/vrl/
cargo run --package vrl-tests --bin vrl-tests
.
.
.
Overall result: SUCCESS
  Number passed: 379
```
Note: IDEs generate the above command.

On this branch:
```
cargo run --package vrl-tests --bin vrl-tests
.
.
.
Overall result: SUCCESS
  Number passed: 643
```

Another way to run the tests is:
```
cd path/to/vrl/lib/tests
cargo run
.
.
.
Overall result: SUCCESS
  Number passed: 643
```
Note the above works already, the problem only appears when using the different method above.

Another tiny improvement is that I added an `uncategorized` category:
```
uncategorized
  example.....................................................OK
``` 