### PR TITLE
fix: check compression level in `encode_zlib` and `encode_gzip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 - added `pretty` parameter for `encode_json` vrl function to produce pretty-printed JSON string (https://github.com/vectordotdev/vrl/pull/370)
-- `encode_gzip` and `encode_zlib` now correctly check the compression level (preventing a panic) (https://github.com/vectordotdev/vrl/issues/257)
+- `encode_gzip` and `encode_zlib` now correctly check the compression level (preventing a panic) (https://github.com/vectordotdev/vrl/pull/393)
 
 ## `0.6.0` (2023-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-- added `pretty` parameter for `encode_json` vrl function to produce pretty-printed JSON string (https://github.com/vectordotdev/vrl/pull/370).
+- added `pretty` parameter for `encode_json` vrl function to produce pretty-printed JSON string (https://github.com/vectordotdev/vrl/pull/370)
+- `encode_gzip` and `encode_zlib` now correctly check the compression level (preventing a panic) (https://github.com/vectordotdev/vrl/issues/257)
 
 ## `0.6.0` (2023-08-02)
 

--- a/src/stdlib/encode_gzip.rs
+++ b/src/stdlib/encode_gzip.rs
@@ -3,10 +3,20 @@ use flate2::read::GzEncoder;
 use nom::AsBytes;
 use std::io::Read;
 
+const MAX_COMPRESSION_LEVEL: u32 = 10;
+
 fn encode_gzip(value: Value, compression_level: Option<Value>) -> Resolved {
     let compression_level = match compression_level {
         None => flate2::Compression::default(),
-        Some(value) => flate2::Compression::new(value.try_integer()? as u32),
+        Some(value) => {
+            let level = value.try_integer()? as u32;
+            if level > MAX_COMPRESSION_LEVEL {
+                return Err(
+                    format!("compression level must be <= {}", MAX_COMPRESSION_LEVEL).into(),
+                );
+            }
+            flate2::Compression::new(level)
+        }
     };
 
     let value = value.try_bytes()?;
@@ -86,8 +96,18 @@ impl FunctionExpression for EncodeGzipFn {
         encode_gzip(value, compression_level)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::bytes().infallible()
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        let is_compression_level_valid_constant = if let Some(level) = &self.compression_level {
+            if let Some(Value::Integer(level)) = level.resolve_constant(state) {
+                level <= (MAX_COMPRESSION_LEVEL as i64)
+            } else {
+                false
+            }
+        } else {
+            true
+        };
+
+        TypeDef::bytes().with_fallibility(!is_compression_level_valid_constant)
     }
 }
 
@@ -119,6 +139,11 @@ mod test {
             args: func_args![value: value!("you_have_successfully_decoded_me.congratulations.you_are_breathtaking."), compression_level: 9],
             want: Ok(value!(decode_base64("H4sIAAAAAAAC/w3LgQ3AIAgEwI1ciVD8qqmVRKAJ29cBLjWo8weyEIHZHXMmVYhWVHpRRFfb7DHZhy4reQBv0LXB3p2fsVr5AXeBkepGAAAA").as_bytes())),
             tdef: TypeDef::bytes().infallible(),
+        }
+        invalid_constant_compression {
+            args: func_args![value: value!("test"), compression_level: 11],
+            want: Err("compression level must be <= 10"),
+            tdef: TypeDef::bytes().fallible(),
         }
     ];
 }

--- a/src/stdlib/encode_gzip.rs
+++ b/src/stdlib/encode_gzip.rs
@@ -11,9 +11,7 @@ fn encode_gzip(value: Value, compression_level: Option<Value>) -> Resolved {
         Some(value) => {
             let level = value.try_integer()? as u32;
             if level > MAX_COMPRESSION_LEVEL {
-                return Err(
-                    format!("compression level must be <= {}", MAX_COMPRESSION_LEVEL).into(),
-                );
+                return Err(format!("compression level must be <= {MAX_COMPRESSION_LEVEL}").into());
             }
             flate2::Compression::new(level)
         }
@@ -99,7 +97,7 @@ impl FunctionExpression for EncodeGzipFn {
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
         let is_compression_level_valid_constant = if let Some(level) = &self.compression_level {
             if let Some(Value::Integer(level)) = level.resolve_constant(state) {
-                level <= (MAX_COMPRESSION_LEVEL as i64)
+                level <= i64::from(MAX_COMPRESSION_LEVEL)
             } else {
                 false
             }

--- a/src/stdlib/encode_zlib.rs
+++ b/src/stdlib/encode_zlib.rs
@@ -11,9 +11,7 @@ fn encode_zlib(value: Value, compression_level: Option<Value>) -> Resolved {
         Some(value) => {
             let level = value.try_integer()? as u32;
             if level > MAX_COMPRESSION_LEVEL {
-                return Err(
-                    format!("compression level must be <= {}", MAX_COMPRESSION_LEVEL).into(),
-                );
+                return Err(format!("compression level must be <= {MAX_COMPRESSION_LEVEL}").into());
             }
             flate2::Compression::new(level)
         }
@@ -100,7 +98,7 @@ impl FunctionExpression for EncodeZlibFn {
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
         let is_compression_level_valid_constant = if let Some(level) = &self.compression_level {
             if let Some(Value::Integer(level)) = level.resolve_constant(state) {
-                level <= (MAX_COMPRESSION_LEVEL as i64)
+                level <= i64::from(MAX_COMPRESSION_LEVEL)
             } else {
                 false
             }

--- a/src/stdlib/encode_zlib.rs
+++ b/src/stdlib/encode_zlib.rs
@@ -3,14 +3,25 @@ use flate2::read::ZlibEncoder;
 use nom::AsBytes;
 use std::io::Read;
 
+const MAX_COMPRESSION_LEVEL: u32 = 10;
+
 fn encode_zlib(value: Value, compression_level: Option<Value>) -> Resolved {
     let compression_level = match compression_level {
         None => flate2::Compression::default(),
-        Some(value) => flate2::Compression::new(value.try_integer()? as u32),
+        Some(value) => {
+            let level = value.try_integer()? as u32;
+            if level > MAX_COMPRESSION_LEVEL {
+                return Err(
+                    format!("compression level must be <= {}", MAX_COMPRESSION_LEVEL).into(),
+                );
+            }
+            flate2::Compression::new(level)
+        }
     };
 
     let value = value.try_bytes()?;
     let mut buf = Vec::new();
+
     // We can safely ignore the error here because the value being read from, `Bytes`, never fails a `read()` call and the value being written to, a `Vec`, never fails a `write()` call
     ZlibEncoder::new(value.as_bytes(), compression_level)
         .read_to_end(&mut buf)
@@ -86,8 +97,18 @@ impl FunctionExpression for EncodeZlibFn {
         encode_zlib(value, compression_level)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::bytes().infallible()
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        let is_compression_level_valid_constant = if let Some(level) = &self.compression_level {
+            if let Some(Value::Integer(level)) = level.resolve_constant(state) {
+                level <= (MAX_COMPRESSION_LEVEL as i64)
+            } else {
+                false
+            }
+        } else {
+            true
+        };
+
+        TypeDef::bytes().with_fallibility(!is_compression_level_valid_constant)
     }
 }
 
@@ -119,6 +140,12 @@ mod test {
             args: func_args![value: value!("you_have_successfully_decoded_me.congratulations.you_are_breathtaking."), compression_level: 9],
             want: Ok(value!(decode_base64("eNoNy4ENwCAIBMCNXIlQ/KqplUSgCdvXAS41qPMHshCB2R1zJlWIVlR6UURX2+wx2YcuK3kAb9C1wd6dn7Fa+QH9gRxr").as_bytes())),
             tdef: TypeDef::bytes().infallible(),
+        }
+
+        invalid_constant_compression {
+            args: func_args![value: value!("d"), compression_level: 11],
+            want: Err("compression level must be <= 10"),
+            tdef: TypeDef::bytes().fallible(),
         }
     ];
 }


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vrl/issues/257

This now ensures the compression level is valid to prevent a panic. The type def was updated to be fallible only if it's not known at compile-time to be valid.