### PR TITLE
chore: standard cargo commands work without requiring the 'test' feature

### DIFF
--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cargo clippy --workspace --all-targets --features "test" -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cargo test --workspace --features "test"
+cargo test --workspace

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -83,18 +83,20 @@
 //! - `owned_value_path!("foo.bar", "x")` will create a path with *two* segments. Equivalent to `."foo.bar".x`
 //!
 
-mod borrowed;
-mod concat;
-mod jit;
-mod owned;
-
-use self::jit::JitValuePath;
-use snafu::Snafu;
 use std::fmt::Debug;
+
+use snafu::Snafu;
 
 pub use borrowed::BorrowedSegment;
 pub use concat::PathConcat;
 pub use owned::{OwnedSegment, OwnedTargetPath, OwnedValuePath};
+
+use self::jit::JitValuePath;
+
+mod borrowed;
+mod concat;
+mod jit;
+mod owned;
 
 #[derive(Clone, Debug, Eq, PartialEq, Snafu)]
 pub enum PathParseError {
@@ -244,7 +246,7 @@ pub trait ValuePath<'a>: Clone {
     }
 }
 
-#[cfg(feature = "string_path")]
+#[cfg(any(feature = "string_path", test))]
 impl<'a> ValuePath<'a> for &'a str {
     type Iter = jit::JitValuePathIter<'a>;
 
@@ -253,7 +255,7 @@ impl<'a> ValuePath<'a> for &'a str {
     }
 }
 
-#[cfg(feature = "string_path")]
+#[cfg(any(feature = "string_path", test))]
 impl<'a> TargetPath<'a> for &'a str {
     type ValuePath = &'a str;
 

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -1,5 +1,17 @@
 //! Contains the main "Value" type for Vector and VRL, as well as helper methods.
 
+use std::collections::BTreeMap;
+
+use bytes::{Bytes, BytesMut};
+use chrono::{DateTime, SecondsFormat, Utc};
+use ordered_float::NotNan;
+
+pub use iter::{IterItem, ValueIter};
+
+use crate::path::ValuePath;
+
+pub use super::value::regex::ValueRegex;
+
 mod convert;
 mod crud;
 mod display;
@@ -12,15 +24,6 @@ mod arbitrary;
 #[cfg(any(test, feature = "lua"))]
 mod lua;
 mod serde;
-
-use std::collections::BTreeMap;
-
-pub use super::value::regex::ValueRegex;
-use crate::path::ValuePath;
-use bytes::{Bytes, BytesMut};
-use chrono::{DateTime, SecondsFormat, Utc};
-pub use iter::{IterItem, ValueIter};
-use ordered_float::NotNan;
 
 /// A boxed `std::error::Error`.
 pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -107,9 +110,9 @@ impl Value {
     ///
     /// let mut val = Value::from(BTreeMap::default());
     /// assert_eq!(val.is_empty(), true);
-    /// val.insert("foo", 1);
+    /// val.insert(path!("foo"), 1);
     /// assert_eq!(val.is_empty(), false);
-    /// val.insert("bar", 2);
+    /// val.insert(path!("bar"), 2);
     /// assert_eq!(val.is_empty(), false);
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -175,9 +178,10 @@ pub fn timestamp_to_string(timestamp: &DateTime<Utc>) -> String {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::{QuickCheck, TestResult};
+
     use crate::path;
     use crate::path::BorrowedSegment;
-    use quickcheck::{QuickCheck, TestResult};
 
     use super::*;
 


### PR DESCRIPTION
We can now run `cargo test` or `cargo clippy` without `--features "tests"`.