### PR TITLE
Run proptests on paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,8 @@ mlua = { version = "0.9.5", default-features = false, features = ["lua54", "send
 quickcheck = { version = "1.0.3"}
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode"] }
 paste = { version = "1", default-features = false }
+proptest = { version = "1.4" }
+proptest-derive = { version = "0.4" }
 
 [build-dependencies]
 lalrpop = { version = "0.20", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -97,6 +97,7 @@ keccak,https://github.com/RustCrypto/sponges/tree/master/keccak,Apache-2.0 OR MI
 lalrpop-util,https://github.com/lalrpop/lalrpop,Apache-2.0 OR MIT,Niko Matsakis <niko@alum.mit.edu>
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libm,https://github.com/rust-lang/libm,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 linked-hash-map,https://github.com/contain-rs/linked-hash-map,MIT OR Apache-2.0,"Stepan Koltsov <stepan.koltsov@gmail.com>, Andrew Paseltiner <apaseltiner@gmail.com>"
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -311,7 +311,7 @@ fn get_target_prefix(path: &str) -> (PathPrefix, &str) {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
+#[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
 pub enum PathPrefix {
     Event,
     Metadata,

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -1,7 +1,9 @@
+use std::fmt::{Debug, Display, Formatter};
+use std::str::FromStr;
+
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Display, Formatter};
 
 use super::PathPrefix;
 use super::{parse_target_path, parse_value_path, BorrowedSegment, PathParseError, ValuePath};
@@ -209,11 +211,29 @@ impl Display for OwnedValuePath {
     }
 }
 
+impl FromStr for OwnedValuePath {
+    type Err = PathParseError;
+
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        parse_value_path(src).map_err(|_| PathParseError::InvalidPathSyntax {
+            path: src.to_owned(),
+        })
+    }
+}
+
 impl TryFrom<String> for OwnedValuePath {
     type Error = PathParseError;
 
     fn try_from(src: String) -> Result<Self, Self::Error> {
-        parse_value_path(&src).map_err(|_| PathParseError::InvalidPathSyntax {
+        src.parse()
+    }
+}
+
+impl FromStr for OwnedTargetPath {
+    type Err = PathParseError;
+
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        parse_target_path(src).map_err(|_| PathParseError::InvalidPathSyntax {
             path: src.to_owned(),
         })
     }
@@ -223,9 +243,7 @@ impl TryFrom<String> for OwnedTargetPath {
     type Error = PathParseError;
 
     fn try_from(src: String) -> Result<Self, Self::Error> {
-        parse_target_path(&src).map_err(|_| PathParseError::InvalidPathSyntax {
-            path: src.to_owned(),
-        })
+        src.parse()
     }
 }
 
@@ -233,7 +251,7 @@ impl TryFrom<KeyString> for OwnedValuePath {
     type Error = PathParseError;
 
     fn try_from(src: KeyString) -> Result<Self, Self::Error> {
-        parse_value_path(&src).map_err(|_| PathParseError::InvalidPathSyntax { path: src.into() })
+        src.parse()
     }
 }
 
@@ -241,7 +259,7 @@ impl TryFrom<KeyString> for OwnedTargetPath {
     type Error = PathParseError;
 
     fn try_from(src: KeyString) -> Result<Self, Self::Error> {
-        parse_target_path(&src).map_err(|_| PathParseError::InvalidPathSyntax { path: src.into() })
+        src.parse()
     }
 }
 

--- a/src/value/keystring.rs
+++ b/src/value/keystring.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// The key type value. This is a simple zero-overhead wrapper set up to make it explicit that
 /// object keys are read-only and their underlying type is opaque and may change for efficiency.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
+#[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
 #[serde(transparent)]
 pub struct KeyString(String);
 


### PR DESCRIPTION
Add property tests to ensure that arbitrary path values can be exported to strings and then re-parsed from that string to produce an equal path. This required some tweaks to the automatically generated `Arbitrary` implementations, and I added implementations of `FromStr` along the way to simplify parsing.