### PR TITLE
Add missing VRL tests for `parse_etld`

### DIFF
--- a/lib/tests/tests/functions/parse_etld/etld_from_url.vrl
+++ b/lib/tests/tests/functions/parse_etld/etld_from_url.vrl
@@ -1,0 +1,6 @@
+# object: { "url": "https://vector.dev" }
+# result: { "etld": "dev", "etld_plus": "vector.dev", "known_suffix": true }
+
+parsed_url = parse_url!(.url)
+etld_result = parse_etld!(parsed_url.host, plus_parts: 1)
+etld_result

--- a/lib/tests/tests/functions/parse_etld/etld_plus_one.vrl
+++ b/lib/tests/tests/functions/parse_etld/etld_plus_one.vrl
@@ -1,0 +1,5 @@
+# object: { "host": "vector.dev" }
+# result: { "etld": "dev", "etld_plus": "vector.dev", "known_suffix": true }
+
+etld_result = parse_etld!(.host, plus_parts: 1)
+etld_result

--- a/lib/tests/tests/functions/parse_etld/etld_plus_ten.vrl
+++ b/lib/tests/tests/functions/parse_etld/etld_plus_ten.vrl
@@ -1,0 +1,5 @@
+# object: { "host": "vector.dev" }
+# result: { "etld": "dev", "etld_plus": "vector.dev", "known_suffix": true }
+
+etld_result = parse_etld!(.host, plus_parts: 10)
+etld_result

--- a/lib/tests/tests/functions/parse_etld/just_etld.vrl
+++ b/lib/tests/tests/functions/parse_etld/just_etld.vrl
@@ -1,0 +1,6 @@
+# object: { "host": "vector.dev" }
+# result: { "etld": "dev", "known_suffix": true }
+
+etld_result = parse_etld!(.host)
+del(etld_result.etld_plus)
+etld_result

--- a/src/stdlib/parse_etld.rs
+++ b/src/stdlib/parse_etld.rs
@@ -129,6 +129,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
     BTreeMap::from([
         ("etld".into(), Kind::bytes()),
         ("etld_plus".into(), Kind::bytes()),
+        ("known_suffix".into(), Kind::boolean()),
     ])
 }
 


### PR DESCRIPTION
Missed in #669

This also adds `known_suffix` to type definition of `parse_etld` result, that was missed in original PR.