### PR TITLE
Optimize path export functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ hmac = { version = "0.12.1", optional = true }
 iana-time-zone = "0.1.59"
 indexmap = { version = "~2.2.2", default-features = false, features = ["std"], optional = true}
 indoc = {version = "2.0.4", optional = true }
-itertools = { version = "0.12.1", default-features = false, optional = true }
+itertools = { version = "0.12.1", default-features = false, features = ["use_alloc"], optional = true }
 lalrpop-util = { version = "0.20", optional = true }
 mlua = { version = "0.9.5", default-features = false, features = ["lua54", "send", "vendored"], optional = true}
 nom = { version = "7.1.3", default-features = false, features = ["std"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ hmac = { version = "0.12.1", optional = true }
 iana-time-zone = "0.1.59"
 indexmap = { version = "~2.2.2", default-features = false, features = ["std"], optional = true}
 indoc = {version = "2.0.4", optional = true }
-itertools = { version = "0.12.1", default-features = false, features = ["use_alloc"], optional = true }
+itertools = { version = "0.12.1", default-features = false, optional = true }
 lalrpop-util = { version = "0.20", optional = true }
 mlua = { version = "0.9.5", default-features = false, features = ["lua54", "send", "vendored"], optional = true}
 nom = { version = "7.1.3", default-features = false, features = ["std"], optional = true }

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -201,7 +201,7 @@ impl OwnedTargetPath {
 
 impl Display for OwnedTargetPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", String::from(self.to_owned()))
+        write!(f, "{}", String::from(self))
     }
 }
 
@@ -213,6 +213,12 @@ impl Debug for OwnedTargetPath {
 
 impl From<OwnedTargetPath> for String {
     fn from(target_path: OwnedTargetPath) -> Self {
+        Self::from(&target_path)
+    }
+}
+
+impl From<&OwnedTargetPath> for String {
+    fn from(target_path: &OwnedTargetPath) -> Self {
         match target_path.prefix {
             PathPrefix::Event => format!(".{}", target_path.path),
             PathPrefix::Metadata => format!("%{}", target_path.path),
@@ -222,7 +228,7 @@ impl From<OwnedTargetPath> for String {
 
 impl Display for OwnedValuePath {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", String::from(self.clone()))
+        write!(f, "{}", String::from(self))
     }
 }
 
@@ -280,6 +286,12 @@ impl TryFrom<KeyString> for OwnedTargetPath {
 
 impl From<OwnedValuePath> for String {
     fn from(owned: OwnedValuePath) -> Self {
+        Self::from(&owned)
+    }
+}
+
+impl From<&OwnedValuePath> for String {
+    fn from(owned: &OwnedValuePath) -> Self {
         let mut output = String::new();
         for (i, segment) in owned.segments.iter().enumerate() {
             match segment {

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter, Write};
 use std::str::FromStr;
 
@@ -491,15 +492,15 @@ impl<'a> ValuePath<'a> for &'a OwnedValuePath {
 static VALID_FIELD: Lazy<Regex> =
     Lazy::new(|| Regex::new("^[0-9]*[a-zA-Z_@][0-9a-zA-Z_@]*$").unwrap());
 
-fn field_to_string(field: &str) -> String {
+fn field_to_string(field: &str) -> Cow<'_, str> {
     // This can eventually just parse the field and see if it's valid, but the
     // parser is currently lenient in what it accepts so it doesn't catch all cases that
     // should be quoted
     let needs_quotes = !VALID_FIELD.is_match(field);
     if needs_quotes {
-        format!("\"{}\"", field)
+        format!("\"{field}\"").into()
     } else {
-        field.to_string()
+        field.into()
     }
 }
 

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -509,7 +509,10 @@ impl Display for OwnedSegment {
             OwnedSegment::Field(field) => format_field(f, field),
             OwnedSegment::Coalesce(v) => {
                 write!(f, "(")?;
-                for field in v {
+                for (i, field) in v.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
                     format_field(f, field)?;
                 }
                 write!(f, ")")

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
+use itertools::Itertools as _;
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "proptest"))]
 use proptest::prelude::*;
@@ -311,7 +312,6 @@ impl From<OwnedValuePath> for String {
                     output
                 }
             })
-            .collect::<Vec<_>>()
             .join("")
     }
 }
@@ -500,10 +500,7 @@ impl Display for OwnedSegment {
             OwnedSegment::Coalesce(v) => write!(
                 f,
                 "({})",
-                v.iter()
-                    .map(|field| field_to_string(field))
-                    .collect::<Vec<_>>()
-                    .join(" | ")
+                v.iter().map(|field| field_to_string(field)).join(" | ")
             ),
         }
     }

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -201,7 +201,11 @@ impl OwnedTargetPath {
 
 impl Display for OwnedTargetPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", String::from(self))
+        match self.prefix {
+            PathPrefix::Event => write!(f, ".")?,
+            PathPrefix::Metadata => write!(f, "%")?,
+        }
+        Display::fmt(&self.path, f)
     }
 }
 
@@ -219,10 +223,7 @@ impl From<OwnedTargetPath> for String {
 
 impl From<&OwnedTargetPath> for String {
     fn from(target_path: &OwnedTargetPath) -> Self {
-        match target_path.prefix {
-            PathPrefix::Event => format!(".{}", target_path.path),
-            PathPrefix::Metadata => format!("%{}", target_path.path),
-        }
+        target_path.to_string()
     }
 }
 
@@ -505,7 +506,7 @@ fn field_to_string(field: &str) -> String {
 impl Display for OwnedSegment {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            OwnedSegment::Index(i) => write!(f, "[{}]", i),
+            OwnedSegment::Index(i) => write!(f, "[{i}]"),
             OwnedSegment::Field(field) => write!(f, "{}", field_to_string(field)),
             OwnedSegment::Coalesce(v) => write!(
                 f,


### PR DESCRIPTION
This is a series of incremental optimizations to the handling of exporting owned paths to strings. Mostly they are a process of eliminating intermediate `String` values and implementing the string conversion in terms of the `Display` implementations instead of the other way around.

FWIW I also did `Display` conversion for `OwnedValuePath` itself, but the underlying `serialize_field` function ended up with a looped `write!` of single characters, which seemed unlikely to be performant. Fixing that is probably more work than it's worth.