### PR TITLE
chore(datadog search): Allow use of `QueryNode` in configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ string_path = []
 datadog = ["datadog_filter", "datadog_grok", "datadog_search"]
 datadog_filter = ["datadog_search", "dep:regex", "dep:dyn-clone"]
 datadog_grok = ["value", "parsing", "dep:nom", "dep:peeking_take_while", "dep:serde_json", "dep:onig", "dep:lalrpop-util", "dep:thiserror", "dep:chrono", "dep:chrono-tz", "dep:percent-encoding"]
-datadog_search = ["dep:pest", "dep:pest_derive", "dep:itertools", "dep:once_cell", "dep:regex"]
+datadog_search = ["dep:pest", "dep:pest_derive", "dep:itertools", "dep:once_cell", "dep:regex", "dep:serde"]
 
 # Features that aren't used as often (default off)
 cli = ["stdlib", "dep:serde_json", "dep:thiserror", "dep:clap", "dep:exitcode", "dep:webbrowser", "dep:rustyline", "dep:prettytable-rs"]

--- a/src/datadog/search/node.rs
+++ b/src/datadog/search/node.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::grammar::{unescape, DEFAULT_FIELD};
 
@@ -341,6 +342,29 @@ impl QueryNode {
         } else {
             format!("{}:", attr)
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for QueryNode {
+    fn deserialize<D>(deserializer: D) -> Result<QueryNode, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let s = String::deserialize(deserializer)?;
+
+        s.parse::<QueryNode>()
+            .map_err(|e| D::Error::custom(e.to_string()))
+    }
+}
+
+impl Serialize for QueryNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_lucene().as_str())
     }
 }
 


### PR DESCRIPTION
This adds support for serde serialization and deserialization for queries via their string representation, allowing them to be used directly in configurations without storing them in an intermediate `String`.