### PR TITLE
fix(parse_groks): support multibyte characters and date matcher w/o zero-padding

### DIFF
--- a/src/datadog/grok/lexer.rs
+++ b/src/datadog/grok/lexer.rs
@@ -256,10 +256,10 @@ fn unescape_string_literal(mut s: &str) -> Result<String, Error> {
     let mut string = String::with_capacity(s.len());
     while let Some(i) = s.bytes().position(|b| b == b'\\') {
         if s.len() > i + 2 {
-            let c = match &s[i..i + 3] {
-                r"\\n" => '\n',
-                r"\\r" => '\r',
-                r"\\t" => '\t',
+            let c = match s.as_bytes()[i..i + 3] { // convert to bytes since there might be multibyte(unicode) characters
+                [b'\\', b'\\', b'n'] => '\n',
+                [b'\\', b'\\', b'r'] => '\r',
+                [b'\\', b'\\', b't'] => '\t',
                 _ => '\0',
             };
             if c != '\0' {

--- a/src/datadog/grok/lexer.rs
+++ b/src/datadog/grok/lexer.rs
@@ -256,7 +256,8 @@ fn unescape_string_literal(mut s: &str) -> Result<String, Error> {
     let mut string = String::with_capacity(s.len());
     while let Some(i) = s.bytes().position(|b| b == b'\\') {
         if s.len() > i + 2 {
-            let c = match s.as_bytes()[i..i + 3] { // convert to bytes since there might be multibyte(unicode) characters
+            let c = match s.as_bytes()[i..i + 3] {
+                // convert to bytes since there might be multibyte(unicode) characters
                 [b'\\', b'\\', b'n'] => '\n',
                 [b'\\', b'\\', b'r'] => '\r',
                 [b'\\', b'\\', b't'] => '\t',

--- a/src/datadog/grok/matchers/date.rs
+++ b/src/datadog/grok/matchers/date.rs
@@ -41,7 +41,9 @@ pub fn convert_time_format(format: &str) -> std::result::Result<String, String> 
                 'x' => time_format.push_str("%D"),
                 // century
                 'c' | 'C' => time_format.push_str("%C"),
-                // day
+                // day w/o 0-padding
+                'd' if token.len() == 1 => time_format.push_str("%-d"),
+                // day with 0-padding
                 'd' => time_format.push_str("%d"),
                 // day of week
                 'e' => time_format.push_str("%u"),
@@ -51,8 +53,11 @@ pub fn convert_time_format(format: &str) -> std::result::Result<String, String> 
                 'w' => time_format.push_str("%V"),
                 // month of year
                 'M' => {
-                    if token.len() == 2 {
-                        // Month number
+                    if token.len() == 1 {
+                        // Month number w/o 0-padding
+                        time_format.push_str("%-m");
+                    } else if token.len() == 2 {
+                        // Month number with 0-padding
                         time_format.push_str("%m");
                     } else if token.len() == 3 {
                         // Abbreviated month name. Always 3 letters.
@@ -148,16 +153,14 @@ pub fn time_format_to_regex(
                     regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str())
                 }
                 // days
-                'd' if token.len() == 1 => regex.push_str("[\\d]{2}"), // expand d to dd
+                'd' if token.len() == 1 => regex.push_str("[\\d]{1,2}"), // support 0-padding
                 'd' => regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str()),
                 // years
                 'y' if token.len() == 1 => regex.push_str("[\\d]{4}"), // expand y to yyyy
                 'y' => regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str()),
-                'M' if token.len() == 2 =>
                 // Month number
-                {
-                    regex.push_str("[\\d]{2}")
-                }
+                'M' if token.len() == 1 => regex.push_str("[\\d]{1,2}"), // with 0-padding
+                'M' if token.len() == 2 => regex.push_str("[\\d]{2}"),
                 'M' if token.len() == 3 =>
                 // Abbreviated month name. Always 3 letters.
                 {

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -535,6 +535,16 @@ mod tests {
                 "171113 14:14:20",
                 Ok(Value::Integer(1510582460000)),
             ),
+            (
+                r#"%{date("M/d/yy HH:mm:ss z"):field}"#,
+                "5/6/18 19:40:59 GMT",
+                Ok(Value::Integer(1525635659000)),
+            ),
+            (
+                r#"%{date("M/d/yy HH:mm:ss z"):field}"#,
+                "11/16/18 19:40:59 GMT",
+                Ok(Value::Integer(1542397259000)),
+            ),
         ]);
 
         // check error handling

--- a/src/datadog/grok/parse_grok_pattern.rs
+++ b/src/datadog/grok/parse_grok_pattern.rs
@@ -131,4 +131,12 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parses_string_with_escaped_quote_followed_by_multibyte_character() {
+        let input = r#"%{regex("[^\\\"“]*"):traefik.backend_url}"#;
+        parse_grok_pattern(input).unwrap_or_else(|error| {
+            panic!("Problem parsing grok: {:?}", error);
+        });
+    }
 }


### PR DESCRIPTION
- Fixes a case where a string in the grok pattern contains an escaped special character, followed by a non-ascii character.
- Extends `date` matcher to support patterns w/o zero-padding, e.g.: `%{date("M/d/yy HH:mm:ss z"):field}`