### PR TITLE
fix(datadog grok:querystring filter): ignore keys w/o values

### DIFF
--- a/src/datadog/grok/grok_filter.rs
+++ b/src/datadog/grok/grok_filter.rs
@@ -203,7 +203,9 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
         GrokFilter::Rubyhash => parse_value_error_prone(value, filter, |b| {
             parse_ruby_hash(String::from_utf8_lossy(b).as_ref())
         }),
-        GrokFilter::Querystring => parse_value_error_prone(value, filter, parse_query_string),
+        GrokFilter::Querystring => {
+            parse_value_error_prone(value, filter, |s| parse_query_string(s, true))
+        }
         GrokFilter::Boolean => parse_value(value, filter, |b| {
             "true".eq_ignore_ascii_case(String::from_utf8_lossy(b).as_ref())
         }),

--- a/src/parsing/query_string.rs
+++ b/src/parsing/query_string.rs
@@ -11,6 +11,9 @@ pub(crate) fn parse_query_string(bytes: &Bytes) -> Resolved {
     let parsed = form_urlencoded::parse(query_string);
     for (k, value) in parsed {
         let value = value.as_ref();
+        if value.is_empty() {
+            continue;
+        }
         result
             .entry(k.into_owned().into())
             .and_modify(|v| {
@@ -41,8 +44,6 @@ mod tests {
             Value::from(btreemap! {
                 "foo" => "+1",
                 "bar" => "2",
-                "xyz" => "",
-                "abc" => "",
             })
         );
     }
@@ -72,23 +73,19 @@ mod tests {
     #[test]
     fn test_parses_empty_key() {
         let result = parse_query_string(&"=&=".into()).unwrap();
-        assert_eq!(
-            result,
-            Value::from(btreemap! {
-                "" => vec!["", ""],
-            })
-        );
+        assert_eq!(result, Value::from(btreemap! {}));
+    }
+
+    #[test]
+    fn test_parses_empty_value() {
+        let result = parse_query_string(&"-".into()).unwrap();
+        assert_eq!(result, Value::from(btreemap! {}));
     }
 
     #[test]
     fn test_parses_single_key() {
         let result = parse_query_string(&"foo".into()).unwrap();
-        assert_eq!(
-            result,
-            Value::from(btreemap! {
-                "foo" => "",
-            })
-        );
+        assert_eq!(result, Value::from(btreemap! {}));
     }
 
     #[test]

--- a/src/stdlib/parse_query_string.rs
+++ b/src/stdlib/parse_query_string.rs
@@ -49,7 +49,7 @@ struct ParseQueryStringFn {
 impl FunctionExpression for ParseQueryStringFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let bytes = self.value.resolve(ctx)?.try_bytes()?;
-        parse_query_string(&bytes)
+        parse_query_string(&bytes, false)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {


### PR DESCRIPTION
Ignores keys w/o values.