### PR TITLE
chore(ci): checkout full depth in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,7 +23,12 @@ jobs:
     env:
       PR_HAS_LABEL: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') }}
     steps:
+        # checkout full depth because in the check_changelog_fragments script, we need to specify a
+        # merge base. If we only shallow clone the repo, git may not have enough history to determine
+        # the base.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - run: |
           if [[ $PR_HAS_LABEL == 'true' ]] ; then


### PR DESCRIPTION
This is necessary so that the git command used in the workflow can find the merge base.