### PR TITLE
feat: replace 'truncate' ellipsis argument with user defined suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `parse_aws_vpc_flow_log` now handles account-id value as a string, avoiding loss of leading zeros and case where value is `unknown` (https://github.com/vectordotdev/vrl/issues/263)
 - added `community_id` function for generation of [V1 Community IDs](https://github.com/corelight/community-id-spec) (https://github.com/vectordotdev/vrl/pull/360). 
 - removed deprecated `to_timestamp` function (https://github.com/vectordotdev/vrl/pull/452)
+- changed `truncate` arguments, it now accepts a suffix string instead of a boolean (https://github.com/vectordotdev/vrl/pull/454) 
 
 ## `0.6.0` (2023-08-02)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vrl"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "ansi_term",

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2619,16 +2619,15 @@ bench_function! {
         args: func_args![
             value: "Supercalifragilisticexpialidocious",
             limit: 5,
-            ellipsis: true,
+            suffix: "...",
         ],
         want: Ok("Super..."),
     }
 
-    no_ellipsis {
+    no_suffix {
         args: func_args![
             value: "Supercalifragilisticexpialidocious",
             limit: 5,
-            ellipsis: false,
         ],
         want: Ok("Super"),
     }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -6,9 +6,9 @@ use crate::compiler::{
     },
     parser::ast::RootExpr,
     program::ProgramInfo,
-    CompileConfig, Function, Program, TypeDef,
+    CompileConfig, DeprecationWarning, Function, Program, TypeDef,
 };
-use crate::diagnostic::{DiagnosticList, DiagnosticMessage};
+use crate::diagnostic::{DiagnosticList, DiagnosticMessage, Note};
 use crate::parser::ast::{self, Node, QueryTarget};
 use crate::path::PathPrefix;
 use crate::path::{OwnedTargetPath, OwnedValuePath};
@@ -590,7 +590,18 @@ impl<'a> Compiler<'a> {
     }
 
     #[allow(clippy::unused_self)]
-    pub(crate) fn check_function_deprecations(&self, _func: &FunctionCall, _args: &ArgumentList) {}
+    pub(crate) fn check_function_deprecations(&mut self, func: &FunctionCall, args: &ArgumentList) {
+        if func.ident == "truncate" && args.optional("ellipsis").is_some() {
+            self.diagnostics.push(Box::new(
+                DeprecationWarning::new("the `ellipsis` argument")
+                    .with_span(func.span)
+                    .with_notes(Note::solution(
+                        "the `truncate` function now supports a `suffix` argument.",
+                        vec!["The `suffix` argument can be used for appending arbitrary strings."],
+                    )),
+            ));
+        }
+    }
 
     fn compile_function_call(
         &mut self,

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -593,7 +593,7 @@ impl<'a> Compiler<'a> {
     pub(crate) fn check_function_deprecations(&mut self, func: &FunctionCall, args: &ArgumentList) {
         if func.ident == "truncate" && args.optional("ellipsis").is_some() {
             self.diagnostics.push(Box::new(
-                DeprecationWarning::new("the `ellipsis` argument")
+                DeprecationWarning::new("the `ellipsis` argument", "0.7.0")
                     .with_span(func.span)
                     .with_notes(Note::solution(
                         "the `truncate` function now supports a `suffix` argument.",


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vrl/issues/438

This preserves backwards compatibility with the existing function signature and behavior.