### PR TITLE
fix(runtime): Re-add wasm features for chrono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+#### Bug Fixes
+* Support WASM features using `chrono` was readded. This was accidentally dropped in 0.9.0.
+
 ## `0.9.0` (2023-12-12)
 * `parse_regex_all` `pattern` param  can now be resolved from a variable
 * fixed `parse_json` data corruption issue for numbers greater or equal to `i64::MAX` 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,8 +411,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ base16 = { version = "0.2", optional = true }
 base64 = { version = "0.21", optional = true }
 bytes = { version = "1.5.0", default-features = false, optional = true }
 charset = { version = "0.1.3", optional = true }
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde"], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"], optional = true }
 chrono-tz = { version = "0.8.4", default-features = false, optional = true }
 cidr-utils = { version = "0.6", optional = true }
 csv = { version = "1.3", optional = true }


### PR DESCRIPTION
The lack of this broke the VRL playground:
https://github.com/vectordotdev/vector/issues/19442

Regression introduced by
https://github.com/vectordotdev/vrl/pull/556