### PR TITLE
chore(ci): Also run tests on MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,10 @@ jobs:
         run: ./scripts/format_check.sh
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -49,7 +52,10 @@ jobs:
         run: ./scripts/tests.sh
 
   vrl:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         run: ./scripts/format_check.sh
 
   test:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +53,7 @@ jobs:
         run: ./scripts/tests.sh
 
   vrl:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
https://github.com/vectordotdev/vrl/pull/874 is fixing a recent example where the tests failed to run on MacOS. Add this CI check to catch it in the future.

This'll also help reduce the likelihood of VRL bugs on MacOS.