### PR TITLE
feat(parse_regex_all): allow variables for the 'pattern' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+* `parse_regex_all` `pattern` param  can now be resolved from a variable
 
 ## `0.8.0` (2023-10-31)
 
@@ -11,6 +12,7 @@
 - added `parse_float` function (https://github.com/vectordotdev/vrl/pull/484)
 - improved fallibility diagnostics (https://github.com/vectordotdev/vrl/pull/523)
 - added `encode_snappy` and `decode_snappy` functions (https://github.com/vectordotdev/vrl/pull/543)
+
 ## `0.7.0` (2023-09-25)
 
 #### Bug Fixes

--- a/lib/tests/tests/functions/parse_regex_all.vrl
+++ b/lib/tests/tests/functions/parse_regex_all.vrl
@@ -2,12 +2,11 @@
 # result: [[{ "0": "pattern1" }], [{ "0": "pattern2" }]]
 
 regex_list = [ r'pattern1', r'pattern2' ]
-
-result = {}
-for_each(regex_list) -> |i, pattern| {
+result = []
+for_each(regex_list) -> |_, pattern| {
     parse_result = parse_regex_all!(to_string!(.http_status), pattern, numeric_groups: true)
     if length(parse_result) > 0 {
-        result = set!(result, [i], parse_result)
+        result = push(result, parse_result)
     }
 }
 . = result

--- a/lib/tests/tests/functions/parse_regex_all.vrl
+++ b/lib/tests/tests/functions/parse_regex_all.vrl
@@ -1,0 +1,13 @@
+# object: {"message": "foo", "http_status" :  "pattern1 pattern2"}
+# result: [[{ "0": "pattern1" }], [{ "0": "pattern2" }]]
+
+regex_list = [ r'pattern1', r'pattern2' ]
+
+result = {}
+for_each(regex_list) -> |i, pattern| {
+    parse_result = parse_regex_all!(to_string!(.http_status), pattern, numeric_groups: true)
+    if length(parse_result) > 0 {
+        result = set!(result, [i], parse_result)
+    }
+}
+. = result

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -1,5 +1,6 @@
-use crate::compiler::prelude::*;
 use regex::Regex;
+
+use crate::compiler::prelude::*;
 
 use super::util;
 
@@ -30,7 +31,7 @@ impl Function for ParseRegexAll {
             },
             Parameter {
                 keyword: "pattern",
-                kind: kind::ANY,
+                kind: kind::REGEX,
                 required: true,
             },
             Parameter {
@@ -43,12 +44,12 @@ impl Function for ParseRegexAll {
 
     fn compile(
         &self,
-        state: &state::TypeState,
+        _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required_regex("pattern", state)?;
+        let pattern = arguments.required("pattern");
         let numeric_groups = arguments
             .optional("numeric_groups")
             .unwrap_or_else(|| expr!(false));
@@ -105,7 +106,7 @@ impl Function for ParseRegexAll {
 #[derive(Debug, Clone)]
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
-    pattern: Regex,
+    pattern: Box<dyn Expression>,
     numeric_groups: Box<dyn Expression>,
 }
 
@@ -113,14 +114,19 @@ impl FunctionExpression for ParseRegexAllFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let numeric_groups = self.numeric_groups.resolve(ctx)?;
-        let pattern = &self.pattern;
+        let pattern = self
+            .pattern
+            .resolve(ctx)?
+            .as_regex()
+            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
+            .clone();
 
-        parse_regex_all(value, numeric_groups.try_boolean()?, pattern)
+        parse_regex_all(value, numeric_groups.try_boolean()?, &pattern)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
         TypeDef::array(Collection::from_unknown(
-            Kind::object(util::regex_kind(&self.pattern)).or_null(),
+            Kind::object(Collection::any()).or_null(),
         ))
         .fallible()
     }
@@ -129,8 +135,9 @@ impl FunctionExpression for ParseRegexAllFn {
 #[cfg(test)]
 #[allow(clippy::trivial_regex)]
 mod tests {
-    use super::*;
     use crate::{btreemap, value};
+
+    use super::*;
 
     test_function![
         parse_regex_all => ParseRegexAll;

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -124,9 +124,18 @@ impl FunctionExpression for ParseRegexAllFn {
         parse_regex_all(value, numeric_groups.try_boolean()?, &pattern)
     }
 
-    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        if let Some(value) = self.pattern.resolve_constant(state) {
+            if let Some(regex) = value.as_regex() {
+                return TypeDef::array(Collection::from_unknown(
+                    Kind::object(util::regex_kind(regex)).or_null(),
+                ))
+                .fallible();
+            }
+        }
+
         TypeDef::array(Collection::from_unknown(
-            Kind::object(Collection::any()).or_null(),
+            Kind::object(Collection::from_unknown(Kind::bytes() | Kind::null())).or_null(),
         ))
         .fallible()
     }


### PR DESCRIPTION
closes: #562 

Tested with 
```
regex_list = [ r'pattern1', r'pattern2' ]

result = {}
for_each(regex_list) -> |i, pattern| {
    parse_result = parse_regex_all!(to_string!(.http_status), pattern, numeric_groups: true)
    if length(parse_result) > 0 {
        result = set!(result, [i], parse_result)
    }
}
. = result
```

Result
```
[[{ "0": "pattern1" }], [{ "0": "pattern2" }]]
```