### PR TITLE
chore: Introduce borrowed path types

### DIFF
--- a/src/path/borrowed.rs
+++ b/src/path/borrowed.rs
@@ -100,7 +100,7 @@ impl<'a, 'b> TargetPath<'a> for BorrowedTargetPath<'a, 'b> {
     }
 
     fn value_path(&self) -> Self::ValuePath {
-        self.path.clone()
+        self.path
     }
 }
 

--- a/src/path/borrowed.rs
+++ b/src/path/borrowed.rs
@@ -3,7 +3,12 @@ use std::borrow::Cow;
 use std::iter::Cloned;
 use std::slice::Iter;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BorrowedValuePath<'a, 'b> {
+    pub segments: &'b [BorrowedSegment<'a>],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BorrowedSegment<'a> {
     Field(Cow<'a, str>),
     Index(isize),
@@ -48,27 +53,19 @@ impl From<isize> for BorrowedSegment<'_> {
     }
 }
 
+impl<'a, 'b> ValuePath<'a> for BorrowedValuePath<'a, 'b> {
+    type Iter = Cloned<Iter<'b, BorrowedSegment<'a>>>;
+
+    fn segment_iter(&self) -> Self::Iter {
+        self.segments.iter().cloned()
+    }
+}
+
 impl<'a, 'b> ValuePath<'a> for &'b Vec<BorrowedSegment<'a>> {
     type Iter = Cloned<Iter<'b, BorrowedSegment<'a>>>;
 
     fn segment_iter(&self) -> Self::Iter {
         self.as_slice().iter().cloned()
-    }
-}
-
-impl<'a, 'b> ValuePath<'a> for &'b [BorrowedSegment<'a>] {
-    type Iter = Cloned<Iter<'b, BorrowedSegment<'a>>>;
-
-    fn segment_iter(&self) -> Self::Iter {
-        self.iter().cloned()
-    }
-}
-
-impl<'a, 'b, const A: usize> ValuePath<'a> for &'b [BorrowedSegment<'a>; A] {
-    type Iter = Cloned<Iter<'b, BorrowedSegment<'a>>>;
-
-    fn segment_iter(&self) -> Self::Iter {
-        self.iter().cloned()
     }
 }
 

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -286,6 +286,19 @@ impl<'a> TargetPath<'a> for &'a OwnedTargetPath {
     }
 }
 
+// This is deprecated but still used in Vector (results in 10 compile errors)
+impl<'a, T: ValuePath<'a>> TargetPath<'a> for (PathPrefix, T) {
+    type ValuePath = T;
+
+    fn prefix(&self) -> PathPrefix {
+        self.0
+    }
+
+    fn value_path(&self) -> Self::ValuePath {
+        self.1.clone()
+    }
+}
+
 /// Determines the prefix of a "TargetPath", and also returns the remaining
 /// "ValuePath" portion of the string.
 fn get_target_prefix(path: &str) -> (PathPrefix, &str) {

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -88,7 +88,7 @@ use std::fmt::Debug;
 
 use snafu::Snafu;
 
-pub use borrowed::{BorrowedSegment, BorrowedValuePath};
+pub use borrowed::{BorrowedSegment, BorrowedTargetPath, BorrowedValuePath};
 pub use concat::PathConcat;
 pub use owned::{OwnedSegment, OwnedTargetPath, OwnedValuePath};
 
@@ -119,8 +119,9 @@ macro_rules! path {
 /// This path points at an event (as opposed to metadata).
 #[macro_export]
 macro_rules! event_path {
-    ($($segment:expr),*) => {{
-        ($crate::path::PathPrefix::Event, $crate::path!($($segment),*))
+    ($($segment:expr),*) => { $crate::path::BorrowedTargetPath {
+        prefix: $crate::path::PathPrefix::Event,
+        path: $crate::path!($($segment),*),
     }};
 }
 
@@ -128,8 +129,9 @@ macro_rules! event_path {
 /// This path points at metadata (as opposed to the event).
 #[macro_export]
 macro_rules! metadata_path {
-    ($($segment:expr),*) => {{
-        ($crate::path::PathPrefix::Metadata, $crate::path!($($segment),*))
+    ($($segment:expr),*) => { $crate::path::BorrowedTargetPath {
+        prefix: $crate::path::PathPrefix::Metadata,
+        path: $crate::path!($($segment),*),
     }};
 }
 
@@ -281,18 +283,6 @@ impl<'a> TargetPath<'a> for &'a OwnedTargetPath {
 
     fn value_path(&self) -> Self::ValuePath {
         &self.path
-    }
-}
-
-impl<'a, T: ValuePath<'a>> TargetPath<'a> for (PathPrefix, T) {
-    type ValuePath = T;
-
-    fn prefix(&self) -> PathPrefix {
-        self.0
-    }
-
-    fn value_path(&self) -> Self::ValuePath {
-        self.1.clone()
     }
 }
 

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -88,7 +88,7 @@ use std::fmt::Debug;
 
 use snafu::Snafu;
 
-pub use borrowed::BorrowedSegment;
+pub use borrowed::{BorrowedSegment, BorrowedValuePath};
 pub use concat::PathConcat;
 pub use owned::{OwnedSegment, OwnedTargetPath, OwnedValuePath};
 
@@ -110,8 +110,8 @@ pub enum PathParseError {
 /// Example: `path!("foo", 4, "bar")` is the pre-parsed path of `foo[4].bar`
 #[macro_export]
 macro_rules! path {
-    ($($segment:expr),*) => {{
-           &[$($crate::path::BorrowedSegment::from($segment),)*]
+    ($($segment:expr),*) => { $crate::path::BorrowedValuePath {
+        segments: &[$($crate::path::BorrowedSegment::from($segment),)*],
     }};
 }
 
@@ -120,7 +120,7 @@ macro_rules! path {
 #[macro_export]
 macro_rules! event_path {
     ($($segment:expr),*) => {{
-           ($crate::path::PathPrefix::Event, &[$($crate::path::BorrowedSegment::from($segment),)*])
+        ($crate::path::PathPrefix::Event, $crate::path!($($segment),*))
     }};
 }
 
@@ -129,7 +129,7 @@ macro_rules! event_path {
 #[macro_export]
 macro_rules! metadata_path {
     ($($segment:expr),*) => {{
-           ($crate::path::PathPrefix::Metadata, &[$($crate::path::BorrowedSegment::from($segment),)*])
+        ($crate::path::PathPrefix::Metadata, $crate::path!($($segment),*))
     }};
 }
 


### PR DESCRIPTION
For a long time, VRL has had a set of "owned" path types, but no corresponding types outside of `BorrowedSegment`. This makes it harder to name the actual type involved in borrows for implementing other traits.

This PR replaces the tuple types used for borrowed path with `BorrowedTargetPath` and `BorrowedValuePath`, mirroring their `Owned` equivalents. There is one deprecated implementation on the tuple types left in to allow Vector `master` branch to build as-is with these changes.