### PR TITLE
fix(parse_key_value): handle more escapes (#725)

### DIFF
--- a/changelog.d/725.breaking.md
+++ b/changelog.d/725.breaking.md
@@ -1,0 +1,1 @@
+fixed `parse_logfmt` handling of escapes in values that could cause spurious keys to be created. As a result of this fix, the breaking change has been made to no longer allow empty keys in key-value pair formats

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -3,9 +3,9 @@ use crate::value;
 use nom::{
     self,
     branch::alt,
-    bytes::complete::{escaped, tag, take_until, take_while1},
+    bytes::complete::{escaped, tag, take, take_until},
     character::complete::{char, satisfy, space0},
-    combinator::{eof, map, opt, peek, recognize, rest, verify},
+    combinator::{eof, map, opt, peek, rest, verify},
     error::{ContextError, ParseError, VerboseError},
     multi::{many0, many1, many_m_n, separated_list1},
     sequence::{delimited, preceded, terminated, tuple},
@@ -374,16 +374,10 @@ fn parse_delimited<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
                 char(delimiter),
                 map(
                     opt(escaped(
-                        recognize(many1(tuple((
-                            take_while1(|c: char| c != '\\' && c != delimiter),
-                            // Consume \something
-                            opt(tuple((
-                                satisfy(|c| c == '\\'),
-                                satisfy(|c| c != '\\' && c != delimiter),
-                            ))),
-                        )))),
+                        satisfy(|c| c != '\\' && c != delimiter),
                         '\\',
-                        satisfy(|c| c == '\\' || c == delimiter),
+                        // match literally any character, there are no invalid escape sequences
+                        take(1usize),
                     )),
                     |inner| inner.unwrap_or(""),
                 ),
@@ -437,16 +431,19 @@ fn parse_key<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 ) -> Box<dyn Fn(&'a str) -> IResult<&'a str, &'a str, E> + 'a> {
     if standalone_key {
         Box::new(move |input| {
-            alt((
-                parse_delimited('\'', key_value_delimiter),
-                parse_delimited('\'', field_delimiter),
-                parse_delimited('"', key_value_delimiter),
-                parse_delimited('"', field_delimiter),
-                verify(parse_undelimited(key_value_delimiter), |s: &str| {
-                    !s.contains(field_delimiter)
-                }),
-                parse_undelimited(field_delimiter),
-            ))(input)
+            verify(
+                alt((
+                    parse_delimited('\'', key_value_delimiter),
+                    parse_delimited('\'', field_delimiter),
+                    parse_delimited('"', key_value_delimiter),
+                    parse_delimited('"', field_delimiter),
+                    verify(parse_undelimited(key_value_delimiter), |s: &str| {
+                        !s.is_empty() && !s.contains(field_delimiter)
+                    }),
+                    parse_undelimited(field_delimiter),
+                )),
+                |key: &str| !key.is_empty(),
+            )(input)
         })
     } else {
         Box::new(move |input| {
@@ -932,6 +929,98 @@ mod test {
                 field_delimiter: " ",
             ],
             want: Ok(value!({"Cc": "bob"})),
+            tdef: type_def(),
+        }
+
+        escaped_tab_escapes_in_quoted_value {
+            args: func_args! [
+                value: r#"level=info field="escaped tabs \t\t""#,
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Ok(value!({
+                "field": "escaped tabs \\t\\t",
+                "level": "info",
+            })),
+            tdef: type_def(),
+        }
+
+        escaped_quote_escapes_in_quoted_value {
+            args: func_args! [
+                value: r#"level=info field="quote -> \" <-""#,
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Ok(value!({
+                "field": "quote -> \\\" <-",
+                "level": "info",
+            })),
+            tdef: type_def(),
+        }
+
+        invalid_quotes_in_quoted_value {
+            args: func_args! [
+                value: r#"level=error field="no quote here """#,
+                //                 this extra quote causes  ~
+                //               the quoted parser to fail
+                //                        and these quotes ~~
+                //       cause the unquoted parser to fail
+                //             when there is an empty key!
+
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Err("could not parse whole line successfully"),
+            tdef: type_def(),
+        }
+
+        unquoted_field_delimiter_followed_by_key_value_delimiter {
+            args: func_args! [
+                value: r"argh=no =",
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Ok(value!({
+                "argh": "no",
+                "=": true,
+            })),
+            tdef: type_def(),
+        }
+
+        field_delimiter_followed_by_unpaired_quote_followed_by_key_value_delimiter {
+            args: func_args! [
+                value: r"argh=no '=",
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Ok(value!({
+                "argh": "no",
+                "'": "",
+            })),
+            tdef: type_def(),
+        }
+
+        quoted_key_value_delimiter {
+            args: func_args! [
+                value: r#"argh="no =""#,
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Ok(value!({
+                "argh": "no =",
+            })),
+            tdef: type_def(),
+        }
+
+        backslash_key {
+            args: func_args! [
+                value: r#"\="oh boy""#,
+                key_value_delimiter: "=",
+                field_delimiter: " ",
+            ],
+            want: Ok(value!({
+                "\\": "oh boy",
+            })),
             tdef: type_def(),
         }
     ];


### PR DESCRIPTION
Fixes #725 

Note: the key_value_parser no longer accepts empty keys!

This turned out to be a bit of a rabbit hole, but I tried to make minimal changes to meet fix the immediate issue.

I'm preserving some observed behavior that I've seen (in practice):
* escape sequences are not transformed
* there are no "invalid" escape sequences
* a wide range of keys parse successfully, such as lone quote characters `'` and backslashes `\`

However, I've made one change which may/may not be acceptable:
* empty keys no longer parse successfully

I'd like to think they have limited usefulness and actually indicate an error in the input, but it's up to you. It's simple enough to remove that validation (done using nom's verify() in `parse_key`) but some tests input start parsing weirdly instead of erroring.

Hope that helps, it's been a fun rabbit hole! Kudos for the test suite, was nice and easy to use.