### PR TITLE
chore: Add wrapper type for key strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ default = ["compiler", "value", "diagnostic", "path", "parser", "stdlib", "datad
 compiler = ["diagnostic", "path", "parser", "value", "dep:paste", "dep:chrono", "dep:serde", "dep:regex", "dep:bytes", "dep:ordered-float", "dep:chrono-tz", "dep:snafu", "dep:tracing", "dep:thiserror", "dep:anymap", "dep:dyn-clone", "dep:indoc", "dep:thiserror", "dep:lalrpop-util"]
 value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json"]
 diagnostic = ["dep:codespan-reporting", "dep:termcolor"]
-path = ["dep:once_cell", "dep:serde", "dep:snafu", "dep:regex"]
-parser = ["path", "diagnostic", "dep:thiserror", "dep:ordered-float", "dep:lalrpop-util"]
+path = ["value", "dep:once_cell", "dep:serde", "dep:snafu", "dep:regex"]
+parser = ["path", "diagnostic", "value", "dep:thiserror", "dep:ordered-float", "dep:lalrpop-util"]
 core = ["value", "dep:snafu", "dep:nom"]
 string_path = []
 

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -228,7 +228,7 @@ fn serde_to_vrl(value: serde_json::Value) -> Value {
         JsonValue::Null => crate::value::Value::Null,
         JsonValue::Object(v) => v
             .into_iter()
-            .map(|(k, v)| (k, serde_to_vrl(v)))
+            .map(|(k, v)| (k.into(), serde_to_vrl(v)))
             .collect::<BTreeMap<_, _>>()
             .into(),
         JsonValue::Bool(v) => v.into(),

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -278,8 +278,6 @@ impl<'a> Compiler<'a> {
     }
 
     fn compile_object(&mut self, node: Node<ast::Object>, state: &mut TypeState) -> Option<Object> {
-        use std::collections::BTreeMap;
-
         let (keys, exprs): (Vec<String>, Vec<Option<Expr>>) = node
             .into_inner()
             .into_iter()
@@ -292,7 +290,7 @@ impl<'a> Compiler<'a> {
             keys.into_iter()
                 .zip(exprs)
                 .map(|(key, value)| (key.into(), value))
-                .collect::<BTreeMap<_, _>>(),
+                .collect(),
         ))
     }
 

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -289,7 +289,10 @@ impl<'a> Compiler<'a> {
         let exprs = exprs.into_iter().collect::<Option<Vec<_>>>()?;
 
         Some(Object::new(
-            keys.into_iter().zip(exprs).collect::<BTreeMap<_, _>>(),
+            keys.into_iter()
+                .zip(exprs)
+                .map(|(key, value)| (key.into(), value))
+                .collect::<BTreeMap<_, _>>(),
         ))
     }
 

--- a/src/compiler/expression/object.rs
+++ b/src/compiler/expression/object.rs
@@ -1,27 +1,26 @@
 use std::{collections::BTreeMap, fmt, ops::Deref};
 
-use crate::value::Value;
-
 use crate::compiler::{
     expression::{Expr, Resolved},
     state::{TypeInfo, TypeState},
     Context, Expression, TypeDef,
 };
+use crate::value::{KeyString, Value};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Object {
-    inner: BTreeMap<String, Expr>,
+    inner: BTreeMap<KeyString, Expr>,
 }
 
 impl Object {
     #[must_use]
-    pub fn new(inner: BTreeMap<String, Expr>) -> Self {
+    pub fn new(inner: BTreeMap<KeyString, Expr>) -> Self {
         Self { inner }
     }
 }
 
 impl Deref for Object {
-    type Target = BTreeMap<String, Expr>;
+    type Target = BTreeMap<KeyString, Expr>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -86,8 +85,8 @@ impl fmt::Display for Object {
     }
 }
 
-impl From<BTreeMap<String, Expr>> for Object {
-    fn from(inner: BTreeMap<String, Expr>) -> Self {
+impl From<BTreeMap<KeyString, Expr>> for Object {
+    fn from(inner: BTreeMap<KeyString, Expr>) -> Self {
         Self { inner }
     }
 }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -3,7 +3,7 @@ pub mod closure;
 use crate::diagnostic::{DiagnosticMessage, Label, Note};
 use crate::parser::ast::Ident;
 use crate::path::OwnedTargetPath;
-use crate::value::{kind::Collection, Value};
+use crate::value::{kind::Collection, KeyString, Value};
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,
@@ -326,7 +326,7 @@ impl ArgumentList {
     pub fn optional_object(
         &self,
         keyword: &'static str,
-    ) -> Result<Option<BTreeMap<String, Expr>>, Error> {
+    ) -> Result<Option<BTreeMap<KeyString, Expr>>, Error> {
         self.optional_expr(keyword)
             .map(|expr| match expr {
                 Expr::Container(Container {
@@ -341,7 +341,10 @@ impl ArgumentList {
             .transpose()
     }
 
-    pub fn required_object(&self, keyword: &'static str) -> Result<BTreeMap<String, Expr>, Error> {
+    pub fn required_object(
+        &self,
+        keyword: &'static str,
+    ) -> Result<BTreeMap<KeyString, Expr>, Error> {
         Ok(required(self.optional_object(keyword)?))
     }
 

--- a/src/compiler/function/closure.rs
+++ b/src/compiler/function/closure.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use crate::parser::ast::Ident;
 use crate::value::{
     kind::{Collection, Field, Index},
-    Value,
+    KeyString, Value,
 };
 
 use super::Example;
@@ -221,14 +221,14 @@ where
     /// value of the closure after completion.
     ///
     /// See `run_key_value` and `run_index_value` for immutable alternatives.
-    pub fn map_key(&self, ctx: &mut Context, key: &mut String) -> Result<(), ExpressionError> {
+    pub fn map_key(&self, ctx: &mut Context, key: &mut KeyString) -> Result<(), ExpressionError> {
         // TODO: we need to allow `LocalEnv` to take a mutable reference to
         // values, instead of owning them.
         let cloned_key = key.clone();
         let ident = self.ident(0);
         let old_key = insert(ctx.state_mut(), ident, cloned_key.into());
 
-        *key = (self.runner)(ctx)?.try_bytes_utf8_lossy()?.into_owned();
+        *key = (self.runner)(ctx)?.try_bytes_utf8_lossy()?.into();
 
         cleanup(ctx.state_mut(), ident, old_key);
 

--- a/src/compiler/prelude.rs
+++ b/src/compiler/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::value::{
     kind::{Collection, Field, Index},
     value,
     value::IterItem,
-    Kind, Value, ValueRegex,
+    KeyString, Kind, ObjectMap, Value, ValueRegex,
 };
 pub use bytes::Bytes;
 pub use indoc::indoc;

--- a/src/compiler/value.rs
+++ b/src/compiler/value.rs
@@ -3,7 +3,7 @@ mod convert;
 mod error;
 pub mod kind;
 
-pub use crate::value::value::IterItem;
+pub use crate::value::value::{IterItem, ObjectMap};
 pub use error::ValueError;
 pub use kind::{Collection, Field, Index, Kind};
 

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -1,9 +1,8 @@
 #![deny(clippy::arithmetic_side_effects)]
 
-use std::collections::BTreeMap;
 use std::ops::{Add, Mul, Rem, Sub};
 
-use crate::value::Value;
+use crate::value::{ObjectMap, Value};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use super::ValueError;
@@ -302,7 +301,7 @@ impl VrlValueArithmetic for Value {
                 .iter()
                 .chain(rhv.iter())
                 .map(|(k, v)| (k.clone(), v.clone()))
-                .collect::<BTreeMap<String, Value>>()
+                .collect::<ObjectMap>()
                 .into(),
             _ => return Err(err()),
         };

--- a/src/compiler/value/convert.rs
+++ b/src/compiler/value/convert.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::borrow::Cow;
 
 use crate::value::{kind::Collection, Value, ValueRegex};
 use bytes::Bytes;
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 
 use crate::compiler::{
     expression::{Container, Expr, Variant},
-    value::{Kind, ValueError},
+    value::{Kind, ObjectMap, ValueError},
     Expression,
 };
 
@@ -21,7 +21,7 @@ pub trait VrlValueConvert: Sized {
     fn try_regex(self) -> Result<ValueRegex, ValueError>;
     fn try_null(self) -> Result<(), ValueError>;
     fn try_array(self) -> Result<Vec<Value>, ValueError>;
-    fn try_object(self) -> Result<BTreeMap<String, Value>, ValueError>;
+    fn try_object(self) -> Result<ObjectMap, ValueError>;
     fn try_timestamp(self) -> Result<DateTime<Utc>, ValueError>;
 
     fn try_into_i64(&self) -> Result<i64, ValueError>;
@@ -132,7 +132,7 @@ impl VrlValueConvert for Value {
         }
     }
 
-    fn try_object(self) -> Result<BTreeMap<String, Value>, ValueError> {
+    fn try_object(self) -> Result<ObjectMap, ValueError> {
         match self {
             Value::Object(v) => Ok(v),
             _ => Err(ValueError::Expected {

--- a/src/core/encode_key_value.rs
+++ b/src/core/encode_key_value.rs
@@ -154,7 +154,7 @@ impl fmt::Display for Data {
 }
 
 struct KeyValueSerializer<'a> {
-    key: String,
+    key: KeyString,
     separator: char,
     output: &'a mut BTreeMap<KeyString, Data>,
 }
@@ -162,7 +162,7 @@ struct KeyValueSerializer<'a> {
 impl<'a> KeyValueSerializer<'a> {
     fn new(key: KeyString, separator: char, output: &'a mut BTreeMap<KeyString, Data>) -> Self {
         Self {
-            key: key.into(),
+            key,
             separator,
             output,
         }
@@ -183,14 +183,13 @@ impl<'a> KeyValueSerializer<'a> {
     }
 
     fn descend(mut self, child: impl fmt::Display) -> Self {
-        self.key.push(self.separator);
-        write!(&mut self.key, "{child}").expect("Shouldn't be reachable.");
+        self.key = format!("{}{}{child}", self.key, self.separator).into();
         self
     }
 
     fn child(&mut self, child: impl fmt::Display) -> KeyValueSerializer<'_> {
         KeyValueSerializer {
-            key: format!("{}{}{child}", self.key, self.separator),
+            key: format!("{}{}{child}", self.key, self.separator).into(),
             separator: self.separator,
             output: self.output,
         }
@@ -198,7 +197,7 @@ impl<'a> KeyValueSerializer<'a> {
 
     #[allow(clippy::unnecessary_wraps)]
     fn process(self, data: Data) -> Result<(), EncodingError> {
-        self.output.insert(self.key.into(), data);
+        self.output.insert(self.key, data);
         Ok(())
     }
 }

--- a/src/core/encode_logfmt.rs
+++ b/src/core/encode_logfmt.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::value::Value;
+use crate::value::{KeyString, Value};
 use serde::Serialize;
 
 use super::encode_key_value::{to_string as encode_key_value, EncodingError};
@@ -10,7 +10,7 @@ use super::encode_key_value::{to_string as encode_key_value, EncodingError};
 /// # Errors
 ///
 /// Returns an `EncodingError` if any of the keys are not strings.
-pub fn encode_map<V: Serialize>(input: &BTreeMap<String, V>) -> Result<String, EncodingError> {
+pub fn encode_map<V: Serialize>(input: &BTreeMap<KeyString, V>) -> Result<String, EncodingError> {
     encode_key_value(input, &[], "=", " ", true)
 }
 
@@ -25,7 +25,7 @@ pub fn encode_value(input: &Value) -> Result<String, EncodingError> {
         encode_map(map)
     } else {
         let mut map = BTreeMap::new();
-        map.insert("message".to_owned(), &input);
+        map.insert("message".to_string().into(), &input);
         encode_map(&map)
     }
 }

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -89,7 +89,7 @@ fn apply_grok_rule(source: &str, grok_rule: &GrokRule) -> Result<Value, Error> {
                 parsed
                     .as_object_mut()
                     .expect("parsed value is not an object")
-                    .insert(name.to_string(), value.into());
+                    .insert(name.to_string().into(), value.into());
             }
         }
 

--- a/src/datadog/grok/parse_grok_rules.rs
+++ b/src/datadog/grok/parse_grok_rules.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::path::OwnedValuePath;
-use crate::value::Value;
+use crate::value::{KeyString, Value};
 use once_cell::sync::Lazy;
 use tracing::error;
 
@@ -45,7 +45,7 @@ pub struct GrokRuleParseContext {
     /// a map of capture names(grok0, grok1, ...) to field information.
     pub fields: HashMap<String, GrokField>,
     /// aliases and their definitions
-    pub aliases: BTreeMap<String, String>,
+    pub aliases: BTreeMap<KeyString, String>,
     /// used to detect cycles in alias definitions
     pub alias_stack: Vec<String>,
 }
@@ -68,7 +68,7 @@ impl GrokRuleParseContext {
             .and_modify(|v| v.filters.insert(0, filter));
     }
 
-    fn new(aliases: BTreeMap<String, String>) -> Self {
+    fn new(aliases: BTreeMap<KeyString, String>) -> Self {
         Self {
             regex: String::new(),
             fields: HashMap::new(),
@@ -115,7 +115,7 @@ pub enum Error {
 /// For further documentation and the full list of available matcher and filters check out <https://docs.datadoghq.com/logs/processing/parsing>
 pub fn parse_grok_rules(
     patterns: &[String],
-    aliases: BTreeMap<String, String>,
+    aliases: BTreeMap<KeyString, String>,
 ) -> Result<Vec<GrokRule>, Error> {
     let mut grok = Grok::with_patterns();
 
@@ -270,7 +270,7 @@ fn resolve_grok_pattern(
     }
 
     let match_name = &pattern.match_fn.name;
-    match context.aliases.get(match_name).cloned() {
+    match context.aliases.get(match_name.as_str()).cloned() {
         Some(alias_def) => match &grok_alias {
             Some(grok_alias) => {
                 context.append_regex("(?<");

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -2,12 +2,13 @@ use std::str::FromStr;
 use super::ast::*;
 use super::template_string::TemplateString;
 use super::lex::*;
-use crate::diagnostic::span;
 use std::collections::BTreeMap;
 use lalrpop_util::ErrorRecovery;
 use ordered_float::NotNan;
+use crate::diagnostic::span;
 use crate::path::{PathPrefix, OwnedTargetPath, OwnedValuePath, OwnedSegment};
 use crate::parser::ast::Expr;
+use crate::value::KeyString;
 
 
 grammar<'err, 'input>(input: &'input str);
@@ -351,10 +352,10 @@ QueryTarget: QueryTarget = {
 // path
 // -----------------------------------------------------------------------------
 
-pub Field: String = {
-    AnyIdent => <>.to_string(),
-    PathField => <>.to_string(),
-    String => <>.to_string(),
+pub Field: KeyString = {
+    AnyIdent => <>.to_string().into(),
+    PathField => <>.to_string().into(),
+    String => <>.to_string().into(),
 }
 
 #[inline]

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -230,14 +230,12 @@ pub trait ValuePath<'a>: Clone {
             match segment {
                 BorrowedSegment::Invalid => return Err(()),
                 BorrowedSegment::Index(i) => owned_path.push(OwnedSegment::Index(i)),
-                BorrowedSegment::Field(field) => {
-                    owned_path.push(OwnedSegment::Field(field.to_string()))
-                }
+                BorrowedSegment::Field(field) => owned_path.push(OwnedSegment::Field(field.into())),
                 BorrowedSegment::CoalesceField(field) => {
-                    coalesce.push(field.to_string());
+                    coalesce.push(field.into());
                 }
                 BorrowedSegment::CoalesceEnd(field) => {
-                    coalesce.push(field.to_string());
+                    coalesce.push(field.into());
                     owned_path.push(OwnedSegment::Coalesce(std::mem::take(&mut coalesce)));
                 }
             }

--- a/src/stdlib/compact.rs
+++ b/src/stdlib/compact.rs
@@ -1,6 +1,5 @@
 use super::util;
 use crate::compiler::prelude::*;
-use std::collections::BTreeMap;
 
 fn compact(
     recursive: Option<Value>,
@@ -250,10 +249,7 @@ fn recurse_compact(value: Value, options: &CompactOptions) -> Value {
     }
 }
 
-fn compact_object(
-    object: BTreeMap<String, Value>,
-    options: &CompactOptions,
-) -> BTreeMap<String, Value> {
+fn compact_object(object: ObjectMap, options: &CompactOptions) -> ObjectMap {
     object
         .into_iter()
         .filter_map(|(key, value)| {
@@ -323,14 +319,17 @@ mod test {
             (
                 vec![
                     Value::from(1),
-                    Value::Object(BTreeMap::from([(String::from("field2"), Value::from(2))])),
+                    Value::Object(ObjectMap::from([(
+                        KeyString::from("field2"),
+                        Value::from(2),
+                    )])),
                     Value::from(2),
                 ],
                 vec![
                     1.into(),
-                    Value::Object(BTreeMap::from([
-                        (String::from("field1"), Value::Null),
-                        (String::from("field2"), Value::from(2)),
+                    Value::Object(ObjectMap::from([
+                        (KeyString::from("field1"), Value::Null),
+                        (KeyString::from("field2"), Value::from(2)),
                     ])),
                     2.into(),
                 ],
@@ -374,44 +373,44 @@ mod test {
                 Default::default(),
             ),
             (
-                BTreeMap::from([
-                    (String::from("key1"), Value::from(1)),
+                ObjectMap::from([
+                    (KeyString::from("key1"), Value::from(1)),
                     (
-                        String::from("key2"),
-                        Value::Object(BTreeMap::from([(String::from("key2"), Value::from(3))])),
+                        KeyString::from("key2"),
+                        Value::Object(ObjectMap::from([(KeyString::from("key2"), Value::from(3))])),
                     ),
-                    (String::from("key3"), Value::from(2)),
+                    (KeyString::from("key3"), Value::from(2)),
                 ]),
-                BTreeMap::from([
-                    (String::from("key1"), Value::from(1)),
+                ObjectMap::from([
+                    (KeyString::from("key1"), Value::from(1)),
                     (
-                        String::from("key2"),
-                        Value::Object(BTreeMap::from([
-                            (String::from("key1"), Value::Null),
-                            (String::from("key2"), Value::from(3)),
-                            (String::from("key3"), Value::Null),
+                        KeyString::from("key2"),
+                        Value::Object(ObjectMap::from([
+                            (KeyString::from("key1"), Value::Null),
+                            (KeyString::from("key2"), Value::from(3)),
+                            (KeyString::from("key3"), Value::Null),
                         ])),
                     ),
-                    (String::from("key3"), Value::from(2)),
+                    (KeyString::from("key3"), Value::from(2)),
                 ]),
                 Default::default(),
             ),
             (
-                BTreeMap::from([
-                    (String::from("key1"), Value::from(1)),
+                ObjectMap::from([
+                    (KeyString::from("key1"), Value::from(1)),
                     (
-                        String::from("key2"),
-                        Value::Object(BTreeMap::from([(String::from("key1"), Value::Null)])),
+                        KeyString::from("key2"),
+                        Value::Object(ObjectMap::from([(KeyString::from("key1"), Value::Null)])),
                     ),
-                    (String::from("key3"), Value::from(2)),
+                    (KeyString::from("key3"), Value::from(2)),
                 ]),
-                BTreeMap::from([
-                    (String::from("key1"), Value::from(1)),
+                ObjectMap::from([
+                    (KeyString::from("key1"), Value::from(1)),
                     (
-                        String::from("key2"),
-                        Value::Object(BTreeMap::from([(String::from("key1"), Value::Null)])),
+                        KeyString::from("key2"),
+                        Value::Object(ObjectMap::from([(KeyString::from("key1"), Value::Null)])),
                     ),
-                    (String::from("key3"), Value::from(2)),
+                    (KeyString::from("key3"), Value::from(2)),
                 ]),
                 CompactOptions {
                     recursive: false,
@@ -419,17 +418,17 @@ mod test {
                 },
             ),
             (
-                BTreeMap::from([
-                    (String::from("key1"), Value::from(1)),
-                    (String::from("key3"), Value::from(2)),
+                ObjectMap::from([
+                    (KeyString::from("key1"), Value::from(1)),
+                    (KeyString::from("key3"), Value::from(2)),
                 ]),
-                BTreeMap::from([
-                    (String::from("key1"), Value::from(1)),
+                ObjectMap::from([
+                    (KeyString::from("key1"), Value::from(1)),
                     (
-                        String::from("key2"),
-                        Value::Object(BTreeMap::from([(String::from("key1"), Value::Null)])),
+                        KeyString::from("key2"),
+                        Value::Object(ObjectMap::from([(KeyString::from("key1"), Value::Null)])),
                     ),
-                    (String::from("key3"), Value::from(2)),
+                    (KeyString::from("key3"), Value::from(2)),
                 ]),
                 Default::default(),
             ),
@@ -457,8 +456,8 @@ mod test {
         compact => Compact;
 
         with_map {
-            args: func_args![value: Value::from(BTreeMap::from([(String::from("key1"), Value::Null), (String::from("key2"), Value::from(1)), (String::from("key3"), Value::from(""))]))],
-            want: Ok(Value::Object(BTreeMap::from([(String::from("key2"), Value::from(1))]))),
+            args: func_args![value: Value::from(ObjectMap::from([(KeyString::from("key1"), Value::Null), (KeyString::from("key2"), Value::from(1)), (KeyString::from("key3"), Value::from(""))]))],
+            want: Ok(Value::Object(ObjectMap::from([(KeyString::from("key2"), Value::from(1))]))),
             tdef: TypeDef::object(Collection::any()),
         }
 
@@ -477,7 +476,7 @@ mod test {
                 },
                 nullish: true
             ],
-            want: Ok(Value::Object(BTreeMap::from([(String::from("key2"), Value::from(1))]))),
+            want: Ok(Value::Object(ObjectMap::from([(KeyString::from("key2"), Value::from(1))]))),
             tdef: TypeDef::object(Collection::any()),
         }
     ];

--- a/src/stdlib/encode_json.rs
+++ b/src/stdlib/encode_json.rs
@@ -92,7 +92,6 @@ impl FunctionExpression for EncodeJsonFn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
     use chrono::{DateTime, Utc};
     use regex::Regex;
@@ -149,13 +148,13 @@ mod tests {
         }
 
         map {
-            args: func_args![value: Value::from(BTreeMap::from([(String::from("field"), Value::from("value"))]))],
+            args: func_args![value: Value::from_iter([(String::from("field"), Value::from("value"))])],
             want: Ok(r#"{"field":"value"}"#),
             tdef: TypeDef::bytes().infallible(),
         }
 
         map_pretty {
-            args: func_args![value: Value::from(BTreeMap::from([(String::from("field"), Value::from("value"))])), pretty: true],
+            args: func_args![value: Value::from_iter([(String::from("field"), Value::from("value"))]), pretty: true],
             want: Ok("{\n  \"field\": \"value\"\n}"),
             tdef: TypeDef::bytes().infallible(),
         }

--- a/src/stdlib/encode_key_value.rs
+++ b/src/stdlib/encode_key_value.rs
@@ -1,5 +1,6 @@
 use crate::compiler::prelude::*;
 use crate::core::encode_key_value;
+use crate::value::KeyString;
 
 /// Also used by `encode_logfmt`.
 pub(crate) fn encode_key_value(
@@ -127,13 +128,13 @@ pub(crate) struct EncodeKeyValueFn {
     pub(crate) flatten_boolean: Box<dyn Expression>,
 }
 
-fn resolve_fields(fields: Value) -> ExpressionResult<Vec<String>> {
+fn resolve_fields(fields: Value) -> ExpressionResult<Vec<KeyString>> {
     let arr = fields.try_array()?;
     arr.iter()
         .enumerate()
         .map(|(idx, v)| {
             v.try_bytes_utf8_lossy()
-                .map(|v| v.to_string())
+                .map(|v| v.to_string().into())
                 .map_err(|e| format!("invalid field value type at index {idx}: {e}").into())
         })
         .collect()

--- a/src/stdlib/flatten.rs
+++ b/src/stdlib/flatten.rs
@@ -108,14 +108,14 @@ impl FunctionExpression for FlattenFn {
 
 /// An iterator to walk over maps allowing us to flatten nested maps to a single level.
 struct MapFlatten<'a> {
-    values: btree_map::Iter<'a, String, Value>,
+    values: btree_map::Iter<'a, KeyString, Value>,
     separator: &'a str,
     inner: Option<Box<MapFlatten<'a>>>,
-    parent: Option<String>,
+    parent: Option<KeyString>,
 }
 
 impl<'a> MapFlatten<'a> {
-    fn new(values: btree_map::Iter<'a, String, Value>, separator: &'a str) -> Self {
+    fn new(values: btree_map::Iter<'a, KeyString, Value>, separator: &'a str) -> Self {
         Self {
             values,
             separator,
@@ -125,8 +125,8 @@ impl<'a> MapFlatten<'a> {
     }
 
     fn new_from_parent(
-        parent: String,
-        values: btree_map::Iter<'a, String, Value>,
+        parent: KeyString,
+        values: btree_map::Iter<'a, KeyString, Value>,
         separator: &'a str,
     ) -> Self {
         Self {
@@ -138,16 +138,16 @@ impl<'a> MapFlatten<'a> {
     }
 
     /// Returns the key with the parent prepended.
-    fn new_key(&self, key: &str) -> String {
+    fn new_key(&self, key: &str) -> KeyString {
         match self.parent {
-            None => key.to_string(),
-            Some(ref parent) => format!("{parent}{}{key}", self.separator),
+            None => key.to_string().into(),
+            Some(ref parent) => format!("{parent}{}{key}", self.separator).into(),
         }
     }
 }
 
 impl<'a> std::iter::Iterator for MapFlatten<'a> {
-    type Item = (String, &'a Value);
+    type Item = (KeyString, &'a Value);
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(ref mut inner) = self.inner {

--- a/src/stdlib/log_util.rs
+++ b/src/stdlib/log_util.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeMap;
-
 use crate::compiler::TimeZone;
-use crate::value::Value;
+use crate::value::{ObjectMap, Value};
 use chrono::prelude::{DateTime, Utc};
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
@@ -232,13 +230,13 @@ pub(crate) fn log_fields(
             name.and_then(|name| {
                 captures.name(name).map(|value| {
                     Ok((
-                        name.to_string(),
+                        name.to_string().into(),
                         capture_value(name, value.as_str(), timestamp_format, timezone)?,
                     ))
                 })
             })
         })
-        .collect::<std::result::Result<BTreeMap<String, Value>, String>>()?
+        .collect::<std::result::Result<ObjectMap, String>>()?
         .into())
 }
 

--- a/src/stdlib/parse_aws_alb_log.rs
+++ b/src/stdlib/parse_aws_alb_log.rs
@@ -129,7 +129,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
 }
 
 fn parse_log(mut input: &str) -> ExpressionResult<Value> {
-    let mut log = BTreeMap::new();
+    let mut log = BTreeMap::<KeyString, Value>::new();
 
     macro_rules! get_value {
         ($name:expr, $parser:expr) => {{
@@ -190,7 +190,7 @@ fn parse_log(mut input: &str) -> ExpressionResult<Value> {
     let request = get_value!("request", take_quoted1);
     let mut iter = request.splitn(2, ' ');
     log.insert(
-        "request_method".to_owned(),
+        "request_method".to_owned().into(),
         match iter.next().unwrap().into() {
             Value::Bytes(bytes) if bytes == "-" => Value::Null,
             value => value,
@@ -200,7 +200,7 @@ fn parse_log(mut input: &str) -> ExpressionResult<Value> {
         Some(value) => {
             let mut iter = value.rsplitn(2, ' ');
             log.insert(
-                "request_protocol".to_owned(),
+                "request_protocol".to_owned().into(),
                 match iter.next().unwrap().into() {
                     Value::Bytes(bytes) if bytes == "-" => Value::Null,
                     value => value,

--- a/src/stdlib/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/src/stdlib/parse_aws_cloudwatch_log_subscription_message.rs
@@ -45,28 +45,31 @@ fn parse_aws_cloudwatch_log_subscription_message(bytes: Value) -> Resolved {
     let message = serde_json::from_slice::<AwsCloudWatchLogsSubscriptionMessage>(&bytes)
         .map_err(|e| format!("unable to parse: {e}"))?;
     let map = Value::from(BTreeMap::from([
-        (String::from("owner"), Value::from(message.owner)),
+        (KeyString::from("owner"), Value::from(message.owner)),
         (
-            String::from("message_type"),
+            KeyString::from("message_type"),
             Value::from(message.message_type.as_str()),
         ),
-        (String::from("log_group"), Value::from(message.log_group)),
-        (String::from("log_stream"), Value::from(message.log_stream)),
+        (KeyString::from("log_group"), Value::from(message.log_group)),
         (
-            String::from("subscription_filters"),
+            KeyString::from("log_stream"),
+            Value::from(message.log_stream),
+        ),
+        (
+            KeyString::from("subscription_filters"),
             Value::from(message.subscription_filters),
         ),
         (
-            String::from("log_events"),
+            KeyString::from("log_events"),
             Value::Array(
                 message
                     .log_events
                     .into_iter()
                     .map(|event| {
                         Value::from(BTreeMap::from([
-                            (String::from("id"), Value::from(event.id)),
-                            (String::from("timestamp"), Value::from(event.timestamp)),
-                            (String::from("message"), Value::from(event.message)),
+                            (KeyString::from("id"), Value::from(event.id)),
+                            (KeyString::from("timestamp"), Value::from(event.timestamp)),
+                            (KeyString::from("message"), Value::from(event.message)),
                         ]))
                     })
                     .collect::<Vec<Value>>(),
@@ -220,22 +223,25 @@ mod tests {
          ]
      }
      "#],
-            want: Ok(Value::from(BTreeMap::from([
+            want: Ok(Value::from_iter([
                 (String::from("owner"), Value::from("071959437513")),
                 (String::from("message_type"), Value::from("DATA_MESSAGE")),
                 (String::from("log_group"), Value::from("/jesse/test")),
                 (String::from("log_stream"), Value::from("test")),
                 (String::from("subscription_filters"), Value::from(vec![Value::from("Destination")])),
-                (String::from("log_events"), Value::from(vec![Value::from(BTreeMap::from([
-                    (String::from("id"), Value::from( "35683658089614582423604394983260738922885519999578275840")),
-                    (String::from("timestamp"), Value::from(Utc.timestamp_opt(1_600_110_569, 39_000_000).single().expect("invalid timestamp"))),
-                    (String::from("message"), Value::from("{\"bytes\":26780,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"157.130.216.193\",\"method\":\"PUT\",\"protocol\":\"HTTP/1.0\",\"referer\":\"https://www.principalcross-platform.io/markets/ubiquitous\",\"request\":\"/expedite/convergence\",\"source_type\":\"stdin\",\"status\":301,\"user-identifier\":\"-\"}")),
-                ])), Value::from(BTreeMap::from([
-                    (String::from("id"), Value::from("35683658089659183914001456229543810359430816722590236673")),
-                    (String::from("timestamp"), Value::from(Utc.timestamp_opt(1_600_110_569, 41_000_000).single().expect("invalid timestamp"))),
-                    (String::from("message"), Value::from("{\"bytes\":17707,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"109.81.244.252\",\"method\":\"GET\",\"protocol\":\"HTTP/2.0\",\"referer\":\"http://www.investormission-critical.io/24/7/vortals\",\"request\":\"/scale/functionalities/optimize\",\"source_type\":\"stdin\",\"status\":502,\"user-identifier\":\"feeney1708\"}")),
-                ]))])),
-                ]))),
+                (String::from("log_events"), Value::from(vec![
+                    Value::from_iter([
+                        (String::from("id"), Value::from( "35683658089614582423604394983260738922885519999578275840")),
+                        (String::from("timestamp"), Value::from(Utc.timestamp_opt(1_600_110_569, 39_000_000).single().expect("invalid timestamp"))),
+                        (String::from("message"), Value::from("{\"bytes\":26780,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"157.130.216.193\",\"method\":\"PUT\",\"protocol\":\"HTTP/1.0\",\"referer\":\"https://www.principalcross-platform.io/markets/ubiquitous\",\"request\":\"/expedite/convergence\",\"source_type\":\"stdin\",\"status\":301,\"user-identifier\":\"-\"}")),
+                    ]),
+                    Value::from_iter([
+                        (String::from("id"), Value::from("35683658089659183914001456229543810359430816722590236673")),
+                        (String::from("timestamp"), Value::from(Utc.timestamp_opt(1_600_110_569, 41_000_000).single().expect("invalid timestamp"))),
+                        (String::from("message"), Value::from("{\"bytes\":17707,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"109.81.244.252\",\"method\":\"GET\",\"protocol\":\"HTTP/2.0\",\"referer\":\"http://www.investormission-critical.io/24/7/vortals\",\"request\":\"/scale/functionalities/optimize\",\"source_type\":\"stdin\",\"status\":502,\"user-identifier\":\"feeney1708\"}")),
+                    ])
+                ])),
+            ])),
             tdef: TypeDef::object(inner_kind()).fallible(),
         }
 

--- a/src/stdlib/parse_cef.rs
+++ b/src/stdlib/parse_cef.rs
@@ -156,7 +156,7 @@ impl FunctionExpression for ParseCefFn {
 
             let mut result = result
                 .filter_map(|(k, v)| {
-                    if let Some(&(i, custom_field)) = self.custom_field_map.get(k.as_str()) {
+                    if let Some(&(i, custom_field)) = self.custom_field_map.get(&k[..]) {
                         let previous =
                             custom_fields.entry(i).or_default()[custom_field as usize].replace(v);
                         if previous.is_some() {
@@ -171,15 +171,15 @@ impl FunctionExpression for ParseCefFn {
                         }
                         None
                     } else {
-                        Some(Ok((k, v.into())))
+                        Some(Ok((k.into(), v.into())))
                     }
                 })
-                .collect::<ExpressionResult<BTreeMap<String, Value>>>()?;
+                .collect::<ExpressionResult<ObjectMap>>()?;
 
             for (_, fields) in custom_fields {
                 match fields {
                     [Some(label), value] => {
-                        result.insert(label, value.into());
+                        result.insert(label.into(), value.into());
                     }
                     _ => return Err("Custom field with missing label or value".into()),
                 }

--- a/src/stdlib/parse_glog.rs
+++ b/src/stdlib/parse_glog.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 fn parse_glog(bytes: Value) -> Resolved {
     let bytes = bytes.try_bytes()?;
     let message = String::from_utf8_lossy(&bytes);
-    let mut log: BTreeMap<String, Value> = BTreeMap::new();
+    let mut log = ObjectMap::new();
     let captures = REGEX_GLOG
         .captures(&message)
         .ok_or("failed parsing glog message")?;

--- a/src/stdlib/parse_grok.rs
+++ b/src/stdlib/parse_grok.rs
@@ -15,7 +15,7 @@ mod non_wasm {
                 let mut result = BTreeMap::new();
 
                 for (name, value) in &matches {
-                    result.insert(name.to_string(), Value::from(value));
+                    result.insert(name.to_string().into(), Value::from(value));
                 }
 
                 Ok(Value::from(result))

--- a/src/stdlib/parse_groks.rs
+++ b/src/stdlib/parse_groks.rs
@@ -168,7 +168,7 @@ impl Function for ParseGroks {
                     })?;
                 Ok((key, alias))
             })
-            .collect::<std::result::Result<BTreeMap<String, String>, function::Error>>()?;
+            .collect::<std::result::Result<BTreeMap<KeyString, String>, function::Error>>()?;
 
         // we use a datadog library here because it is a superset of grok
         let grok_rules = crate::datadog_grok::parse_grok_rules::parse_grok_rules(

--- a/src/stdlib/parse_klog.rs
+++ b/src/stdlib/parse_klog.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 fn parse_klog(bytes: Value) -> Resolved {
     let bytes = bytes.try_bytes()?;
     let message = String::from_utf8_lossy(&bytes);
-    let mut log: BTreeMap<String, Value> = BTreeMap::new();
+    let mut log = ObjectMap::new();
     let captures = REGEX_KLOG
         .captures(&message)
         .ok_or("failed parsing klog message")?;

--- a/src/stdlib/parse_query_string.rs
+++ b/src/stdlib/parse_query_string.rs
@@ -13,7 +13,7 @@ fn parse_query_string(bytes: Value) -> Resolved {
     for (k, value) in parsed {
         let value = value.as_ref();
         result
-            .entry(k.into_owned())
+            .entry(k.into_owned().into())
             .and_modify(|v| {
                 match v {
                     Value::Array(v) => {

--- a/src/stdlib/parse_ruby_hash.rs
+++ b/src/stdlib/parse_ruby_hash.rs
@@ -166,13 +166,13 @@ where
 
 fn parse_colon_key<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, String, E> {
+) -> IResult<&'a str, KeyString, E> {
     map(
         preceded(
             char(':'),
             alt((parse_str('"'), parse_str('\''), parse_symbol_key)),
         ),
-        |res| String::from(":") + res,
+        |res| (String::from(":") + res).into(),
     )(input)
 }
 
@@ -184,11 +184,11 @@ fn parse_colon_key<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 // That being said, handling all the corner cases from Ruby's syntax would imply
 // increasing a lot the code complexity which is probably not necessary considering
 // that Vector is not a Ruby parser.
-fn parse_key<'a, E: HashParseError<&'a str>>(input: &'a str) -> IResult<&'a str, String, E> {
+fn parse_key<'a, E: HashParseError<&'a str>>(input: &'a str) -> IResult<&'a str, KeyString, E> {
     alt((
         map(
             alt((parse_str('"'), parse_str('\''), parse_symbol_key, digit1)),
-            String::from,
+            KeyString::from,
         ),
         parse_colon_key,
     ))(input)
@@ -212,7 +212,7 @@ fn parse_array<'a, E: HashParseError<&'a str>>(input: &'a str) -> IResult<&'a st
 
 fn parse_key_value<'a, E: HashParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, (String, Value), E> {
+) -> IResult<&'a str, (KeyString, Value), E> {
     separated_pair(
         preceded(sp, parse_key),
         cut(preceded(sp, alt((tag(":"), tag("=>"))))),

--- a/src/stdlib/parse_syslog.rs
+++ b/src/stdlib/parse_syslog.rs
@@ -102,35 +102,41 @@ fn resolve_year((month, _date, _hour, _min, _sec): IncompleteDate) -> i32 {
 fn message_to_value(message: Message<&str>) -> Value {
     let mut result = BTreeMap::new();
 
-    result.insert("message".to_string(), message.msg.to_string().into());
+    result.insert("message".to_string().into(), message.msg.to_string().into());
 
     if let Some(host) = message.hostname {
-        result.insert("hostname".to_string(), host.to_string().into());
+        result.insert("hostname".to_string().into(), host.to_string().into());
     }
 
     if let Some(severity) = message.severity {
-        result.insert("severity".to_string(), severity.as_str().to_owned().into());
+        result.insert(
+            "severity".to_string().into(),
+            severity.as_str().to_owned().into(),
+        );
     }
 
     if let Some(facility) = message.facility {
-        result.insert("facility".to_string(), facility.as_str().to_owned().into());
+        result.insert(
+            "facility".to_string().into(),
+            facility.as_str().to_owned().into(),
+        );
     }
 
     if let Protocol::RFC5424(version) = message.protocol {
-        result.insert("version".to_string(), version.into());
+        result.insert("version".to_string().into(), version.into());
     }
 
     if let Some(app_name) = message.appname {
-        result.insert("appname".to_string(), app_name.to_owned().into());
+        result.insert("appname".to_string().into(), app_name.to_owned().into());
     }
 
     if let Some(msg_id) = message.msgid {
-        result.insert("msgid".to_string(), msg_id.to_owned().into());
+        result.insert("msgid".to_string().into(), msg_id.to_owned().into());
     }
 
     if let Some(timestamp) = message.timestamp {
         let timestamp: DateTime<Utc> = timestamp.into();
-        result.insert("timestamp".to_string(), timestamp.into());
+        result.insert("timestamp".to_string().into(), timestamp.into());
     }
 
     if let Some(procid) = message.procid {
@@ -138,15 +144,15 @@ fn message_to_value(message: Message<&str>) -> Value {
             ProcId::PID(pid) => pid.into(),
             ProcId::Name(name) => name.to_string().into(),
         };
-        result.insert("procid".to_string(), value);
+        result.insert("procid".to_string().into(), value);
     }
 
     for element in message.structured_data {
         let mut sdata = BTreeMap::new();
         for (name, value) in element.params() {
-            sdata.insert(name.to_string(), value.into());
+            sdata.insert(name.to_string().into(), value.into());
         }
-        result.insert(element.id.to_string(), sdata.into());
+        result.insert(element.id.to_string().into(), sdata.into());
     }
 
     result.into()

--- a/src/stdlib/parse_url.rs
+++ b/src/stdlib/parse_url.rs
@@ -130,8 +130,8 @@ fn url_to_value(url: Url, default_known_ports: bool) -> Value {
         "query",
         url.query_pairs()
             .into_owned()
-            .map(|(k, v)| (k, v.into()))
-            .collect::<BTreeMap<String, Value>>()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect::<ObjectMap>()
             .into(),
     );
 

--- a/src/stdlib/parse_xml.rs
+++ b/src/stdlib/parse_xml.rs
@@ -280,14 +280,14 @@ fn inner_kind() -> Kind {
 /// Process an XML node, and return a VRL `Value`.
 fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
     // Helper to recurse over a `Node`s children, and build an object.
-    let recurse = |node: Node| -> BTreeMap<String, Value> {
+    let recurse = |node: Node| -> ObjectMap {
         let mut map = BTreeMap::new();
 
         // Expand attributes, if required.
         if config.include_attr {
             for attr in node.attributes() {
                 map.insert(
-                    format!("{}{}", config.attr_prefix, attr.name()),
+                    format!("{}{}", config.attr_prefix, attr.name()).into(),
                     attr.value().into(),
                 );
             }
@@ -295,8 +295,8 @@ fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
 
         for n in node.children().filter(|n| n.is_element() || n.is_text()) {
             let name = match n.node_type() {
-                NodeType::Element => n.tag_name().name().to_string(),
-                NodeType::Text => config.text_key.to_string(),
+                NodeType::Element => n.tag_name().name().to_string().into(),
+                NodeType::Text => config.text_key.to_string().into(),
                 _ => unreachable!("shouldn't be other XML nodes"),
             };
 
@@ -352,7 +352,7 @@ fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
                             let mut map = BTreeMap::new();
 
                             map.insert(
-                                node.tag_name().name().to_string(),
+                                node.tag_name().name().to_string().into(),
                                 Value::Object(recurse(node)),
                             );
 

--- a/src/stdlib/remove.rs
+++ b/src/stdlib/remove.rs
@@ -9,7 +9,7 @@ fn remove(path: Value, compact: Value, mut value: Value) -> Resolved {
             for segment in path {
                 let segment = match segment {
                     Value::Bytes(field) => {
-                        OwnedSegment::Field(String::from_utf8_lossy(&field).into_owned())
+                        OwnedSegment::Field(String::from_utf8_lossy(&field).into())
                     }
                     Value::Integer(index) => OwnedSegment::Index(index as isize),
                     value => {

--- a/src/stdlib/set.rs
+++ b/src/stdlib/set.rs
@@ -9,7 +9,7 @@ fn set(path: Value, mut value: Value, data: Value) -> Resolved {
             for segment in segments {
                 let segment = match segment {
                     Value::Bytes(path) => {
-                        OwnedSegment::Field(String::from_utf8_lossy(&path).into_owned())
+                        OwnedSegment::Field(String::from_utf8_lossy(&path).into())
                     }
                     Value::Integer(index) => OwnedSegment::Index(index as isize),
                     value => {

--- a/src/stdlib/tag_types_externally.rs
+++ b/src/stdlib/tag_types_externally.rs
@@ -96,7 +96,7 @@ fn tag_type_externally(value: Value) -> Value {
             object
                 .into_iter()
                 .map(|(key, value)| (key, tag_type_externally(value)))
-                .collect::<BTreeMap<String, Value>>()
+                .collect::<ObjectMap>()
                 .into(),
         ),
         Value::Array(array) => (
@@ -113,7 +113,7 @@ fn tag_type_externally(value: Value) -> Value {
     };
 
     if let Some(key) = key {
-        BTreeMap::from([(key.to_owned(), value)]).into()
+        BTreeMap::from([(key.to_owned().into(), value)]).into()
     } else {
         value
     }

--- a/src/stdlib/tally.rs
+++ b/src/stdlib/tally.rs
@@ -14,7 +14,12 @@ fn tally(value: Value) -> Resolved {
     }
     let map: BTreeMap<_, _> = map
         .into_iter()
-        .map(|(k, v)| (String::from_utf8_lossy(&k).into_owned(), Value::from(v)))
+        .map(|(k, v)| {
+            (
+                String::from_utf8_lossy(&k).into_owned().into(),
+                Value::from(v),
+            )
+        })
         .collect();
     Ok(map.into())
 }

--- a/src/stdlib/type_def.rs
+++ b/src/stdlib/type_def.rs
@@ -4,7 +4,7 @@ fn type_def(type_def: &VrlTypeDef) -> Value {
     let mut tree = type_def.kind().canonicalize().debug_info();
 
     if type_def.is_fallible() {
-        tree.insert("fallible".to_owned(), true.into());
+        tree.insert("fallible".to_owned().into(), true.into());
     }
 
     tree.into()

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -1,3 +1,5 @@
+use crate::value::{KeyString, ObjectMap};
+
 /// Rounds the given number to the given precision.
 /// Takes a function parameter so the exact rounding function (ceil, floor or round)
 /// can be specified.
@@ -21,10 +23,10 @@ pub(crate) fn capture_regex_to_map(
     regex: &regex::Regex,
     capture: &regex::Captures,
     numeric_groups: bool,
-) -> std::collections::BTreeMap<String, crate::value::Value> {
+) -> ObjectMap {
     let names = regex.capture_names().flatten().map(|name| {
         (
-            name.to_owned(),
+            name.to_owned().into(),
             capture.name(name).map(|s| s.as_str()).into(),
         )
     });
@@ -34,7 +36,7 @@ pub(crate) fn capture_regex_to_map(
             .iter()
             .flatten()
             .enumerate()
-            .map(|(idx, c)| (idx.to_string(), c.as_str().into()));
+            .map(|(idx, c)| (KeyString::from(idx.to_string()), c.as_str().into()));
 
         indexed.chain(names).collect()
     } else {

--- a/src/value/keystring.rs
+++ b/src/value/keystring.rs
@@ -1,0 +1,126 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// The key type value.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct KeyString(String);
+
+impl KeyString {
+    /// Convert the key into a boxed slice of bytes (`u8`).
+    #[inline]
+    #[must_use]
+    pub fn into_bytes(self) -> Box<[u8]> {
+        self.0.into_bytes().into()
+    }
+
+    /// Is this string empty?
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Get the length of the contained key.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return a reference to the contained string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for KeyString {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl AsRef<str> for KeyString {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for KeyString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<str> for KeyString {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for KeyString {
+    fn eq(&self, that: &str) -> bool {
+        self.0[..].eq(that)
+    }
+}
+
+impl From<&str> for KeyString {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<String> for KeyString {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<Cow<'_, str>> for KeyString {
+    fn from(s: Cow<'_, str>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<KeyString> for String {
+    fn from(s: KeyString) -> Self {
+        s.0
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl quickcheck::Arbitrary for KeyString {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        String::arbitrary(g).into()
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let s = self.0.to_string();
+        Box::new(s.shrink().map(Into::into))
+    }
+}
+
+#[cfg(any(test, feature = "lua"))]
+mod lua {
+    use mlua::prelude::LuaResult;
+    use mlua::{FromLua, IntoLua, Lua, Value as LuaValue};
+
+    use super::*;
+
+    impl<'a> FromLua<'a> for KeyString {
+        fn from_lua(value: LuaValue<'a>, lua: &'a Lua) -> LuaResult<Self> {
+            String::from_lua(value, lua).map(Self::from)
+        }
+    }
+
+    impl<'a> IntoLua<'a> for KeyString {
+        fn into_lua(self, lua: &'a Lua) -> LuaResult<LuaValue<'_>> {
+            self.0.into_lua(lua)
+        }
+    }
+}

--- a/src/value/keystring.rs
+++ b/src/value/keystring.rs
@@ -3,7 +3,8 @@ use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-/// The key type value.
+/// The key type value. This is a simple zero-overhead wrapper set up to make it explicit that
+/// object keys are read-only and their underlying type is opaque and may change for efficiency.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct KeyString(String);

--- a/src/value/kind/collection.rs
+++ b/src/value/kind/collection.rs
@@ -396,7 +396,7 @@ mod tests {
 
     impl CollectionKey for &'static str {
         fn to_segment(&self) -> OwnedSegment {
-            OwnedSegment::Field((*self).to_string())
+            OwnedSegment::Field((*self).into())
         }
     }
 

--- a/src/value/kind/collection/field.rs
+++ b/src/value/kind/collection/field.rs
@@ -15,7 +15,7 @@ impl std::fmt::Display for Field {
 
 impl CollectionKey for Field {
     fn to_segment(&self) -> OwnedSegment {
-        OwnedSegment::Field(self.0.clone().into())
+        OwnedSegment::Field(self.0.clone())
     }
 }
 

--- a/src/value/kind/collection/field.rs
+++ b/src/value/kind/collection/field.rs
@@ -1,10 +1,11 @@
 use crate::path::OwnedSegment;
 use crate::value::kind::collection::{CollectionKey, CollectionRemove};
 use crate::value::kind::Collection;
+use crate::value::KeyString;
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct Field(String);
+pub struct Field(KeyString);
 
 impl std::fmt::Display for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -14,7 +15,7 @@ impl std::fmt::Display for Field {
 
 impl CollectionKey for Field {
     fn to_segment(&self) -> OwnedSegment {
-        OwnedSegment::Field(self.0.clone())
+        OwnedSegment::Field(self.0.clone().into())
     }
 }
 
@@ -22,7 +23,7 @@ impl Field {
     /// Get a `str` representation of the field.
     #[must_use]
     pub fn as_str(&self) -> &str {
-        self.0.as_str()
+        &self.0
     }
 }
 
@@ -35,9 +36,9 @@ impl CollectionRemove for Collection<Field> {
 }
 
 impl std::ops::Deref for Field {
-    type Target = String;
+    type Target = KeyString;
 
-    fn deref(&self) -> &String {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
@@ -50,6 +51,12 @@ impl From<&str> for Field {
 
 impl From<String> for Field {
     fn from(field: String) -> Self {
+        Self(field.into())
+    }
+}
+
+impl From<KeyString> for Field {
+    fn from(field: KeyString) -> Self {
         Self(field)
     }
 }

--- a/src/value/kind/crud/remove.rs
+++ b/src/value/kind/crud/remove.rs
@@ -125,7 +125,7 @@ impl Kind {
 
                         for field in fields {
                             let field_kind =
-                                original.at_path([OwnedSegment::Field(field.to_string())].as_ref());
+                                original.at_path([OwnedSegment::Field(field.clone())].as_ref());
 
                             if field_kind.contains_any_defined() {
                                 let mut child_kind = original.clone();

--- a/src/value/kind/debug.rs
+++ b/src/value/kind/debug.rs
@@ -1,18 +1,17 @@
-use super::{Kind, Value};
-use std::collections::BTreeMap;
+use super::{super::ObjectMap, Kind, Value};
 
 impl Kind {
     /// Returns a tree representation of `Kind`, in a more human readable format.
     /// This is for debugging / development purposes only.
     #[must_use]
-    pub fn debug_info(&self) -> BTreeMap<String, Value> {
-        let mut output = BTreeMap::new();
+    pub fn debug_info(&self) -> ObjectMap {
+        let mut output = ObjectMap::new();
         insert_kind(&mut output, self, true);
         output
     }
 }
 
-fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bool) {
+fn insert_kind(tree: &mut ObjectMap, kind: &Kind, show_unknown: bool) {
     if kind.is_never() {
         insert_if_true(tree, "never", true);
     } else if kind.is_any() {
@@ -30,13 +29,13 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
         insert_if_true(tree, "undefined", kind.contains_undefined());
 
         if let Some(fields) = &kind.object {
-            let mut object_tree = BTreeMap::new();
+            let mut object_tree = ObjectMap::new();
             for (field, field_kind) in fields.known() {
-                let mut field_tree = BTreeMap::new();
+                let mut field_tree = ObjectMap::new();
                 insert_kind(&mut field_tree, field_kind, show_unknown);
-                object_tree.insert(field.to_string(), Value::Object(field_tree));
+                object_tree.insert(field.to_string().into(), Value::Object(field_tree));
             }
-            tree.insert("object".to_owned(), Value::Object(object_tree));
+            tree.insert("object".into(), Value::Object(object_tree));
             if show_unknown {
                 insert_unknown(
                     tree,
@@ -48,13 +47,13 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
         }
 
         if let Some(indices) = &kind.array {
-            let mut array_tree = BTreeMap::new();
+            let mut array_tree = ObjectMap::new();
             for (index, index_kind) in indices.known() {
-                let mut index_tree = BTreeMap::new();
+                let mut index_tree = ObjectMap::new();
                 insert_kind(&mut index_tree, index_kind, show_unknown);
-                array_tree.insert(index.to_string(), Value::Object(index_tree));
+                array_tree.insert(index.to_string().into(), Value::Object(index_tree));
             }
-            tree.insert("array".to_owned(), Value::Object(array_tree));
+            tree.insert("array".to_owned().into(), Value::Object(array_tree));
             if show_unknown {
                 insert_unknown(
                     tree,
@@ -69,32 +68,27 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
 
 // Clippy complains with "needless_borrow" if you try to fix this.
 #[allow(clippy::needless_pass_by_value)]
-fn insert_unknown(
-    tree: &mut BTreeMap<String, Value>,
-    unknown: Kind,
-    unknown_exact: bool,
-    prefix: &str,
-) {
+fn insert_unknown(tree: &mut ObjectMap, unknown: Kind, unknown_exact: bool, prefix: &str) {
     if unknown.is_undefined() {
         return;
     }
-    let mut unknown_tree = BTreeMap::new();
+    let mut unknown_tree = ObjectMap::new();
     insert_kind(&mut unknown_tree, &unknown, unknown_exact);
     if unknown.is_exact() {
         tree.insert(
-            format!("{prefix}_unknown_exact"),
+            format!("{prefix}_unknown_exact").into(),
             Value::Object(unknown_tree),
         );
     } else {
         tree.insert(
-            format!("{prefix}_unknown_infinite"),
+            format!("{prefix}_unknown_infinite").into(),
             Value::Object(unknown_tree),
         );
     }
 }
 
-fn insert_if_true(tree: &mut BTreeMap<String, Value>, key: &str, value: bool) {
+fn insert_if_true(tree: &mut ObjectMap, key: &str, value: bool) {
     if value {
-        tree.insert(key.to_owned(), Value::Boolean(true));
+        tree.insert(key.to_owned().into(), Value::Boolean(true));
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -40,11 +40,13 @@ pub mod secrets;
 pub mod value;
 
 mod btreemap;
+mod keystring;
 
 pub use kind::Kind;
 
+pub use self::keystring::KeyString;
 pub use self::secrets::Secrets;
-pub use self::value::{Value, ValueRegex};
+pub use self::value::{ObjectMap, Value, ValueRegex};
 
 /// A macro to easily generate Values
 #[macro_export]
@@ -63,7 +65,7 @@ macro_rules! value {
     });
 
     ({$($($k1:literal)? $($k2:ident)?: $v:tt),+ $(,)?}) => ({
-        let map = vec![$((String::from($($k1)? $(stringify!($k2))?), $crate::value!($v))),+]
+        let map = vec![$((String::from($($k1)? $(stringify!($k2))?).into(), $crate::value!($v))),+]
             .into_iter()
             .collect::<::std::collections::BTreeMap<_, $crate::value::Value>>();
 

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -8,9 +8,9 @@ use ordered_float::NotNan;
 
 pub use iter::{IterItem, ValueIter};
 
-use crate::path::ValuePath;
-
 pub use super::value::regex::ValueRegex;
+use super::KeyString;
+use crate::path::ValuePath;
 
 mod convert;
 mod crud;
@@ -27,6 +27,9 @@ mod serde;
 
 /// A boxed `std::error::Error`.
 pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// The storage mapping for the `Object` variant.
+pub type ObjectMap = BTreeMap<KeyString, Value>;
 
 /// The main value type used in Vector events, and VRL.
 #[derive(Eq, PartialEq, Hash, Debug, Clone)]
@@ -52,7 +55,7 @@ pub enum Value {
     Timestamp(DateTime<Utc>),
 
     /// Object.
-    Object(BTreeMap<String, Value>),
+    Object(ObjectMap),
 
     /// Array.
     Array(Vec<Value>),

--- a/src/value/value/arbitrary.rs
+++ b/src/value/value/arbitrary.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use bytes::Bytes;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use ordered_float::NotNan;
@@ -45,7 +43,13 @@ impl Arbitrary for Value {
             4 => Self::Timestamp(datetime(g)),
             5 => {
                 let mut gen = Gen::new(MAX_MAP_SIZE);
-                Self::Object(BTreeMap::arbitrary(&mut gen))
+                Self::Object(
+                    // `Arbitrary` is not directly implemented for `KeyString` so have to convert.
+                    Vec::<(String, Self)>::arbitrary(&mut gen)
+                        .into_iter()
+                        .map(|(k, v)| (k.into(), v))
+                        .collect(),
+                )
             }
             6 => {
                 let mut gen = Gen::new(MAX_ARRAY_SIZE);

--- a/src/value/value/crud/insert.rs
+++ b/src/value/value/crud/insert.rs
@@ -13,10 +13,11 @@ pub fn insert<'a, T: ValueCollection>(
     match path_iter.next() {
         Some(BorrowedSegment::Field(field)) => {
             if let Some(Value::Object(map)) = value.get_mut_value(key.borrow()) {
-                insert(map, field.to_string(), path_iter, insert_value)
+                insert(map, field.to_string().into(), path_iter, insert_value)
             } else {
                 let mut map = BTreeMap::new();
-                let prev_value = insert(&mut map, field.to_string(), path_iter, insert_value);
+                let prev_value =
+                    insert(&mut map, field.to_string().into(), path_iter, insert_value);
                 value.insert_value(key, Value::Object(map));
                 prev_value
             }
@@ -40,14 +41,14 @@ pub fn insert<'a, T: ValueCollection>(
             if let Some(Value::Object(map)) = value.get_mut_value(key.borrow()) {
                 let (Ok(matched_key) | Err(matched_key)) =
                     get_matching_coalesce_key(field, map, &mut path_iter);
-                insert(map, matched_key.to_string(), path_iter, insert_value)
+                insert(map, matched_key.to_string().into(), path_iter, insert_value)
             } else {
                 let mut map = BTreeMap::new();
                 // The map is empty, so only the last segment will be used.
                 let last_coalesce_key = skip_remaining_coalesce_segments(&mut path_iter);
                 let prev_value = insert(
                     &mut map,
-                    last_coalesce_key.to_string(),
+                    last_coalesce_key.to_string().into(),
                     path_iter,
                     insert_value,
                 );

--- a/src/value/value/crud/mod.rs
+++ b/src/value/value/crud/mod.rs
@@ -1,7 +1,6 @@
 use crate::path::BorrowedSegment;
-use crate::value::Value;
+use crate::value::{KeyString, ObjectMap, Value};
 use std::borrow::{Borrow, Cow};
-use std::collections::BTreeMap;
 
 mod get;
 mod get_mut;
@@ -55,8 +54,8 @@ impl ValueCollection for Value {
     }
 }
 
-impl ValueCollection for BTreeMap<String, Value> {
-    type Key = String;
+impl ValueCollection for ObjectMap {
+    type Key = KeyString;
     type BorrowedKey = str;
 
     fn get_value(&self, key: &str) -> Option<&Value> {
@@ -67,7 +66,7 @@ impl ValueCollection for BTreeMap<String, Value> {
         self.get_mut(key)
     }
 
-    fn insert_value(&mut self, key: String, value: Value) -> Option<Value> {
+    fn insert_value(&mut self, key: KeyString, value: Value) -> Option<Value> {
         self.insert(key, value)
     }
 
@@ -164,7 +163,7 @@ pub fn skip_remaining_coalesce_segments<'a>(
 /// If none matches, returns Err with the last key.
 pub fn get_matching_coalesce_key<'a>(
     initial_key: Cow<'a, str>,
-    map: &BTreeMap<String, Value>,
+    map: &ObjectMap,
     path_iter: &mut impl Iterator<Item = BorrowedSegment<'a>>,
 ) -> Result<Cow<'a, str>, Cow<'a, str>> {
     let mut key = initial_key;
@@ -203,7 +202,7 @@ mod test {
 
     #[test]
     fn single_field() {
-        let mut value = Value::from(BTreeMap::default());
+        let mut value = Value::from(ObjectMap::default());
         let key = "root";
         let mut marker = Value::from(true);
         assert_eq!(value.insert(key, marker.clone()), None);
@@ -215,7 +214,7 @@ mod test {
 
     #[test]
     fn nested_field() {
-        let mut value = Value::from(BTreeMap::default());
+        let mut value = Value::from(ObjectMap::default());
         let key = "root.doot";
         let mut marker = Value::from(true);
         assert_eq!(value.insert(key, marker.clone()), None);
@@ -230,7 +229,7 @@ mod test {
 
     #[test]
     fn double_nested_field() {
-        let mut value = Value::from(BTreeMap::default());
+        let mut value = Value::from(ObjectMap::default());
         let key = "root.doot.toot";
         let mut marker = Value::from(true);
         assert_eq!(value.insert(key, marker.clone()), None);
@@ -271,7 +270,7 @@ mod test {
 
     #[test]
     fn field_index() {
-        let mut value = Value::from(BTreeMap::default());
+        let mut value = Value::from(ObjectMap::default());
         let key = "root[0]";
         let mut marker = Value::from(true);
         assert_eq!(value.insert(key, marker.clone()), None);
@@ -318,7 +317,7 @@ mod test {
 
     #[test]
     fn field_with_nested_index_field() {
-        let mut value = Value::from(BTreeMap::default());
+        let mut value = Value::from(ObjectMap::default());
         let key = "root[0][0].boot";
         let mut marker = Value::from(true);
         assert_eq!(value.insert(key, marker.clone()), None);
@@ -335,7 +334,7 @@ mod test {
 
     #[test]
     fn populated_field() {
-        let mut value = Value::from(BTreeMap::default());
+        let mut value = Value::from(ObjectMap::default());
         let marker = Value::from(true);
         assert_eq!(value.insert("a[2]", marker.clone()), None);
 

--- a/src/value/value/serde.rs
+++ b/src/value/value/serde.rs
@@ -188,7 +188,7 @@ impl From<serde_json::Value> for Value {
             serde_json::Value::String(s) => Self::Bytes(Bytes::from(s)),
             serde_json::Value::Object(obj) => Self::Object(
                 obj.into_iter()
-                    .map(|(key, value)| (key, Self::from(value)))
+                    .map(|(key, value)| (key.into(), Self::from(value)))
                     .collect(),
             ),
             serde_json::Value::Array(arr) => Self::Array(arr.into_iter().map(Self::from).collect()),


### PR DESCRIPTION
This change adds a newtype struct for the object key type called `KeyString` and a convenience type alias for the object mapping type called `ObjectMap`. This lays the groundwork for future changes to the key data model.