### PR TITLE
chore: Set user-agent for publish script

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -11,7 +11,10 @@ REPO_ROOT_DIR = os.path.dirname(SCRIPTS_DIR)
 CHANGELOG_DIR = os.path.join(REPO_ROOT_DIR, "changelog.d")
 
 def get_crate_versions(crate_name):
-    response = requests.get(f"https://crates.io/api/v1/crates/{crate_name}")
+    # crates.io returns a 403 now for the default requests user-agent
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'}
+
+    response = requests.get(f"https://crates.io/api/v1/crates/{crate_name}", headers=headers)
     if response.status_code != 200:
         raise Exception(f"Error fetching crate info: {response.status_code}")
     data = response.json()


### PR DESCRIPTION
crates.io has started returning 403s for the default requests user-agent. I'm guessing to avoid bot requests.