### PR TITLE
fix(stdlib): parse_json improved accuracy float parsing #755

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ test_framework = ["compiler", "dep:prettydiff", "dep:serde_json", "dep:ansi_term
 arbitrary = ["dep:quickcheck", "dep:arbitrary"]
 lua = ["dep:mlua"]
 proptest = ["dep:proptest", "dep:proptest-derive"]
+float_roundtrip = ["dep:serde_json", "serde_json/float_roundtrip"]
 
 # Internal testing utilities (used for benches)
 test = ["string_path"]
@@ -157,7 +158,7 @@ rustyline = { version = "14", default-features = false, optional = true }
 rust_decimal = { version = "1", optional = true }
 seahash = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value", "float_roundtrip"] }
+serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ rustyline = { version = "14", default-features = false, optional = true }
 rust_decimal = { version = "1", optional = true }
 seahash = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
+serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value", "float_roundtrip"] }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }

--- a/changelog.d/755.fix.md
+++ b/changelog.d/755.fix.md
@@ -1,0 +1,1 @@
+`parse_json` now supports round-tripable float parsing by activating the `float_roundtrip` feature in serde_json

--- a/src/stdlib/parse_json.rs
+++ b/src/stdlib/parse_json.rs
@@ -322,8 +322,24 @@ mod tests {
             want: Ok(value!({"num": 9.223_372_036_854_776e18})),
             tdef: type_def(),
         }
+    ];
 
-        lossless_float_conversion {
+    #[cfg(not(feature = "float_roundtrip"))]
+    test_function![
+        parse_json => ParseJson;
+
+        no_roundtrip_float_conversion {
+            args: func_args![ value: r#"{"num": 1626175065.5934923}"#],
+            want: Ok(value!({"num": 1_626_175_065.593_492_5})),
+            tdef: type_def(),
+        }
+    ];
+
+    #[cfg(feature = "float_roundtrip")]
+    test_function![
+        parse_json => ParseJson;
+
+        roundtrip_float_conversion {
             args: func_args![ value: r#"{"num": 1626175065.5934923}"#],
             want: Ok(value!({"num": 1_626_175_065.593_492_3})),
             tdef: type_def(),

--- a/src/stdlib/parse_json.rs
+++ b/src/stdlib/parse_json.rs
@@ -322,5 +322,11 @@ mod tests {
             want: Ok(value!({"num": 9.223_372_036_854_776e18})),
             tdef: type_def(),
         }
+
+        lossless_float_conversion {
+            args: func_args![ value: r#"{"num": 1626175065.5934923}"#],
+            want: Ok(value!({"num": 1_626_175_065.593_492_3})),
+            tdef: type_def(),
+        }
     ];
 }


### PR DESCRIPTION
Fixed by activating a feature in serde_json, see https://github.com/serde-rs/json/issues/536

For anyone somehow relying on the innaccurate/faster parsing of floats, it's technically a breaking change.