### PR TITLE
chore(deps): Relax constraint on indexmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ hex = { version = "0.4", optional = true }
 hmac = { version = "0.12", optional = true }
 iana-time-zone = { version = "0.1", optional = true }
 idna = { version = "0.5", optional = true }
-indexmap = { version = "~2.4.0", default-features = false, features = ["std"], optional = true}
+indexmap = { version = "2", default-features = false, features = ["std"], optional = true}
 influxdb-line-protocol = { version = "2.0.0", optional = true }
 indoc = {version = "2", optional = true }
 itertools = { version = "0.13", default-features = false, optional = true }


### PR DESCRIPTION
I can't find a reason this needs to be restricted and it is prohibiting upgrades of indexmap in Vector.