### PR TITLE
chore(dev): Bump rust-toolchain to 1.74.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.74.0"
 profile = "default"


### PR DESCRIPTION
Needed by the `clap` upgrade: https://github.com/vectordotdev/vrl/pull/688

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
