### PR TITLE
enhancement(codecs)!: Use DescriptorPool from ProtobufDeserializer

### DIFF
--- a/src/protobuf/descriptor.rs
+++ b/src/protobuf/descriptor.rs
@@ -7,9 +7,8 @@ pub fn get_message_pool_descriptor(
     let b = std::fs::read(descriptor_set_path).map_err(|e| {
         format!("Failed to open protobuf desc file '{descriptor_set_path:?}': {e}",)
     })?;
-    DescriptorPool::decode(b.as_slice()).map_err(|e| {
-        format!("Failed to parse protobuf desc file '{descriptor_set_path:?}': {e}")
-    })
+    DescriptorPool::decode(b.as_slice())
+        .map_err(|e| format!("Failed to parse protobuf desc file '{descriptor_set_path:?}': {e}"))
 }
 
 pub fn get_message_descriptor(

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -3,8 +3,8 @@ mod encode;
 mod parse;
 
 pub use descriptor::get_message_descriptor;
-pub use descriptor::get_message_pool_descriptor;
 pub use descriptor::get_message_descriptor_from_pool;
+pub use descriptor::get_message_pool_descriptor;
 
 pub use encode::encode_message;
 pub(crate) use encode::encode_proto;

--- a/src/protobuf/parse.rs
+++ b/src/protobuf/parse.rs
@@ -54,12 +54,22 @@ pub fn proto_to_value(
                                 let type_name = type_url.trim_start_matches("type.googleapis.com/");
                                 match get_message_descriptor_from_pool(descriptor_pool, type_name) {
                                     Ok(message_descriptor) => {
-                                        match DynamicMessage::decode(message_descriptor, value.clone()) {
+                                        match DynamicMessage::decode(
+                                            message_descriptor,
+                                            value.clone(),
+                                        ) {
                                             Ok(dynamic_message) => {
-                                                return proto_to_value(Some(descriptor_pool), &prost_reflect::Value::Message(dynamic_message), None);
+                                                return proto_to_value(
+                                                    Some(descriptor_pool),
+                                                    &prost_reflect::Value::Message(dynamic_message),
+                                                    None,
+                                                );
                                             }
                                             Err(error) => {
-                                                return Err(format!("Error parsing embedded protobuf message: {:?}", error));
+                                                return Err(format!(
+                                                    "Error parsing embedded protobuf message: {:?}",
+                                                    error
+                                                ));
                                             }
                                         }
                                     }
@@ -77,7 +87,8 @@ pub fn proto_to_value(
             for field_desc in v.descriptor().fields() {
                 if v.has_field(&field_desc) {
                     let field_value = v.get_field(&field_desc);
-                    let out = proto_to_value(descriptor_pool, field_value.as_ref(), Some(&field_desc))?;
+                    let out =
+                        proto_to_value(descriptor_pool, field_value.as_ref(), Some(&field_desc))?;
                     obj_map.insert(field_desc.name().into(), out);
                 }
             }


### PR DESCRIPTION
This change allows to recursively handle `google.protobuf.Any` messages from a shared DescriptorPool loaded via `decoding.protobuf.desc_file` at best effort.