### PR TITLE
chore(deps): Relax version dependency constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,59 +103,59 @@ stdlib = [
  ]
 
 [dependencies]
-cfg-if = "1.0.0"
+cfg-if = "1"
 
 # Optional dependencies
 ansi_term = {version = "0.12", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 base16 = { version = "0.2", optional = true }
 base64 = { version = "0.22", optional = true }
-bytes = { version = "1.5.0", default-features = false, optional = true }
-charset = { version = "0.1.3", optional = true }
+bytes = { version = "1", default-features = false, optional = true }
+charset = { version = "0.1", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"], optional = true }
-chrono-tz = { version = "0.8.6", default-features = false, optional = true }
+chrono-tz = { version = "0.8", default-features = false, optional = true }
 cidr-utils = { version = "0.6", optional = true }
-csv = { version = "1.3", optional = true }
-clap = { version = "4.5.1", features = ["derive"], optional = true }
+csv = { version = "1", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 codespan-reporting = {version = "0.11", optional = true }
-data-encoding = { version = "2.5.0", optional = true }
+data-encoding = { version = "2", optional = true }
 digest = { version = "0.10", optional = true }
-dyn-clone = { version = "1.0.17", default-features = false, optional = true }
+dyn-clone = { version = "1", default-features = false, optional = true }
 exitcode = {version = "1", optional = true }
-flate2 = { version = "1.0.28", default-features = false, features = ["default"], optional = true }
+flate2 = { version = "1", default-features = false, features = ["default"], optional = true }
 hex = { version = "0.4", optional = true }
-hmac = { version = "0.12.1", optional = true }
-iana-time-zone = { version = "0.1.60", optional = true }
+hmac = { version = "0.12", optional = true }
+iana-time-zone = { version = "0.1", optional = true }
 idna = { version = "0.5", optional = true }
 indexmap = { version = "~2.2.5", default-features = false, features = ["std"], optional = true}
-indoc = {version = "2.0.4", optional = true }
-itertools = { version = "0.12.1", default-features = false, optional = true }
+indoc = {version = "2", optional = true }
+itertools = { version = "0.12", default-features = false, optional = true }
 lalrpop-util = { version = "0.20", optional = true }
-mlua = { version = "0.9.6", default-features = false, features = ["lua54", "send", "vendored"], optional = true}
-nom = { version = "7.1.3", default-features = false, features = ["std"], optional = true }
-once_cell = { version = "1.19", default-features = false, features = ["std"], optional = true }
+mlua = { version = "0.9", default-features = false, features = ["lua54", "send", "vendored"], optional = true}
+nom = { version = "7", default-features = false, features = ["std"], optional = true }
+once_cell = { version = "1", default-features = false, features = ["std"], optional = true }
 ordered-float = { version = "4", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 paste = { version = "1", default-features = false, optional = true }
-peeking_take_while = { version = "1.0.0", default-features = false, optional = true }
-percent-encoding = { version = "2.3", optional = true }
-pest = { version = "2.7.8", default-features = false, optional = true, features = ["std"] }
-pest_derive = { version = "2.7.8", default-features = false, optional = true, features = ["std"] }
-proptest = { version = "1.4", optional = true }
+peeking_take_while = { version = "1", default-features = false, optional = true }
+percent-encoding = { version = "2", optional = true }
+pest = { version = "2", default-features = false, optional = true, features = ["std"] }
+pest_derive = { version = "2", default-features = false, optional = true, features = ["std"] }
+proptest = { version = "1", optional = true }
 proptest-derive = { version = "0.4", optional = true }
 prettydiff = {version = "0.6", default-features = false, optional = true }
 prettytable-rs = { version = "0.10", default-features = false, optional = true }
-quickcheck = { version = "1.0.3", optional = true }
-quoted_printable = {version = "0.5.0", optional = true }
+quickcheck = { version = "1", optional = true }
+quoted_printable = {version = "0.5", optional = true }
 psl = { version = "2", optional = true }
-rand = { version = "0.8.5", optional = true }
+rand = { version = "0.8", optional = true }
 regex = { version = "1", default-features = false, optional = true, features = ["std", "perf", "unicode"] }
-roxmltree = { version = "0.19.0", optional = true }
+roxmltree = { version = "0.19", optional = true }
 rustyline = { version = "13", default-features = false, optional = true }
 rust_decimal = { version = "1", optional = true }
-seahash = { version = "4.1.0", optional = true }
+seahash = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1.0.114", default-features = false, optional = true, features = ["std", "raw_value"] }
+serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }
@@ -164,34 +164,34 @@ snap = { version = "1", optional = true }
 syslog_loose = { version = "0.21", optional = true }
 termcolor = {version = "1", optional = true }
 thiserror ={ version =  "1", optional = true }
-tracing = { version = "0.1.40", default-features = false, optional = true }
-uaparser = { version = "0.6.1", default-features = false, optional = true }
-utf8-width = { version = "0.1.7", optional = true }
+tracing = { version = "0.1", default-features = false, optional = true }
+uaparser = { version = "0.6", default-features = false, optional = true }
+utf8-width = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 snafu = { version = "0.8", optional = true }
 webbrowser = { version = "0.8", default-features = false, optional = true }
-woothee = { version = "0.13.0", optional = true }
-community-id = { version = "0.2.2", optional = true}
+woothee = { version = "0.13", optional = true }
+community-id = { version = "0.2", optional = true}
 
-zstd = { version = "0.13.0", default-features = false, features = ["wasm"], optional = true }
+zstd = { version = "0.13", default-features = false, features = ["wasm"], optional = true }
 
 # Cryptography
-aes = { version = "0.8.4", optional = true }
-chacha20poly1305 = { version = "0.10.1", optional = true }
-crypto_secretbox = { version = "0.1.1", features = ["salsa20"], optional = true }
+aes = { version = "0.8", optional = true }
+chacha20poly1305 = { version = "0.10", optional = true }
+crypto_secretbox = { version = "0.1", features = ["salsa20"], optional = true }
 
 # Cryptography - Block Modes
-ctr = { version = "0.9.2", optional = true }
-cbc = { version = "0.1.2", optional = true, features = ["alloc"] }
-cfb-mode = { version = "0.8.2", optional = true }
-ofb = { version = "0.6.1", optional = true }
+ctr = { version = "0.9", optional = true }
+cbc = { version = "0.1", optional = true, features = ["alloc"] }
+cfb-mode = { version = "0.8", optional = true }
+ofb = { version = "0.6", optional = true }
 
 # Dependencies used for non-WASM
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-dns-lookup = { version = "2.0.4", optional = true }
+dns-lookup = { version = "2", optional = true }
 hostname = { version = "0.3", optional = true }
 grok = { version = "2", optional = true }
-onig = { version = "6.4", default-features = false, optional = true }
+onig = { version = "6", default-features = false, optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 
 # Dependencies used for WASM
@@ -203,14 +203,14 @@ anyhow = "1"
 criterion = "0.5"
 chrono-tz = "0.8"
 serde_json = "1"
-indoc = "2.0.4"
+indoc = "2"
 tracing-test = { version = "0.2", default-features = false }
-toml = { version = "0.8.10", default-features = false }
-mlua = { version = "0.9.6", default-features = false, features = ["lua54", "send", "vendored"]}
-quickcheck = { version = "1.0.3"}
+toml = { version = "0.8", default-features = false }
+mlua = { version = "0.9", default-features = false, features = ["lua54", "send", "vendored"]}
+quickcheck = { version = "1"}
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode"] }
 paste = { version = "1", default-features = false }
-proptest = { version = "1.4" }
+proptest = { version = "1" }
 proptest-derive = { version = "0.4" }
 
 [build-dependencies]


### PR DESCRIPTION
To allow for semantically versioned dependency equivalents. When trying to downgrade flate2 in Vector for testing it complained that the VRL crate required a newever version of flate2 since 1.0.28 restricts to >=1.0.28 and < 2.