### PR TITLE
fix(repl): do not check for unused expressions

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -168,6 +168,7 @@ fn resolve(
     let mut config = CompileConfig::default();
     // The CLI should be moved out of the "vrl" module, and then it can use the `vector-core::compile_vrl` function which includes this automatically
     config.set_read_only_path(owned_metadata_path!("vector"), true);
+    config.disable_unused_expression_check();
 
     let program = match compile_with_state(program, stdlib_functions, state, config) {
         Ok(result) => result.program,

--- a/src/compiler/compile_config.rs
+++ b/src/compiler/compile_config.rs
@@ -6,11 +6,21 @@ use std::{
 
 type AnyMap = HashMap<TypeId, Box<dyn Any>>;
 
-#[derive(Default)]
 pub struct CompileConfig {
     /// Custom context injected by the external environment
     custom: AnyMap,
     read_only_paths: BTreeSet<ReadOnlyPath>,
+    check_unused_expressions: bool,
+}
+
+impl Default for CompileConfig {
+    fn default() -> Self {
+        CompileConfig {
+            custom: AnyMap::default(),
+            read_only_paths: BTreeSet::default(),
+            check_unused_expressions: true,
+        }
+    }
 }
 
 impl CompileConfig {
@@ -69,6 +79,15 @@ impl CompileConfig {
     pub fn set_read_only_path(&mut self, path: OwnedTargetPath, recursive: bool) {
         self.read_only_paths
             .insert(ReadOnlyPath { path, recursive });
+    }
+
+    #[must_use]
+    pub fn unused_expression_check_enabled(&self) -> bool {
+        self.check_unused_expressions
+    }
+
+    pub fn disable_unused_expression_check(&mut self) {
+        self.check_unused_expressions = false;
     }
 }
 


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vector/issues/20840

This check is not useful in REPL mode. This PR disables the check only for REPL mode.