### PR TITLE
fix(stdlib): clear default servers when setting custom servers for `dns_lookup`

### DIFF
--- a/changelog.d/910.fix.md
+++ b/changelog.d/910.fix.md
@@ -1,0 +1,1 @@
+`server` option for `dns_lookup` now properly replaces default server settings

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -219,6 +219,7 @@ mod non_wasm {
             .map(|s| s.clone().try_array())
             .transpose()?
         {
+            conf.servers.clear();
             for server in servers {
                 let mut server = server.try_bytes_utf8_lossy()?;
                 if !server.contains(':') {


### PR DESCRIPTION


---
>Sponsored by [Quad9](https://quad9.net/)