### PR TITLE
fix: return back proptest_derive::Arbitrary for OwnedValuePath

### DIFF
--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -14,6 +14,7 @@ use crate::value::KeyString;
 /// A lookup path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct OwnedValuePath {
     pub segments: Vec<OwnedSegment>,
 }


### PR DESCRIPTION
Returns back `proptest_derive::Arbitrary` for `OwnedValuePath` to bump the `vrl` version of upstream deps.