### PR TITLE
fix(datadog grok): enable the DOTALL mode by default

### DIFF
--- a/changelog.d/1022.breaking.md
+++ b/changelog.d/1022.breaking.md
@@ -1,0 +1,2 @@
+The `parse_groks` VRL function has the multiline mode enabled by default.
+Use the `(?-m)` modifier to disable this behaviour.

--- a/changelog.d/1022.breaking.md
+++ b/changelog.d/1022.breaking.md
@@ -1,2 +1,2 @@
-The `parse_groks` VRL function has the multiline mode enabled by default.
+The multi-line mode of the `parse_groks` VRL function is now enabled by default.
 Use the `(?-m)` modifier to disable this behaviour.

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -1021,7 +1021,7 @@ mod tests {
     #[test]
     fn parses_with_new_lines() {
         test_full_grok(vec![
-            // multi-line mode is enabled by default
+            // multiline mode is enabled by default
             (
                 "%{data:field}",
                 "a\nb",

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -1021,9 +1021,17 @@ mod tests {
     #[test]
     fn parses_with_new_lines() {
         test_full_grok(vec![
-            // multiline mode is enabled by default
+            // the DOTALL mode is enabled by default
             (
                 "%{data:field}",
+                "a\nb",
+                Ok(Value::from(btreemap! {
+                    "field" => "a\nb"
+                })),
+            ),
+            // (?s) enables the DOTALL mode
+            (
+                "(?s)%{data:field}",
                 "a\nb",
                 Ok(Value::from(btreemap! {
                     "field" => "a\nb"
@@ -1037,17 +1045,9 @@ mod tests {
                     "line2" => "b"
                 })),
             ),
-            // (?s) is not supported by the underlying regex engine(onig) - it uses (?m) instead, so we convert it silently
-            (
-                "(?s)%{data:field}",
-                "a\nb",
-                Ok(Value::from(btreemap! {
-                    "field" => "a\nb"
-                })),
-            ),
-            // disable DOTALL mode with (?-s)
+            // disable the DOTALL mode with (?-s)
             ("(?s)(?-s)%{data:field}", "a\nb", Err(Error::NoMatch)),
-            // disable and then enable DOTALL mode
+            // disable and then enable the DOTALL mode
             (
                 "(?-s)%{data:field} (?s)%{data:field}",
                 "abc d\ne",

--- a/src/datadog/grok/parse_grok_rules.rs
+++ b/src/datadog/grok/parse_grok_rules.rs
@@ -180,9 +180,13 @@ fn parse_pattern(
         // as opposed to the (?s) modifier in other regex flavors.
         // \A, \z - parses from the beginning to the end of string, not line(until \n)
         r"(?m)\A", // (?m) enables the DOTALL mode by default
-        &context.regex.replace("(?s)", "(?m)").replace("(?-s)", "(?-m)"),
+        &context
+            .regex
+            .replace("(?s)", "(?m)")
+            .replace("(?-s)", "(?-m)"),
         r"\z",
-    ].concat();
+    ]
+    .concat();
 
     // compile pattern
     let pattern = grok

--- a/src/datadog/grok/parse_grok_rules.rs
+++ b/src/datadog/grok/parse_grok_rules.rs
@@ -176,12 +176,13 @@ fn parse_pattern(
 ) -> Result<GrokRule, Error> {
     parse_grok_rule(pattern, context)?;
     let mut pattern = String::new();
+    // In Oniguruma the (?m) modifier is used to enable the DOTALL mode(dot includes newlines),
+    // as opposed to the (?s) modifier in other regex flavors.
     // \A, \z - parses from the beginning to the end of string, not line(until \n)
-    pattern.push_str(r"(?m)\A"); // (?m) enables multiline mode
+    pattern.push_str(r"(?m)\A"); // (?m) enables the DOTALL mode by default
     pattern.push_str(&context.regex);
     pattern.push_str(r"\z");
 
-    // our regex engine(onig) uses (?m) mode modifier instead of (?s) to make the dot match all characters
     pattern = pattern.replace("(?s)", "(?m)").replace("(?-s)", "(?-m)");
 
     // compile pattern

--- a/src/datadog/grok/parse_grok_rules.rs
+++ b/src/datadog/grok/parse_grok_rules.rs
@@ -177,7 +177,7 @@ fn parse_pattern(
     parse_grok_rule(pattern, context)?;
     let mut pattern = String::new();
     // \A, \z - parses from the beginning to the end of string, not line(until \n)
-    pattern.push_str(r"\A");
+    pattern.push_str(r"(?m)\A"); // (?m) enables multiline mode
     pattern.push_str(&context.regex);
     pattern.push_str(r"\z");
 

--- a/src/datadog/grok/parse_grok_rules.rs
+++ b/src/datadog/grok/parse_grok_rules.rs
@@ -175,15 +175,14 @@ fn parse_pattern(
     grok: &mut Grok,
 ) -> Result<GrokRule, Error> {
     parse_grok_rule(pattern, context)?;
-    let mut pattern = String::new();
-    // In Oniguruma the (?m) modifier is used to enable the DOTALL mode(dot includes newlines),
-    // as opposed to the (?s) modifier in other regex flavors.
-    // \A, \z - parses from the beginning to the end of string, not line(until \n)
-    pattern.push_str(r"(?m)\A"); // (?m) enables the DOTALL mode by default
-    pattern.push_str(&context.regex);
-    pattern.push_str(r"\z");
-
-    pattern = pattern.replace("(?s)", "(?m)").replace("(?-s)", "(?-m)");
+    let pattern = [
+        // In Oniguruma the (?m) modifier is used to enable the DOTALL mode(dot includes newlines),
+        // as opposed to the (?s) modifier in other regex flavors.
+        // \A, \z - parses from the beginning to the end of string, not line(until \n)
+        r"(?m)\A", // (?m) enables the DOTALL mode by default
+        &context.regex.replace("(?s)", "(?m)").replace("(?-s)", "(?-m)"),
+        r"\z",
+    ].concat();
 
     // compile pattern
     let pattern = grok

--- a/src/stdlib/parse_groks.rs
+++ b/src/stdlib/parse_groks.rs
@@ -264,7 +264,7 @@ mod test {
         invalid_grok {
             args: func_args![ value: "foo",
                               patterns: vec!["%{NOG}"]],
-            want: Err("failed to parse grok expression '\\A%{NOG}\\z': The given pattern definition name \"NOG\" could not be found in the definition map"),
+            want: Err("failed to parse grok expression '(?m)\\A%{NOG}\\z': The given pattern definition name \"NOG\" could not be found in the definition map"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 


### PR DESCRIPTION
Enables the DOTALL mode(dot includes \n) for the Datadog grok lib by default.