### PR TITLE
chore: Update parameter usage in convert_to_string

### DIFF
--- a/src/stdlib/contains.rs
+++ b/src/stdlib/contains.rs
@@ -2,8 +2,8 @@ use crate::compiler::prelude::*;
 use crate::stdlib::string_utils::convert_to_string;
 
 fn contains(value: Value, substring: Value, case_sensitive: bool) -> Resolved {
-    let value = convert_to_string(value, case_sensitive)?;
-    let substring = convert_to_string(substring, case_sensitive)?;
+    let value = convert_to_string(value, !case_sensitive)?;
+    let substring = convert_to_string(substring, !case_sensitive)?;
     Ok(value.contains(&substring).into())
 }
 

--- a/src/stdlib/contains_all.rs
+++ b/src/stdlib/contains_all.rs
@@ -2,16 +2,16 @@ use crate::compiler::prelude::*;
 use crate::stdlib::string_utils::convert_to_string;
 
 fn contains_all(value: Value, substrings: Value, case_sensitive: Option<Value>) -> Resolved {
-    let to_lowercase = match case_sensitive {
+    let case_sensitive = match case_sensitive {
         Some(v) => v.try_boolean()?,
         None => true,
     };
 
-    let value_string = convert_to_string(value, to_lowercase)?;
+    let value_string = convert_to_string(value, !case_sensitive)?;
     let substring_values = substrings.try_array()?;
 
     for substring_value in substring_values {
-        let substring = convert_to_string(substring_value, to_lowercase)?;
+        let substring = convert_to_string(substring_value, !case_sensitive)?;
         if !value_string.contains(&substring) {
             return Ok(false.into());
         }

--- a/src/stdlib/ends_with.rs
+++ b/src/stdlib/ends_with.rs
@@ -2,8 +2,8 @@ use crate::compiler::prelude::*;
 use crate::stdlib::string_utils::convert_to_string;
 
 fn ends_with(value: Value, substring: Value, case_sensitive: bool) -> Resolved {
-    let value = convert_to_string(value, case_sensitive)?;
-    let substring = convert_to_string(substring, case_sensitive)?;
+    let value = convert_to_string(value, !case_sensitive)?;
+    let substring = convert_to_string(substring, !case_sensitive)?;
     Ok(value.ends_with(&substring).into())
 }
 

--- a/src/stdlib/string_utils.rs
+++ b/src/stdlib/string_utils.rs
@@ -3,7 +3,7 @@ use crate::prelude::{Value, ValueError, VrlValueConvert};
 pub(crate) fn convert_to_string(value: Value, to_lowercase: bool) -> Result<String, ValueError> {
     let string = value.try_bytes_utf8_lossy()?;
     Ok(match to_lowercase {
-        true => string.to_string(),
-        false => string.to_lowercase(),
+        true => string.to_lowercase(),
+        false => string.to_string(),
     })
 }


### PR DESCRIPTION
The parameter name was currently indicating the opposite of what it was doing.

Fixes: #802