### PR TITLE
chore(ci): use merge-base in check for added changelog fragments

### DIFF
--- a/scripts/check_changelog_fragments.sh
+++ b/scripts/check_changelog_fragments.sh
@@ -17,7 +17,7 @@ if [ ! -d "${CHANGELOG_DIR}" ]; then
 fi
 
 # diff-filter=A lists only added files
-FRAGMENTS=$(git diff --name-only --diff-filter=A origin/main ${CHANGELOG_DIR})
+FRAGMENTS=$(git diff --name-only --diff-filter=A --merge-base origin/main ${CHANGELOG_DIR})
 
 if [ -z "$FRAGMENTS" ]; then
   echo "No changelog fragments detected"


### PR DESCRIPTION
This avoids the diff listing fragments that were deleted on master but still exist on the current branch.