### PR TITLE
fix(stdlib): make nullable timestamp and tags fields in `parse_influxdb` function

### DIFF
--- a/changelog.d/1011.fix.md
+++ b/changelog.d/1011.fix.md
@@ -1,0 +1,4 @@
+For the `parse_influxdb` function the `timestamp` and `tags` fields of returned objects are now
+correctly marked as nullable.
+
+authors: jorgehermo9

--- a/src/stdlib/parse_influxdb.rs
+++ b/src/stdlib/parse_influxdb.rs
@@ -240,7 +240,7 @@ impl FunctionExpression for ParseInfluxDBFn {
 }
 
 fn tags_kind() -> Kind {
-    Kind::object(Collection::from_unknown(Kind::bytes()))
+    Kind::object(Collection::from_unknown(Kind::bytes())) | Kind::null()
 }
 
 fn gauge_kind() -> Kind {
@@ -253,7 +253,7 @@ fn metric_kind() -> BTreeMap<Field, Kind> {
     btreemap! {
         "name" => Kind::bytes(),
         "tags" => tags_kind(),
-        "timestamp" => Kind::timestamp(),
+        "timestamp" => Kind::timestamp() | Kind::null(),
         "kind" => Kind::bytes(),
         "gauge" => gauge_kind(),
     }
@@ -276,7 +276,7 @@ mod test {
         parse_influxdb => ParseInfluxDB;
 
         influxdb_valid {
-            args: func_args![ value: format!("cpu,host=A,region=us-west usage_system=64i,usage_user=10u,temperature=50.5,on=true,sleep=false 1590488773254420000") ],
+            args: func_args![ value: "cpu,host=A,region=us-west usage_system=64i,usage_user=10u,temperature=50.5,on=true,sleep=false 1590488773254420000" ],
             want: Ok(Value::from(vec![
                 Value::from(btreemap! {
                     "name" => "cpu_usage_system",
@@ -373,7 +373,7 @@ mod test {
         }
 
         influxdb_valid_no_tags {
-            args: func_args![ value: format!("cpu usage_system=64i,usage_user=10i 1590488773254420000") ],
+            args: func_args![ value: "cpu usage_system=64i,usage_user=10i 1590488773254420000" ],
             want: Ok(Value::from(vec![
                 Value::from(btreemap! {
                     "name" => "cpu_usage_system",


### PR DESCRIPTION
Noticed that in `parse_influxdb` typedef it is not reflected that the `timestamp` and `tags` fields are nullable and may be missing when parsing.

Didn't add a changelog for this fix since I don't know how the typedef really affects the end user (and because that function is not really released yet)