### PR TITLE
chore(datadog search): Rewrite parse function in terms of `FromStr`

### DIFF
--- a/src/datadog/filter/matcher.rs
+++ b/src/datadog/filter/matcher.rs
@@ -1,9 +1,8 @@
 use std::{fmt, marker::PhantomData};
 
-use crate::datadog::search::{BooleanType, QueryNode};
 use dyn_clone::{clone_trait_object, DynClone};
 
-use super::{Filter, Resolver};
+use super::{BooleanType, Filter, QueryNode, Resolver};
 
 /// A `Matcher` is a type that contains a "run" method which returns true/false if value `V`
 /// matches a filter.

--- a/src/datadog/filter/mod.rs
+++ b/src/datadog/filter/mod.rs
@@ -17,3 +17,5 @@ mod resolver;
 pub use filter::*;
 pub use matcher::*;
 pub use resolver::*;
+
+use super::search::{normalize_fields, BooleanType, Field, QueryNode};

--- a/src/datadog/filter/resolver.rs
+++ b/src/datadog/filter/resolver.rs
@@ -1,4 +1,4 @@
-use crate::datadog::search::{normalize_fields, Field};
+use super::{normalize_fields, Field};
 
 /// A `Resolver` is type that can build and return an `IntoIterator` of Datadog Search
 /// Syntax `Field`s. These are intended to be passed along to `Filter` methods as pre-parsed

--- a/src/datadog/search/field.rs
+++ b/src/datadog/search/field.rs
@@ -27,6 +27,8 @@ pub enum Field {
     /// Default field (when tag/facet isn't provided)
     Default(String),
 
+    // TODO investigate making this be an enum which may make more sense
+    //      when dealing with a fixed set of field names
     /// Reserved field that receives special treatment in Datadog.
     Reserved(String),
 

--- a/src/datadog/search/grammar.rs
+++ b/src/datadog/search/grammar.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::upper_case_acronyms)]
 use itertools::Itertools;
 use pest::iterators::Pair;
+use pest_derive::Parser;
 
 use super::node::{
     BooleanBuilder, Comparison, ComparisonValue, LuceneClause, LuceneOccur, QueryNode, Range,

--- a/src/datadog/search/mod.rs
+++ b/src/datadog/search/mod.rs
@@ -12,4 +12,4 @@ mod parser;
 
 pub use field::{normalize_fields, Field};
 pub use node::{BooleanType, Comparison, ComparisonValue, QueryNode};
-pub use parser::{parse, Error};
+pub use parser::Error as ParseError;

--- a/src/datadog/search/parser.rs
+++ b/src/datadog/search/parser.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use pest::Parser;
 
 use super::{
@@ -8,18 +10,22 @@ use super::{
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Quick wrapper parse function to convert query strings into our AST
-pub fn parse(query: &str) -> Result<QueryNode, Error> {
-    // Clean up our query string
-    let clean_query = query.trim();
-    // If we have an empty query, we presume we're matching everything
-    if clean_query.is_empty() {
-        return Ok(QueryNode::MatchAllDocs);
+impl FromStr for QueryNode {
+    type Err = Error;
+
+    fn from_str(query: &str) -> Result<Self, Self::Err> {
+        // Clean up our query string
+        let clean_query = query.trim();
+        // If we have an empty query, we presume we're matching everything
+        Ok(if clean_query.is_empty() {
+            Self::MatchAllDocs
+        } else {
+            // Otherwise parse and interpret the query
+            let mut ast = EventPlatformQuery::parse(super::grammar::Rule::queryroot, query)?;
+            let rootquery = ast.next().ok_or("Unable to find root query")?;
+            QueryVisitor::visit_queryroot(rootquery, DEFAULT_FIELD)
+        })
     }
-    // Otherwise parse and interpret the query
-    let mut ast = EventPlatformQuery::parse(super::grammar::Rule::queryroot, query)?;
-    let rootquery = ast.next().ok_or("Unable to find root query")?;
-    let q = QueryVisitor::visit_queryroot(rootquery, DEFAULT_FIELD);
-    Ok(q)
 }
 
 #[cfg(test)]
@@ -27,16 +33,21 @@ mod tests {
     use super::super::node::{BooleanType, Comparison, ComparisonValue, QueryNode};
     use super::*;
 
+    fn parse(s: &str) -> QueryNode {
+        s.parse()
+            .unwrap_or_else(|_| panic!("Unable to parse {s:?}."))
+    }
+
     #[test]
     fn parses_basic_string() {
-        parse("foo:bar").expect("Unable to parse 'foo:bar'");
+        parse("foo:bar");
     }
 
     #[test]
     fn parses_whitespace() {
         let cases = [" ", "    ", "\t"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res, QueryNode::MatchAllDocs),
                 "Failed to parse MatchAllDocs query out of empty input"
@@ -48,7 +59,7 @@ mod tests {
     fn parses_unquoted_default_field_query() {
         let cases = ["foo"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeTerm { ref attr, ref value }
@@ -64,7 +75,7 @@ mod tests {
     fn parses_quoted_default_field_query() {
         let cases = ["\"foo bar\""];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::QuotedAttribute { ref attr, ref phrase }
@@ -80,7 +91,7 @@ mod tests {
     fn parses_attribute_term_query() {
         let cases = ["foo:bar", "foo:(bar)", "foo:b\\ar", "foo:(b\\ar)"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeTerm { ref attr, ref value }
@@ -96,7 +107,7 @@ mod tests {
     fn parses_numeric_attribute_term_query() {
         let cases = ["foo:10"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeTerm { ref attr, ref value }
@@ -112,7 +123,7 @@ mod tests {
     fn parses_attribute_term_query_with_escapes() {
         let cases = ["foo:bar\\:baz", "fo\\o:bar\\:baz"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeTerm { ref attr, ref value }
@@ -128,7 +139,7 @@ mod tests {
     fn parses_attribute_comparison_query_with_escapes() {
         let cases = ["foo:<4.12345E-4", "foo:<4.12345E\\-4"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeComparison { ref attr, value: ComparisonValue::Float(ref compvalue), comparator: Comparison::Lt }
@@ -144,7 +155,7 @@ mod tests {
     fn parses_and_normalizes_multiterm_query() {
         let cases = ["foo bar", "foo        bar"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeTerm { ref attr, ref value }
@@ -160,7 +171,7 @@ mod tests {
     fn parses_multiple_multiterm_query() {
         let cases = ["foo bar baz AND qux quux quuz"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::Boolean {
                 oper: BooleanType::And,
                 ref nodes,
@@ -185,7 +196,7 @@ mod tests {
     fn parses_negated_attribute_term_query() {
         let cases = ["-foo:bar", "- foo:bar", "NOT foo:bar"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::NegatedNode { ref node } = res {
                 if let QueryNode::AttributeTerm {
                     ref attr,
@@ -205,7 +216,7 @@ mod tests {
     fn parses_quoted_attribute_term_query() {
         let cases = ["foo:\"bar baz\""];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::QuotedAttribute { ref attr, ref phrase }
@@ -221,7 +232,7 @@ mod tests {
     fn parses_attribute_prefix_query() {
         let cases = ["foo:ba*"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributePrefix { ref attr, ref prefix }
@@ -237,7 +248,7 @@ mod tests {
     fn parses_attribute_wildcard_query() {
         let cases = ["foo:b*r"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeWildcard { ref attr, ref wildcard }
@@ -253,7 +264,7 @@ mod tests {
     fn parses_attribute_wildcard_query_with_trailing_question_mark() {
         let cases = ["foo:ba?"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeWildcard { ref attr, ref wildcard }
@@ -269,7 +280,7 @@ mod tests {
     fn parses_attribute_wildcard_query_with_leading_wildcard() {
         let cases = ["foo:*ar"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeWildcard { ref attr, ref wildcard }
@@ -285,7 +296,7 @@ mod tests {
     fn parses_non_numeric_attribute_comparison_query() {
         let cases = ["foo:>=bar"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeComparison {
@@ -304,7 +315,7 @@ mod tests {
     fn parses_numeric_attribute_range_query() {
         let cases = ["foo:[10 TO 20]"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeRange {
@@ -325,7 +336,7 @@ mod tests {
     fn parses_non_numeric_attribute_range_query() {
         let cases = ["foo:{bar TO baz}"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeRange {
@@ -346,7 +357,7 @@ mod tests {
     fn parses_attribute_range_query_with_open_endpoints() {
         let cases = ["foo:[* TO *]"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeRange {
@@ -367,7 +378,7 @@ mod tests {
     fn parses_attribute_range_query_with_fake_wildcards() {
         let cases = ["foo:[ba* TO b*z]"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeRange {
@@ -388,7 +399,7 @@ mod tests {
     fn parses_attribute_exists_query() {
         let cases = ["_exists_:foo", "_exists_:\"foo\""];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeExists { ref attr }
@@ -404,7 +415,7 @@ mod tests {
     fn parses_attribute_exists_query_with_escapes() {
         let cases = ["_exists_:foo\\ bar"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeExists { ref attr }
@@ -420,7 +431,7 @@ mod tests {
     fn parses_star_as_wildcard_not_exists() {
         let cases = ["foo:*"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeWildcard { ref attr, ref wildcard }
@@ -436,7 +447,7 @@ mod tests {
     fn parses_attribute_missing_query() {
         let cases = ["_missing_:foo", "_missing_:\"foo\""];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeMissing { ref attr }
@@ -452,7 +463,7 @@ mod tests {
     fn parses_attribute_missing_query_with_escapes() {
         let cases = ["_missing_:foo\\ bar"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeMissing { ref attr }
@@ -468,7 +479,7 @@ mod tests {
     fn parses_match_all_docs_query() {
         let cases = ["*:*", "*", "_default_:*", "foo:(*:*)"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res, QueryNode::MatchAllDocs),
                 "Failed to parse '{:?}' as MatchAllDocs, got {:?}",
@@ -482,7 +493,7 @@ mod tests {
     fn parses_all_as_wildcard() {
         let cases = ["_all:*"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res,
                 QueryNode::AttributeWildcard { ref attr, ref wildcard }
@@ -504,7 +515,7 @@ mod tests {
             "foo:(NOT *:*)",
         ];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             assert!(
                 matches!(res, QueryNode::MatchNoDocs),
                 "Failed to parse '{:?}' as MatchNoDocs, got {:?}",
@@ -518,7 +529,7 @@ mod tests {
     fn parses_boolean_nodes_with_implicit_operators() {
         let cases = ["foo:bar baz:qux quux:quuz"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::Boolean {
                 oper: BooleanType::And,
                 ref nodes,
@@ -547,7 +558,7 @@ mod tests {
             "-foo:bar baz:qux -quux:quuz",
         ];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::Boolean {
                 oper: BooleanType::And,
                 ref nodes,
@@ -571,7 +582,7 @@ mod tests {
     fn parses_boolean_nodes_with_explicit_operators() {
         let cases = ["foo:bar OR baz:qux AND quux:quuz"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::Boolean {
                 oper: BooleanType::And,
                 ref nodes,
@@ -594,7 +605,7 @@ mod tests {
     fn parses_boolean_nodes_with_implicit_and_explicit_operators() {
         let cases = ["foo:bar OR baz:qux quux:quuz"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::Boolean {
                 oper: BooleanType::And,
                 ref nodes,
@@ -616,7 +627,7 @@ mod tests {
     fn parses_nested_boolean_query_node() {
         let cases = ["foo:bar (baz:qux quux:quuz)"];
         for query in cases.iter() {
-            let res = parse(query).unwrap_or_else(|_| panic!("Unable to parse query {:?}", query));
+            let res = parse(query);
             if let QueryNode::Boolean {
                 oper: BooleanType::And,
                 ref nodes,

--- a/src/datadog/search/parser.rs
+++ b/src/datadog/search/parser.rs
@@ -35,7 +35,7 @@ mod tests {
 
     fn parse(s: &str) -> QueryNode {
         s.parse()
-            .unwrap_or_else(|_| panic!("Unable to parse {s:?}."))
+            .unwrap_or_else(|error| panic!("Unable to parse {s:?}: {error}."))
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,3 @@ pub use datadog::grok as datadog_grok;
 
 #[cfg(feature = "datadog_search")]
 pub use datadog::search as datadog_search_syntax;
-
-#[cfg(feature = "datadog_search")]
-#[macro_use]
-extern crate pest_derive;

--- a/src/stdlib/match_datadog_query.rs
+++ b/src/stdlib/match_datadog_query.rs
@@ -6,7 +6,7 @@ use crate::datadog_filter::{
     regex::{wildcard_regex, word_regex},
     Filter, Matcher, Resolver, Run,
 };
-use crate::datadog_search_syntax::{parse, Comparison, ComparisonValue, Field};
+use crate::datadog_search_syntax::{Comparison, ComparisonValue, Field, ParseError, QueryNode};
 use crate::owned_value_path;
 use crate::path::{parse_value_path, OwnedValuePath};
 
@@ -58,7 +58,7 @@ impl Function for MatchDatadogQuery {
             .expect("datadog search query should be a UTF8 string");
 
         // Compile the Datadog search query to AST.
-        let node = parse(&query).map_err(|e| {
+        let node: QueryNode = query.parse().map_err(|e: ParseError| {
             Box::new(ExpressionError::from(e.to_string())) as Box<dyn DiagnosticMessage>
         })?;
 


### PR DESCRIPTION
The `FromStr` interface is a standard in Rust for parsing strings into some
other type, and can then be used through the `str::parse<T>` which is
implemented for all `T` that implement `FromStr`. Most of the lines changed in
this PR come from rewriting tests to use the different interface.