### PR TITLE
chore(benches): remove redundant required features from some benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,12 +242,10 @@ lalrpop = { version = "0.20", default-features = false }
 [[bench]]
 name = "kind"
 harness = false
-required-features = ["default", "test"]
 
 [[bench]]
 name = "keyvalue"
 harness = false
-required-features = ["default", "test"]
 
 [[bench]]
 name = "stdlib"


### PR DESCRIPTION
Note that `stdlib.rs` benches require extra features and will not run with `cargo bench`. To run all benches, we can use `cargo bench --features="default test"`.