### PR TITLE
chore(ci): Validate `cargo-deny` output in CI and check license compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,14 @@ jobs:
       - name: "Check that the MSRV is up to date"
         run: ./scripts/check_msrv.sh
 
+  check-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: "Check that the 3rd-party license file is up to date"
+        run: ./scripts/check_deny.sh
+
   wasm32-unknown-unknown:
     runs-on: ubuntu-latest
     steps:

--- a/deny.toml
+++ b/deny.toml
@@ -1,22 +1,30 @@
 [licenses]
+default = "deny"
+copyleft = "deny"
 allow = [
-  "MIT",
-  "CC0-1.0",
-  "ISC",
-  "OpenSSL",
-  "Unicode-3.0",
-  "Unlicense",
+  "0BSD",
+  "Apache-2.0 WITH LLVM-exception",
+  "Apache-2.0",
   "BSD-2-Clause",
   "BSD-3-Clause",
-  "Apache-2.0",
-  "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "OpenSSL",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "Unlicense",
   "Zlib",
 ]
 
-unlicensed = "warn"
-default = "warn"
-
 private = { ignore = true }
+
+exceptions = [
+    # MPL-2.0 are added case-by-case to make sure we are in compliance. To be in
+    # compliance we cannot be modifying the source files.
+    { allow = ["MPL-2.0"], name = "vrl", version = "*" },
+]
 
 [[licenses.clarify]]
 name = "ring"
@@ -24,4 +32,12 @@ version = "*"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[advisories]
+ignore = [
+    # ansi_term is Unmaintained
+    # Only used when test_framework feature is enabled for tests
+    # TODO: We should swap this out for a maintained library
+    "RUSTSEC-2021-0139"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,4 @@
 [licenses]
-default = "deny"
-copyleft = "deny"
 allow = [
   "0BSD",
   "Apache-2.0 WITH LLVM-exception",

--- a/scripts/check_deny.sh
+++ b/scripts/check_deny.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if ! cargo install --list | grep -q "cargo-deny v0.16.1"; then
+    echo "Install cargo-deny"
+    cargo install cargo-deny --version 0.16.1 --force --locked
+fi
+
+echo "Check deny"
+cargo deny --log-level error --all-features check all


### PR DESCRIPTION
This PR checks license compatibility using `cargo-deny` (updating the configuration) and also adds it as a CI check.