### PR TITLE
Fix `std::fmt::Display` for abort expressions

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1196,7 +1196,7 @@ impl fmt::Display for Abort {
             &self
                 .message
                 .as_ref()
-                .map_or_else(|| "abort".to_owned(), |m| format!("abort: {m}")),
+                .map_or_else(|| "abort".to_owned(), |m| format!("abort {m}")),
         )
     }
 }


### PR DESCRIPTION
Fixes #829. I couldn't see any tests for this code, but a very simply one exists as I wrote in the issue. Let me know if you want that included and where it should live.

```rs
    #[test]
    fn abort_display_isomorphism() {
        let expression = r#"abort "error message""#;

        assert_eq!(
            format!("{expression}\n"),
            vrl::parser::parse(expression).unwrap().to_string()
        )
    }
```