### PR TITLE
fix: vpc flow log field account-id as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added `pretty` parameter for `encode_json` vrl function to produce pretty-printed JSON string (https://github.com/vectordotdev/vrl/pull/370)
 - `encode_gzip` and `encode_zlib` now correctly check the compression level (preventing a panic) (https://github.com/vectordotdev/vrl/pull/393)
 - fix the type definition of array/object literal expressions where one of the values is undefined (https://github.com/vectordotdev/vrl/pull/401)
+- `parse_aws_vpc_flow_log` now handles account-id value as a string, avoiding loss of leading zeros and case where value is `unknown` (https://github.com/vectordotdev/vrl/issues/263)
 
 ## `0.6.0` (2023-08-02)
 

--- a/src/stdlib/parse_aws_vpc_flow_log.rs
+++ b/src/stdlib/parse_aws_vpc_flow_log.rs
@@ -28,7 +28,7 @@ impl Function for ParseAwsVpcFlowLog {
                 source: r#"parse_aws_vpc_flow_log!("2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA")"#,
                 result: Ok(indoc! { r#"{
                     "version": 2,
-                    "account_id": 123456789010,
+                    "account_id": "123456789010",
                     "interface_id": "eni-1235b8ca123456789",
                     "srcaddr": null,
                     "dstaddr": null,
@@ -117,7 +117,7 @@ impl FunctionExpression for ParseAwsVpcFlowLogFn {
 
 fn inner_kind() -> BTreeMap<Field, Kind> {
     BTreeMap::from([
-        (Field::from("account_id"), Kind::integer() | Kind::null()),
+        (Field::from("account_id"), Kind::bytes() | Kind::null()),
         (Field::from("action"), Kind::bytes() | Kind::null()),
         (Field::from("az_id"), Kind::bytes() | Kind::null()),
         (Field::from("bytes"), Kind::integer() | Kind::null()),
@@ -191,7 +191,7 @@ fn parse_log(input: &str, format: Option<&str>) -> ParseResult<Value> {
             (Some(key), Some(value)) => {
                 create_match!(
                     log, key, value,
-                    "account_id" => parse_i64,
+                    "account_id" => identity,
                     "action" => identity,
                     "az_id" => identity,
                     "bytes" => parse_i64,
@@ -291,7 +291,7 @@ mod tests {
         default {
              args: func_args![value: "2 123456789010 eni-1235b8ca123456789 172.31.16.139 172.31.16.21 20641 22 6 20 4249 1418530010 1418530070 ACCEPT OK"],
              want: Ok(value!({
-                 "account_id": 123_456_789_010_i64,
+                 "account_id": "123456789010",
                  "action": "ACCEPT",
                  "bytes": 4249,
                  "dstaddr": "172.31.16.21",
@@ -313,7 +313,7 @@ mod tests {
              args: func_args![value: "3 vpc-abcdefab012345678 subnet-aaaaaaaa012345678 i-01234567890123456 eni-1235b8ca123456789 123456789010 IPv4 52.213.180.42 10.0.0.62 43416 5001 52.213.180.42 10.0.0.62 6 568 8 1566848875 1566848933 ACCEPT 2 OK",
                               format: "version vpc_id subnet_id instance_id interface_id account_id type srcaddr dstaddr srcport dstport pkt_srcaddr pkt_dstaddr protocol bytes packets start end action tcp_flags log_status"],
              want: Ok(value!({
-                 "account_id": 123_456_789_010_i64,
+                 "account_id": "123456789010",
                  "action": "ACCEPT",
                  "bytes": 568,
                  "dstaddr": "10.0.0.62",


### PR DESCRIPTION
REF: https://github.com/vectordotdev/vrl/issues/263

Changed field `account_id` from an Integer type to a string.
As stated in [VPC Flow Log documentation](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-logs-fields), account-id is labelled as a string type. It is also stated that this field may have a value of `unknown`. Some account ID's may have leading zeros, which would be dropped during conversion to integer.