### PR TITLE
feat(stdlib): add optional `psl` argument to `parse_etld`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -2298,6 +2308,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]
@@ -3346,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -3424,7 +3444,7 @@ dependencies = [
  "hmac",
  "hostname",
  "iana-time-zone",
- "idna",
+ "idna 0.5.0",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.13.0",
@@ -3449,6 +3469,8 @@ dependencies = [
  "prost",
  "prost-reflect",
  "psl",
+ "psl-types",
+ "publicsuffix",
  "quickcheck",
  "quoted_printable",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ stdlib = [
  "dep:prost",
  "dep:prost-reflect",
  "dep:psl",
+ "dep:psl-types",
+ "dep:publicsuffix",
  "dep:quoted_printable",
  "dep:rand",
  "dep:roxmltree",
@@ -154,6 +156,8 @@ prettytable-rs = { version = "0.10", default-features = false, optional = true }
 quickcheck = { version = "1", optional = true }
 quoted_printable = {version = "0.5", optional = true }
 psl = { version = "2", optional = true }
+psl-types = { version = "2", optional = true }
+publicsuffix = { version = "2", optional = true }
 rand = { version = "0.8", optional = true }
 regex = { version = "1", default-features = false, optional = true, features = ["std", "perf", "unicode"] }
 roxmltree = { version = "0.19", optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -171,6 +171,7 @@ prost-reflect,https://github.com/andrewhickman/prost-reflect,MIT OR Apache-2.0,A
 psl,https://github.com/addr-rs/psl,MIT OR Apache-2.0,rushmorem <rushmore@webenchanter.com>
 psl-types,https://github.com/addr-rs/psl-types,MIT OR Apache-2.0,rushmorem <rushmore@webenchanter.com>
 ptr_meta,https://github.com/djkoloski/ptr_meta,MIT,David Koloski <djkoloski@gmail.com>
+publicsuffix,https://github.com/rushmorem/publicsuffix,MIT OR Apache-2.0,rushmorem <rushmore@webenchanter.com>
 quanta,https://github.com/metrics-rs/quanta,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 quoted_printable,https://github.com/staktrace/quoted-printable,0BSD,Kartikaya Gupta <kats@seldon.staktrace.com>

--- a/lib/tests/tests/functions/custom_public_suffix_list.dat
+++ b/lib/tests/tests/functions/custom_public_suffix_list.dat
@@ -1,0 +1,3 @@
+// ===BEGIN ICANN DOMAINS===
+
+customdev

--- a/lib/tests/tests/functions/parse_etld/custom_psl_file.vrl
+++ b/lib/tests/tests/functions/parse_etld/custom_psl_file.vrl
@@ -1,0 +1,5 @@
+# object: { "host": "vector.customdev" }
+# result: { "etld": "customdev", "etld_plus": "vector.customdev", "known_suffix": true }
+
+etld_result = parse_etld!(.host, plus_parts: 1, psl: "lib/tests/tests/functions/custom_public_suffix_list.dat")
+etld_result

--- a/lib/tests/tests/functions/parse_etld/custom_psl_file_does_not_exist.vrl
+++ b/lib/tests/tests/functions/parse_etld/custom_psl_file_does_not_exist.vrl
@@ -1,0 +1,19 @@
+# object: { "host": "vector.customdev" }
+# result:
+#
+# error[E610]: function compilation error: error[E403] invalid argument
+# ┌─ :2:15
+# │
+# 2 │ etld_result = parse_etld!(.host, plus_parts: 1, psl: "lib/tests/tests/functions/definitelydoesnot.exist")
+# │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# │               │
+# │               invalid argument "psl"
+# │               error: Unable to read psl file
+# │               received: "\"lib/tests/tests/functions/definitelydoesnot.exist\""
+# │
+# = learn more about error code 403 at https://errors.vrl.dev/403
+# = see language documentation at https://vrl.dev
+# = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+etld_result = parse_etld!(.host, plus_parts: 1, psl: "lib/tests/tests/functions/definitelydoesnot.exist")
+etld_result

--- a/lib/tests/tests/functions/parse_etld/custom_psl_file_wrong_format.vrl
+++ b/lib/tests/tests/functions/parse_etld/custom_psl_file_wrong_format.vrl
@@ -1,0 +1,19 @@
+# object: { "host": "vector.customdev" }
+# result:
+#
+# error[E610]: function compilation error: error[E403] invalid argument
+# ┌─ :2:15
+# │
+# 2 │ etld_result = parse_etld!(.host, plus_parts: 1, psl: "lib/tests/tests/functions/parse_groks_alias_source.json")
+# │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# │               │
+# │               invalid argument "psl"
+# │               error: Unable to parse psl file
+# │               received: "\"lib/tests/tests/functions/parse_groks_alias_source.json\""
+# │
+# = learn more about error code 403 at https://errors.vrl.dev/403
+# = see language documentation at https://vrl.dev
+# = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+etld_result = parse_etld!(.host, plus_parts: 1, psl: "lib/tests/tests/functions/parse_groks_alias_source.json")
+etld_result


### PR DESCRIPTION
This adds an optional argument `psl` to `parse_etld`function, which should be a file path to a custom PSL list (default one can be found on https://publicsuffix.org/list/public_suffix_list.dat). If none is provided, the default is used.

Related: #669