### PR TITLE
feat(stdlib): add option to skip validation for punycode functions

### DIFF
--- a/changelog.d/709.feature.md
+++ b/changelog.d/709.feature.md
@@ -1,0 +1,2 @@
+Added `validate` option to `encode_punycode` and `decode_punycode`, which defaults to true, but can
+be used to skip validation when set to false.


### PR DESCRIPTION
Adds additional optional argument to `encode_punycode` and `decode_punycode` that disables validation. This is useful in cases when it is not important if the result is a valid domain name. By default validation is enabled.