### PR TITLE
Add traceability_id field to alb log parse

### DIFF
--- a/changelog.d/862.enhancement.md
+++ b/changelog.d/862.enhancement.md
@@ -1,0 +1,1 @@
+Add traceability_id field support to parse_aws_alb_log

--- a/src/stdlib/parse_aws_alb_log.rs
+++ b/src/stdlib/parse_aws_alb_log.rs
@@ -269,8 +269,8 @@ fn take_quoted1(input: &str) -> SResult<String> {
 }
 
 fn take_tid_or_nothing(input: &str) -> SResult<Option<&str>> {
-    if input.starts_with( " TID_") {
-        let (rest, value) = take_anything(&input)?; 
+    if input.starts_with(" TID_") {
+        let (rest, value) = take_anything(input)?;
         Ok((rest, Some(value)))
     } else {
         Ok((input, None))
@@ -352,7 +352,7 @@ mod tests {
                              type: "http",
                              user_agent: "curl/7.46.0",
                              traceability_id: "TID_dc57cebed65b444ebc8177bb698fe166"
-                             
+
 
             })),
             tdef: TypeDef::object(inner_kind()).fallible(),

--- a/src/stdlib/parse_aws_alb_log.rs
+++ b/src/stdlib/parse_aws_alb_log.rs
@@ -125,7 +125,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         (Field::from("trace_id"), Kind::bytes()),
         (Field::from("type"), Kind::bytes()),
         (Field::from("user_agent"), Kind::bytes()),
-        (Field::from("traceability_id"), Kind::bytes()),
+        (Field::from("traceability_id"), Kind::bytes() | Kind::null()),
     ])
 }
 
@@ -165,6 +165,17 @@ fn parse_log(mut input: &str) -> ExpressionResult<Value> {
     macro_rules! field_parse {
         ($name:expr, $($pattern:pat_param)|+, $type:ty) => {
             field_raw!($name, map_res(preceded(char(' '), take_while1(|c| matches!(c, $($pattern)|+))), |s: &str| s.parse::<$type>()))
+        };
+    }
+    macro_rules! field_tid {
+        ($name:expr) => {
+            log.insert(
+                $name.into(),
+                match get_value!($name, take_tid_or_nothing) {
+                    Some(value) => Value::Bytes(value.to_owned().into()),
+                    None => Value::Null,
+                },
+            )
         };
     }
 
@@ -239,7 +250,7 @@ fn parse_log(mut input: &str) -> ExpressionResult<Value> {
     );
     field_raw!("classification", take_quoted1);
     field_raw!("classification_reason", take_quoted1);
-    field_raw!("traceability_id", take_anything);
+    field_tid!("traceability_id");
 
     match input.is_empty() {
         true => Ok(log.into()),
@@ -255,6 +266,15 @@ fn take_anything(input: &str) -> SResult<&str> {
 
 fn take_quoted1(input: &str) -> SResult<String> {
     delimited(tag(" \""), until_quote, char('"'))(input)
+}
+
+fn take_tid_or_nothing(input: &str) -> SResult<Option<&str>> {
+    if input.starts_with( " TID_") {
+        let (rest, value) = take_anything(&input)?; 
+        Ok((rest, Some(value)))
+    } else {
+        Ok((input, None))
+    }
 }
 
 fn until_quote(input: &str) -> SResult<String> {
@@ -705,6 +725,42 @@ mod tests {
                              classification: null,
                              classification_reason: null,
                              traceability_id: "TID_dc57cebed65b444ebc8177bb698fe166"})),
+            tdef: TypeDef::object(inner_kind()).fallible(),
+        }
+        twelve {
+            args: func_args![value: r#"https 2021-03-16T20:20:00.135052Z app/awseb-AWSEB-1MVD8OW91UMOH/a32a5528b8fdaa6b 2601:6bbc:c529:9dad:6bbc:c529:9dad:6bbc:50599 fd6d:6bbc:c529:6::face:ed83:f46:80 0.001 0.052 0.000 200 200 589 2084 "POST https://test.domain.com:443/api/deposits/transactions:search?detailsLevel=FULL&offset=0&limit=50 HTTP/1.1" "User 1.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-1:755269215481:targetgroup/awseb-AWSEB-91MZX0WA1A0F/5a03cc723870f039 "Root=1-605112f0-31f367be4fd3da651daa4157" "some.domain.com" "arn:aws:acm:us-east-1:765229915481:certificate/d8450a8a-b4f6-4714-8535-17c625c36899" 0 2021-03-16T20:20:00.081000Z "waf,forward" "-" "-" "fd6d:6bbc:c529:27ff:b::dead:ed84:80" "200" "-" "-""#],
+            want: Ok(value!({type: "https",
+                             timestamp: "2021-03-16T20:20:00.135052Z",
+                             elb: "app/awseb-AWSEB-1MVD8OW91UMOH/a32a5528b8fdaa6b",
+                             client_host: "2601:6bbc:c529:9dad:6bbc:c529:9dad:6bbc:50599",
+                             target_host: "fd6d:6bbc:c529:6::face:ed83:f46:80",
+                             request_processing_time: 0.001,
+                             target_processing_time: 0.052,
+                             response_processing_time: 0.0,
+                             elb_status_code: "200",
+                             target_status_code: "200",
+                             received_bytes: 589,
+                             sent_bytes: 2084,
+                             request_method: "POST",
+                             request_url: "https://test.domain.com:443/api/deposits/transactions:search?detailsLevel=FULL&offset=0&limit=50",
+                             request_protocol: "HTTP/1.1",
+                             user_agent: "User 1.0",
+                             ssl_cipher: "ECDHE-RSA-AES128-GCM-SHA256",
+                             ssl_protocol: "TLSv1.2",
+                             target_group_arn: "arn:aws:elasticloadbalancing:us-east-1:755269215481:targetgroup/awseb-AWSEB-91MZX0WA1A0F/5a03cc723870f039",
+                             trace_id: "Root=1-605112f0-31f367be4fd3da651daa4157",
+                             domain_name: "some.domain.com",
+                             chosen_cert_arn: "arn:aws:acm:us-east-1:765229915481:certificate/d8450a8a-b4f6-4714-8535-17c625c36899",
+                             matched_rule_priority: "0",
+                             request_creation_time: "2021-03-16T20:20:00.081000Z",
+                             actions_executed: "waf,forward",
+                             redirect_url: null,
+                             error_reason: null,
+                             target_port_list: ["fd6d:6bbc:c529:27ff:b::dead:ed84:80"],
+                             target_status_code_list: ["200"],
+                             classification: null,
+                             classification_reason: null,
+                             traceability_id: null})),
             tdef: TypeDef::object(inner_kind()).fallible(),
         }
     ];


### PR DESCRIPTION
Apparently AWS added new field to ALB log which broke our ingestion pipeline. Only place I found it is AWS Athena guide to parse ALB logs
https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html

Closes: https://github.com/vectordotdev/vrl/issues/852