### PR TITLE
Make iana-time-zone optional and behind stdlib flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ stdlib = [
  "dep:hex",
  "dep:hmac",
  "dep:hostname",
+ "dep:iana-time-zone",
  "dep:idna",
  "dep:indexmap",
  "dep:md-5",
@@ -124,8 +125,8 @@ exitcode = {version = "1", optional = true }
 flate2 = { version = "1.0.28", default-features = false, features = ["default"], optional = true }
 hex = { version = "0.4", optional = true }
 hmac = { version = "0.12.1", optional = true }
+iana-time-zone = { version = "0.1.60", optional = true }
 idna = { version = "0.5", optional = true }
-iana-time-zone = "0.1.59"
 indexmap = { version = "~2.2.3", default-features = false, features = ["std"], optional = true}
 indoc = {version = "2.0.4", optional = true }
 itertools = { version = "0.12.1", default-features = false, optional = true }


### PR DESCRIPTION
As requested here: https://github.com/vectordotdev/vrl/pull/671#discussion_r1479769824

Please add the no-changelog label to the PR.

Tested to pass the checks script.

Note that iana-time-zone is a dependency of the chrono crate, which is a dependency of the compiler and value features, so this crate is usually pulled in anyway, but this is definitely cleaner.