### PR TITLE
ci: create a release-plz action

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,26 @@
+name: release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,11 @@
+[workspace]
+# prevent release-plz to update the changelog. This is handled
+# manually by the developers.
+changelog_update = false
+# prevent the CI to break due to a missing changelog update.
+pr_labels = ["no-changelog"]
+
+[[package]]
+name = "vrl"
+changelog_path = "./CHANGELOG.md"
+changelog_update = false


### PR DESCRIPTION
This PR creates a configuration for [release-plz](https://github.com/MarcoIeni/release-plz).
To make this work, we need to follow the first 2 steps from [this doc](https://release-plz.ieni.dev/docs/github/quickstart). This will add a secret token that will allow this new action to publish the new release to crates.io.

Fixes #880