### PR TITLE
chore(ci): Run changelog check on merge queues

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -5,18 +5,23 @@
 #   - opened/re-opened
 #   - new commits pushed
 #   - label is added or removed
+# Runs on merge queues, but just passes, because it is a required check.
 
 name: Changelog
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  # Due to merge queue requiring same status checks as PRs, must pass by default
+  merge_group:
+    types: [checks_requested]
 
 jobs:
-  check-changelog:
+  validate-changelog:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     env:
       PR_HAS_LABEL: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') }}
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -30,3 +35,20 @@ jobs:
           git fetch origin main:refs/remotes/origin/main
 
           ./scripts/check_changelog_fragments.sh
+
+  check-changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    needs: validate-changelog
+    if: always()
+    env:
+      FAILED: ${{ contains(needs.*.result, 'failure') }}
+    steps:
+      - name: exit
+        run: |
+          echo "failed=${{ env.FAILED }}"
+          if [[ "$FAILED" == "true" ]] ; then
+            exit 1
+          else
+            exit 0
+          fi


### PR DESCRIPTION
Since we want it to be a required check it needs to pass on merge queues.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
