### PR TITLE
fix: typedef of array/object literals containing undefined values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added `pretty` parameter for `encode_json` vrl function to produce pretty-printed JSON string (https://github.com/vectordotdev/vrl/pull/370)
 - `encode_gzip` and `encode_zlib` now correctly check the compression level (preventing a panic) (https://github.com/vectordotdev/vrl/pull/393)
+- fix the type definition of array/object literal expressions where one of the values is undefined (https://github.com/vectordotdev/vrl/pull/401)
 
 ## `0.6.0` (2023-08-02)
 

--- a/lib/tests/tests/expressions/literal/array_undefined_upgrade copy.vrl
+++ b/lib/tests/tests/expressions/literal/array_undefined_upgrade copy.vrl
@@ -1,0 +1,7 @@
+# result: {"x": [null], "typedef": {"array": {"0": {"null": true}}}}
+
+. = {}
+
+# x is an array of size one that is assigned an undefined value that is upgraded to null
+x = [.x]
+{"x": x, "typedef": type_def(x)}

--- a/lib/tests/tests/expressions/literal/object_undefined_upgrade.vrl
+++ b/lib/tests/tests/expressions/literal/object_undefined_upgrade.vrl
@@ -1,0 +1,7 @@
+# result: {"x": {"foo": null}, "typedef": {"object": {"foo": {"null": true}}}}
+
+. = {}
+
+# x is an object containing a single field foo that is assigned an undefined value that is upgraded to null
+x = {"foo": .x}
+{"x": x, "typedef": type_def(x)}

--- a/src/compiler/expression/array.rs
+++ b/src/compiler/expression/array.rs
@@ -51,7 +51,7 @@ impl Expression for Array {
         let mut fallible = false;
 
         for expr in &self.inner {
-            let type_def = expr.apply_type_info(&mut state);
+            let type_def = expr.apply_type_info(&mut state).upgrade_undefined();
 
             // If any expression is fallible, the entire array is fallible.
             fallible |= type_def.is_fallible();

--- a/src/compiler/expression/object.rs
+++ b/src/compiler/expression/object.rs
@@ -51,7 +51,7 @@ impl Expression for Object {
 
         let mut type_defs = BTreeMap::new();
         for (k, expr) in &self.inner {
-            let type_def = expr.apply_type_info(&mut state);
+            let type_def = expr.apply_type_info(&mut state).upgrade_undefined();
 
             // If any expression is fallible, the entire object is fallible.
             fallible |= type_def.is_fallible();

--- a/src/compiler/type_def.rs
+++ b/src/compiler/type_def.rs
@@ -295,6 +295,16 @@ impl TypeDef {
         self
     }
 
+    /// VRL has an interesting property where accessing an undefined value "upgrades"
+    /// it to a "null" value.
+    /// This should be used in places those implicit upgrades can occur.
+    // see: https://github.com/vectordotdev/vector/issues/13594
+    #[must_use]
+    pub fn upgrade_undefined(mut self) -> Self {
+        self.kind = self.kind.upgrade_undefined();
+        self
+    }
+
     /// Collects any subtypes that can contain multiple indexed types (array, object) and collects
     /// them into a single type for all indexes.
     ///


### PR DESCRIPTION
closes https://github.com/vectordotdev/vrl/issues/241 for both array and object literals