### PR TITLE
chore(tests): Use dns.google in dns_lookup tests instead of localhost

### DIFF
--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -672,7 +672,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(linux)]
+    #[cfg(target_os = "linux")]
     // MacOS resolver doesn't always handle localhost
     fn test_localhost() {
         let result = execute_dns_lookup(DnsLookupFn {

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -359,13 +359,17 @@ impl Function for DnsLookup {
                     res.answers = filter(res.answers) -> |_, value| {
                         value.rData == "8.8.8.8"
                     }
+                    # remove class since this is also dynamic
+                    res.additional = map_values(res.additional) -> |value| {
+                        del(value.class)
+                        value
+                    }
                     res
                     "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
                       {
-                        "class": "CLASS512",
                         "domainName": "",
                         "rData": "OPT ...",
                         "recordType": "OPT",
@@ -425,13 +429,17 @@ impl Function for DnsLookup {
                     res.answers = filter(res.answers) -> |_, value| {
                         value.rData == "8.8.8.8"
                     }
+                    # remove class since this is also dynamic
+                    res.additional = map_values(res.additional) -> |value| {
+                        del(value.class)
+                        value
+                    }
                     res
                     "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
                       {
-                        "class": "CLASS512",
                         "domainName": "",
                         "rData": "OPT ...",
                         "recordType": "OPT",
@@ -490,13 +498,17 @@ impl Function for DnsLookup {
                     res.answers = filter(res.answers) -> |_, value| {
                         value.rData == "8.8.8.8"
                     }
+                    # remove class since this is also dynamic
+                    res.additional = map_values(res.additional) -> |value| {
+                        del(value.class)
+                        value
+                    }
                     res
                     "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
                       {
-                        "class": "CLASS512",
                         "domainName": "",
                         "rData": "OPT ...",
                         "recordType": "OPT",
@@ -555,13 +567,17 @@ impl Function for DnsLookup {
                     res.answers = filter(res.answers) -> |_, value| {
                         value.rData == "8.8.8.8"
                     }
+                    # remove class since this is also dynamic
+                    res.additional = map_values(res.additional) -> |value| {
+                        del(value.class)
+                        value
+                    }
                     res
                     "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
                       {
-                        "class": "CLASS512",
                         "domainName": "",
                         "rData": "OPT ...",
                         "recordType": "OPT",

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -348,218 +348,264 @@ impl Function for DnsLookup {
         &[
             Example {
                 title: "Basic lookup",
-                source: r#"dns_lookup!("localhost")"#,
+                source: r#"
+                    res = dns_lookup!("dns.google")
+                    # reset non-static ttl so result is static
+                    res.answers = map_values(res.answers) -> |value| {
+                      value.ttl = 600
+                      value
+                    }
+                    # remove extra responses for example
+                    res.answers = filter(res.answers) -> |_, value| {
+                        value.rData == "8.8.8.8"
+                    }
+                    res
+                    "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
-                        {
-                            "class": "CLASS65494",
-                            "domainName": "",
-                            "rData": "OPT ...",
-                            "recordType": "OPT",
-                            "recordTypeId": 41,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "CLASS512",
+                        "domainName": "",
+                        "rData": "OPT ...",
+                        "recordType": "OPT",
+                        "recordTypeId": 41,
+                        "ttl": 0
+                      }
                     ],
                     "answers": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "rData": "127.0.0.1",
-                            "recordType": "A",
-                            "recordTypeId": 1,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "rData": "8.8.8.8",
+                        "recordType": "A",
+                        "recordTypeId": 1,
+                        "ttl": 600
+                      }
                     ],
                     "authority": [],
                     "fullRcode": 0,
                     "header": {
-                        "aa": true,
-                        "ad": false,
-                        "anCount": 1,
-                        "arCount": 1,
-                        "cd": false,
-                        "nsCount": 0,
-                        "opcode": 0,
-                        "qdCount": 1,
-                        "qr": true,
-                        "ra": true,
-                        "rcode": 0,
-                        "rd": true,
-                        "tc": false
+                      "aa": false,
+                      "ad": false,
+                      "anCount": 2,
+                      "arCount": 1,
+                      "cd": false,
+                      "nsCount": 0,
+                      "opcode": 0,
+                      "qdCount": 1,
+                      "qr": true,
+                      "ra": true,
+                      "rcode": 0,
+                      "rd": true,
+                      "tc": false
                     },
                     "question": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "questionType": "A",
-                            "questionTypeId": 1
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "questionType": "A",
+                        "questionTypeId": 1
+                      }
                     ],
                     "rcodeName": "NOERROR"
-                }"#
+                  }"#
                 )),
             },
             Example {
                 title: "Custom class and qtype",
-                source: r#"dns_lookup!("localhost", class: "IN", qtype: "A")"#,
+                source: r#"
+                    res = dns_lookup!("dns.google", class: "IN", qtype: "A")
+                    # reset non-static ttl so result is static
+                    res.answers = map_values(res.answers) -> |value| {
+                      value.ttl = 600
+                      value
+                    }
+                    # remove extra responses for example
+                    res.answers = filter(res.answers) -> |_, value| {
+                        value.rData == "8.8.8.8"
+                    }
+                    res
+                    "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
-                        {
-                            "class": "CLASS65494",
-                            "domainName": "",
-                            "rData": "OPT ...",
-                            "recordType": "OPT",
-                            "recordTypeId": 41,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "CLASS512",
+                        "domainName": "",
+                        "rData": "OPT ...",
+                        "recordType": "OPT",
+                        "recordTypeId": 41,
+                        "ttl": 0
+                      }
                     ],
                     "answers": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "rData": "127.0.0.1",
-                            "recordType": "A",
-                            "recordTypeId": 1,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "rData": "8.8.8.8",
+                        "recordType": "A",
+                        "recordTypeId": 1,
+                        "ttl": 600
+                      }
                     ],
                     "authority": [],
                     "fullRcode": 0,
                     "header": {
-                        "aa": true,
-                        "ad": false,
-                        "anCount": 1,
-                        "arCount": 1,
-                        "cd": false,
-                        "nsCount": 0,
-                        "opcode": 0,
-                        "qdCount": 1,
-                        "qr": true,
-                        "ra": true,
-                        "rcode": 0,
-                        "rd": true,
-                        "tc": false
+                      "aa": false,
+                      "ad": false,
+                      "anCount": 2,
+                      "arCount": 1,
+                      "cd": false,
+                      "nsCount": 0,
+                      "opcode": 0,
+                      "qdCount": 1,
+                      "qr": true,
+                      "ra": true,
+                      "rcode": 0,
+                      "rd": true,
+                      "tc": false
                     },
                     "question": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "questionType": "A",
-                            "questionTypeId": 1
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "questionType": "A",
+                        "questionTypeId": 1
+                      }
                     ],
                     "rcodeName": "NOERROR"
-                }"#
+                  }"#
                 )),
             },
             Example {
                 title: "Custom options",
-                source: r#"dns_lookup!("localhost", options: {"timeout": 30, "attempts": 5})"#,
+                source: r#"
+                    res = dns_lookup!("dns.google", options: {"timeout": 30, "attempts": 5})
+                    res.answers = map_values(res.answers) -> |value| {
+                      value.ttl = 600
+                      value
+                    }
+                    # remove extra responses for example
+                    res.answers = filter(res.answers) -> |_, value| {
+                        value.rData == "8.8.8.8"
+                    }
+                    res
+                    "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
-                        {
-                            "class": "CLASS65494",
-                            "domainName": "",
-                            "rData": "OPT ...",
-                            "recordType": "OPT",
-                            "recordTypeId": 41,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "CLASS512",
+                        "domainName": "",
+                        "rData": "OPT ...",
+                        "recordType": "OPT",
+                        "recordTypeId": 41,
+                        "ttl": 0
+                      }
                     ],
                     "answers": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "rData": "127.0.0.1",
-                            "recordType": "A",
-                            "recordTypeId": 1,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "rData": "8.8.8.8",
+                        "recordType": "A",
+                        "recordTypeId": 1,
+                        "ttl": 600
+                      }
                     ],
                     "authority": [],
                     "fullRcode": 0,
                     "header": {
-                        "aa": true,
-                        "ad": false,
-                        "anCount": 1,
-                        "arCount": 1,
-                        "cd": false,
-                        "nsCount": 0,
-                        "opcode": 0,
-                        "qdCount": 1,
-                        "qr": true,
-                        "ra": true,
-                        "rcode": 0,
-                        "rd": true,
-                        "tc": false
+                      "aa": false,
+                      "ad": false,
+                      "anCount": 2,
+                      "arCount": 1,
+                      "cd": false,
+                      "nsCount": 0,
+                      "opcode": 0,
+                      "qdCount": 1,
+                      "qr": true,
+                      "ra": true,
+                      "rcode": 0,
+                      "rd": true,
+                      "tc": false
                     },
                     "question": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "questionType": "A",
-                            "questionTypeId": 1
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "questionType": "A",
+                        "questionTypeId": 1
+                      }
                     ],
                     "rcodeName": "NOERROR"
-                }"#
+                  }"#
                 )),
             },
             Example {
                 title: "Custom server",
-                source: r#"dns_lookup!("localhost", options: {"servers": ["dns.quad9.net"]})"#,
+                source: r#"
+                    res = dns_lookup!("dns.google", options: {"servers": ["dns.quad9.net"]})
+                    res.answers = map_values(res.answers) -> |value| {
+                      value.ttl = 600
+                      value
+                    }
+                    # remove extra responses for example
+                    res.answers = filter(res.answers) -> |_, value| {
+                        value.rData == "8.8.8.8"
+                    }
+                    res
+                    "#,
                 result: Ok(indoc!(
                     r#"{
                     "additional": [
-                        {
-                            "class": "CLASS65494",
-                            "domainName": "",
-                            "rData": "OPT ...",
-                            "recordType": "OPT",
-                            "recordTypeId": 41,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "CLASS512",
+                        "domainName": "",
+                        "rData": "OPT ...",
+                        "recordType": "OPT",
+                        "recordTypeId": 41,
+                        "ttl": 0
+                      }
                     ],
                     "answers": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "rData": "127.0.0.1",
-                            "recordType": "A",
-                            "recordTypeId": 1,
-                            "ttl": 0
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "rData": "8.8.8.8",
+                        "recordType": "A",
+                        "recordTypeId": 1,
+                        "ttl": 600
+                      }
                     ],
                     "authority": [],
                     "fullRcode": 0,
                     "header": {
-                        "aa": true,
-                        "ad": false,
-                        "anCount": 1,
-                        "arCount": 1,
-                        "cd": false,
-                        "nsCount": 0,
-                        "opcode": 0,
-                        "qdCount": 1,
-                        "qr": true,
-                        "ra": true,
-                        "rcode": 0,
-                        "rd": true,
-                        "tc": false
+                      "aa": false,
+                      "ad": false,
+                      "anCount": 2,
+                      "arCount": 1,
+                      "cd": false,
+                      "nsCount": 0,
+                      "opcode": 0,
+                      "qdCount": 1,
+                      "qr": true,
+                      "ra": true,
+                      "rcode": 0,
+                      "rd": true,
+                      "tc": false
                     },
                     "question": [
-                        {
-                            "class": "IN",
-                            "domainName": "localhost",
-                            "questionType": "A",
-                            "questionTypeId": 1
-                        }
+                      {
+                        "class": "IN",
+                        "domainName": "dns.google",
+                        "questionType": "A",
+                        "questionTypeId": 1
+                      }
                     ],
                     "rcodeName": "NOERROR"
-                }"#
+                  }"#
                 )),
             },
         ]
@@ -626,6 +672,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg(linux)]
+    // MacOS resolver doesn't always handle localhost
     fn test_localhost() {
         let result = execute_dns_lookup(DnsLookupFn {
             value: expr!("localhost"),
@@ -648,11 +696,10 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_class_and_type() {
+    fn test_custom_class() {
         let result = execute_dns_lookup(DnsLookupFn {
-            value: expr!("localhost"),
-            class: expr!("*"),
-            qtype: expr!("HTTPS"),
+            value: expr!("google.com"),
+            qtype: expr!("mx"),
             ..Default::default()
         });
 
@@ -661,10 +708,10 @@ mod tests {
         assert_eq!(
             result["question"].as_array_unwrap()[0],
             value!({
-                "questionTypeId": 65,
-                "questionType": "HTTPS",
-                "class": "*",
-                "domainName": "localhost"
+                "questionTypeId": 15,
+                "questionType": "MX",
+                "class": "IN",
+                "domainName": "google.com"
             })
         );
     }
@@ -706,7 +753,7 @@ mod tests {
     #[test]
     fn unknown_options_ignored() {
         let result = execute_dns_lookup(DnsLookupFn {
-            value: expr!("localhost"),
+            value: expr!("dns.google"),
             options: expr!({"test": "test"}),
             ..Default::default()
         });
@@ -717,7 +764,7 @@ mod tests {
     #[test]
     fn invalid_option_type() {
         let result = execute_dns_lookup_with_expected_error(DnsLookupFn {
-            value: expr!("localhost"),
+            value: expr!("dns.google"),
             options: expr!({"tcp": "yes"}),
             ..Default::default()
         });
@@ -729,7 +776,7 @@ mod tests {
     fn negative_int_type() {
         let attempts_val = -5;
         let result = execute_dns_lookup_with_expected_error(DnsLookupFn {
-            value: expr!("localhost"),
+            value: expr!("dns.google"),
             options: expr!({"attempts": attempts_val}),
             ..Default::default()
         });

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -696,7 +696,7 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_class() {
+    fn test_custom_type() {
         let result = execute_dns_lookup(DnsLookupFn {
             value: expr!("google.com"),
             qtype: expr!("mx"),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -230,7 +230,7 @@ fn process_result(
                 print!("{} (expectation)", Colour::Red.bold().paint("FAILED"));
 
                 if !config.no_diff {
-                    let want = serde_json::to_string_pretty(&test.result.clone()).unwrap();
+                    let want = serde_json::to_string_pretty(&want_value).unwrap();
                     let got = serde_json::to_string_pretty(&got_value).unwrap();
 
                     let diff = prettydiff::diff_lines(&want, &got);


### PR DESCRIPTION
localhost doesn't seem to resolve consistently on MacOS causing test failures locally. Certainly there is some risk relying on dns.google but it seems minimal. We can swap it out with another domain if/as needed. Failures can be seen here: https://github.com/vectordotdev/vrl/pull/875

Also updates the VRL test runner to correctly diff objects.

Easier to review with whitespace changes disabled since I changed the indentation when updating the fixtures.