### PR TITLE
fix(datadog grok): support multiline logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.4",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3509,7 @@ dependencies = [
  "domain",
  "dyn-clone",
  "exitcode",
+ "fancy-regex",
  "flate2",
  "grok",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/vectordotdev/vrl"
 readme = "README.md"
 keywords = ["vector", "datadog", "compiler"]
 categories = ["compilers"]
-rust-version = "1.78" # msrv
+rust-version = "1.79" # msrv
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ string_path = []
 # Datadog related features (on by default)
 datadog = ["datadog_filter", "datadog_grok", "datadog_search"]
 datadog_filter = ["datadog_search", "dep:regex", "dep:dyn-clone"]
-datadog_grok = ["value", "parsing", "dep:nom", "dep:peeking_take_while", "dep:serde_json", "dep:onig", "dep:lalrpop-util", "dep:thiserror", "dep:chrono", "dep:chrono-tz", "dep:percent-encoding"]
+datadog_grok = ["value", "parsing", "dep:nom", "dep:peeking_take_while", "dep:serde_json", "dep:onig", "dep:lalrpop-util", "dep:thiserror", "dep:chrono", "dep:chrono-tz", "dep:percent-encoding", "dep:fancy-regex"]
 datadog_search = ["dep:pest", "dep:pest_derive", "dep:itertools", "dep:once_cell", "dep:regex", "dep:serde"]
 
 # Features that aren't used as often (default off)
@@ -173,6 +173,7 @@ rust_decimal = { version = "1", optional = true }
 seahash = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
+fancy-regex = { version = "0.13.0", default-features = false, optional = true }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -23,6 +23,8 @@ base16,https://github.com/thomcc/rust-base16,CC0-1.0,Thom Chiovoloni <tchiovolon
 base62,https://github.com/fbernier/base62,MIT,"François Bernier <frankbernier@gmail.com>, Chai T. Rex <ChaiTRex@users.noreply.github.com>, Kevin Darlington <kevin@outroot.com>, Christopher Tarquini <code@tarq.io>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
+bit-set,https://github.com/contain-rs/bit-set,MIT OR Apache-2.0,Alexis Beingessner <a.beingessner@gmail.com>
+bit-vec,https://github.com/contain-rs/bit-vec,MIT OR Apache-2.0,Alexis Beingessner <a.beingessner@gmail.com>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 bitvec,https://github.com/bitvecto-rs/bitvec,MIT,The bitvec Authors
 block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
@@ -85,6 +87,7 @@ error-code,https://github.com/DoumanAsh/error-code,BSL-1.0,Douman <douman@gmx.se
 event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 event-listener-strategy,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
 exitcode,https://github.com/benwilber/exitcode,Apache-2.0,Ben Wilber <benwilber@gmail.com>
+fancy-regex,https://github.com/fancy-regex/fancy-regex,MIT,"Raph Levien <raph@google.com>, Robin Stocker <robin@nibor.org>"
 flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>"
 funty,https://github.com/myrrlyn/funty,MIT,myrrlyn <self@myrrlyn.dev>
 futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors

--- a/benches/keyvalue.rs
+++ b/benches/keyvalue.rs
@@ -20,7 +20,7 @@ fn apply_filter_bench(c: &mut Criterion) {
                 let value = Value::Bytes(Bytes::from("key=valueStr"));
                 let filter = KeyValueFilter {
                     key_value_delimiter: "=".into(),
-                    value_re: Regex::new(r"^[\w.\-_@]+").unwrap(),
+                    re_pattern: Regex::new(r"^[\w.\-_@]+").unwrap(),
                     quotes: vec![('"', '"'), ('\'', '\''), ('<', '>')],
                     field_delimiters: [" ", ",", ";"]
                         .iter()
@@ -42,7 +42,7 @@ fn apply_filter_bench(c: &mut Criterion) {
                 let value = Value::Bytes(Bytes::from("key1=value1|key2=value2"));
                 let filter = KeyValueFilter {
                     key_value_delimiter: "=".into(),
-                    value_re: Regex::new(r"^[\w.\-_@]+").unwrap(),
+                    re_pattern: Regex::new(r"^[\w.\-_@]+").unwrap(),
                     quotes: vec![('"', '"'), ('\'', '\''), ('<', '>')],
                     field_delimiters: ["|"]
                         .iter()

--- a/changelog.d/1015.enhancement.md
+++ b/changelog.d/1015.enhancement.md
@@ -1,0 +1,1 @@
+The `keyvalue` grok filter is extended to match Datadog implementation.

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -117,10 +117,8 @@ fn regex_from_config(
     quotes: Vec<(char, char)>,
     _field_delimiters: (String, String),
 ) -> Result<Regex, GrokStaticError> {
-    let mut quoting = String::new();
-
     // start group
-    quoting.push('(');
+    let mut quoting = String::from("(");
     // add quotes with OR
     for (left, right) in quotes {
         quoting.push_str(&regex::escape(&left.to_string()));

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -191,7 +191,19 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
                     || matches!(&value, Value::Bytes(b) if b.is_empty())
                     || key.is_empty())
                 {
-                    result.insert(crate::path!(key), value);
+                    let path = crate::path!(key);
+                    match result.get(path).cloned() {
+                        Some(Value::Array(mut values)) => {
+                            values.push(value);
+                            result.insert(path, values);
+                        }
+                        Some(prev) => {
+                            result.insert(path, Value::Array(vec![prev, value]));
+                        }
+                        None => {
+                            result.insert(path, value);
+                        }
+                    };
                 }
                 }
             });

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -120,12 +120,13 @@ fn regex_from_config(
     let mut quoting = String::from("(");
     // add quotes with OR
     for (left, right) in quotes {
-        quoting.push_str(&regex::escape(&left.to_string()));
-        quoting.push_str("[^");
-        quoting.push_str(&regex::escape(&left.to_string()));
-        quoting.push_str("]+");
-        quoting.push_str(&regex::escape(&right.to_string()));
-        quoting.push('|');
+        quoting.extend([
+            &regex::escape(&left.to_string()),
+            "[^",
+            &regex::escape(&left.to_string()),
+            "]+",
+            &regex::escape(&right.to_string()),
+            "|"]);
     }
 
     quoting.push('[');

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -80,10 +80,11 @@ pub fn filter_from_function(f: &Function) -> Result<GrokFilter, GrokStaticError>
         let field_delimiters = if args_len > 3 {
             match f.args.as_ref().unwrap()[3] {
                 FunctionArgument::Arg(Value::Bytes(ref bytes)) => {
-                    let delimiter = String::from_utf8_lossy(bytes).to_string();
-                    match (&delimiter[..1], &delimiter[1..]) {
-                        (left, right) if !right.is_empty() => (left.to_string(), right.to_string()),
-                        (single, "") => (single.to_string(), single.to_string()),
+                    let delimiter_str = String::from_utf8_lossy(bytes);
+                    let mut delimiter_chars = delimiter_str.chars();
+                    match (delimiter_chars.next(), delimiter_chars.as_str()) {
+                        (Some(left), right) if !right.is_empty() => (left.to_string(), right.to_string()),
+                        (Some(single), "") => (single.to_string(), single.to_string()),
                         _ => return Err(GrokStaticError::InvalidFunctionArguments(f.name.clone())),
                     }
                 }

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -183,31 +183,30 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
                 .captures_iter(value.as_ref())
                 .for_each(|c| {
                     let key = parse_key(extract_capture(&c, 1), filter.quotes.as_slice());
-                    if key.contains(' ') {
-                        return;
-                    }
-                    let value = extract_capture(&c, 2);
-                    // trim trailing comma for value
-                    let value = value.trim_end_matches(|c| c == ',');
+                    if !key.contains(' ') {
+                        let value = extract_capture(&c, 2);
+                        // trim trailing comma for value
+                        let value = value.trim_end_matches(|c| c == ',');
 
-                    if let Ok((_, value)) = parse_value(value, filter.quotes.as_slice()) {
-                        if !(value.is_null()
-                            || matches!(&value, Value::Bytes(b) if b.is_empty())
-                            || key.is_empty())
-                        {
-                            let path = crate::path!(key);
-                            match result.get(path).cloned() {
-                                Some(Value::Array(mut values)) => {
-                                    values.push(value);
-                                    result.insert(path, values);
-                                }
-                                Some(prev) => {
-                                    result.insert(path, Value::Array(vec![prev, value]));
-                                }
-                                None => {
-                                    result.insert(path, value);
-                                }
-                            };
+                        if let Ok((_, value)) = parse_value(value, filter.quotes.as_slice()) {
+                            if !(value.is_null()
+                                || matches!(&value, Value::Bytes(b) if b.is_empty())
+                                || key.is_empty())
+                            {
+                                let path = crate::path!(key);
+                                match result.get(path).cloned() {
+                                    Some(Value::Array(mut values)) => {
+                                        values.push(value);
+                                        result.insert(path, values);
+                                    }
+                                    Some(prev) => {
+                                        result.insert(path, Value::Array(vec![prev, value]));
+                                    }
+                                    None => {
+                                        result.insert(path, value);
+                                    }
+                                };
+                            }
                         }
                     }
                 });

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -131,26 +131,25 @@ fn regex_from_config(
 
     quoting.push('[');
 
-    let mut keyvalue = String::from("(?<=[");
-    keyvalue.push_str(&_field_delimiters.0);
-    keyvalue.push_str("]|^)");
-
-    // key
-    keyvalue.push_str(quoting.as_str());
-    keyvalue.push_str(&value_re);
-    keyvalue.push_str("]+)");
-
-    // delimiter
-    keyvalue.push_str(key_value_delimiter);
-
-    // value
-    keyvalue.push_str(quoting.as_str());
-    keyvalue.push_str(&value_re);
-    keyvalue.push_str("]+)");
-
-    keyvalue.push_str("(?:[");
-    keyvalue.push_str(&_field_delimiters.1);
-    keyvalue.push_str("]|$)");
+    let keyvalue = [
+        "(?<=[",
+        &_field_delimiters.0,
+        "]|^)",
+        // key
+        quoting.as_str(),
+        &value_re,
+        "]+)",
+        // delimiter
+        key_value_delimiter,
+        // value
+        quoting.as_str(),
+        &value_re,
+        "]+)",
+        "(?:[",
+        &_field_delimiters.1,
+        "]|$)",
+    ]
+        .concat();
 
     Regex::new(keyvalue.as_str())
         .map_err(|_e| GrokStaticError::InvalidFunctionArguments("keyvalue".to_string()))

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -15,6 +15,7 @@ use nom::{
     sequence::{delimited, terminated},
     IResult, Parser,
 };
+use nom::error::ErrorKind;
 use onig::EncodedChars;
 use ordered_float::NotNan;
 
@@ -296,13 +297,18 @@ fn parse_number(input: &str) -> SResult<Value> {
         nom::Err::Failure(_) => nom::Err::Error((input, nom::error::ErrorKind::Float)),
         e => e,
     });
+    validate_octal_number(input, res)
+}
+
+/// Checks if it is a valid octal number(start with 0) - keep parsed as a decimal though.
+fn validate_octal_number<'a>(input: &'a str, res: Result<(&'a str, Value), nom::Err<(&'a str, ErrorKind)>>) -> SResult<'a, Value> {
     match res {
-        // check if it is a valid octal number(start with 0) - keep parsed as a decimal though
+
         Ok((_, Value::Integer(_)))
-            if input.starts_with('0') && input.contains(|c| c == '8' || c == '9') =>
-        {
-            Err(nom::Err::Error((input, nom::error::ErrorKind::OctDigit)))
-        }
+        if input.starts_with('0') && input.contains(|c| c == '8' || c == '9') =>
+            {
+                Err(nom::Err::Error((input, nom::error::ErrorKind::OctDigit)))
+            }
         res => res,
     }
 }

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -46,9 +46,7 @@ pub fn filter_from_function(f: &Function) -> Result<GrokFilter, GrokStaticError>
         let value_re = if args_len > 1 {
             match f.args.as_ref().unwrap()[1] {
                 FunctionArgument::Arg(Value::Bytes(ref bytes)) => {
-                    let mut re_str = String::from(DEFAULT_VALUE_RE);
-                    re_str.push_str(&String::from_utf8_lossy(bytes));
-                    re_str
+                    [DEFAULT_VALUE_RE, &String::from_utf8_lossy(bytes)].concat()
                 }
                 _ => return Err(GrokStaticError::InvalidFunctionArguments(f.name.clone())),
             }

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -182,33 +182,7 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
                 .re_pattern
                 .captures_iter(value.as_ref())
                 .for_each(|c| {
-                    let key = parse_key(extract_capture(&c, 1), filter.quotes.as_slice());
-                    if !key.contains(' ') {
-                        let value = extract_capture(&c, 2);
-                        // trim trailing comma for value
-                        let value = value.trim_end_matches(|c| c == ',');
-
-                        if let Ok((_, value)) = parse_value(value, filter.quotes.as_slice()) {
-                            if !(value.is_null()
-                                || matches!(&value, Value::Bytes(b) if b.is_empty())
-                                || key.is_empty())
-                            {
-                                let path = crate::path!(key);
-                                match result.get(path).cloned() {
-                                    Some(Value::Array(mut values)) => {
-                                        values.push(value);
-                                        result.insert(path, values);
-                                    }
-                                    Some(prev) => {
-                                        result.insert(path, Value::Array(vec![prev, value]));
-                                    }
-                                    None => {
-                                        result.insert(path, value);
-                                    }
-                                };
-                            }
-                        }
-                    }
+                    parse_key_value_capture(filter, &mut result, c);
                 });
             Ok(result)
         }
@@ -216,6 +190,36 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
             filter.to_string(),
             value.to_string(),
         )),
+    }
+}
+
+fn parse_key_value_capture(filter: &KeyValueFilter, result: &mut Value, c: Result<Captures, fancy_regex::Error>) {
+    let key = parse_key(extract_capture(&c, 1), filter.quotes.as_slice());
+    if !key.contains(' ') {
+        let value = extract_capture(&c, 2);
+        // trim trailing comma for value
+        let value = value.trim_end_matches(|c| c == ',');
+
+        if let Ok((_, value)) = parse_value(value, filter.quotes.as_slice()) {
+            if !(value.is_null()
+                || matches!(&value, Value::Bytes(b) if b.is_empty())
+                || key.is_empty())
+            {
+                let path = crate::path!(key);
+                match result.get(path).cloned() {
+                    Some(Value::Array(mut values)) => {
+                        values.push(value);
+                        result.insert(path, values);
+                    }
+                    Some(prev) => {
+                        result.insert(path, Value::Array(vec![prev, value]));
+                    }
+                    None => {
+                        result.insert(path, value);
+                    }
+                };
+            }
+        }
     }
 }
 

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -226,7 +226,8 @@ fn extract_capture<'a>(c: &'a Result<Captures<'a>, fancy_regex::Error>, i: usize
     c.as_ref()
         .map(|c| c.get(i).map(|m| m.as_str()))
         .unwrap_or_default()
-        .unwrap_or_default().trim()
+        .unwrap_or_default()
+        .trim()
 }
 
 type SResult<'a, O> = IResult<&'a str, O, (&'a str, nom::error::ErrorKind)>;
@@ -322,7 +323,6 @@ fn parse_key<'a>(input: &'a str, quotes: &'a [(char, char)]) -> &'a str {
     quoted(quotes)(input)
         .map(|(_, key)| key)
         .unwrap_or_else(|_| input)
-
 }
 
 #[cfg(test)]

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -264,7 +264,7 @@ fn parse_value<'a>(input: &'a str, quotes: &'a[(char, char)]) -> SResult<'a, Val
         parse_null,
         parse_boolean,
         parse_number,
-        quoted(quotes).and_then(alt((parse_number, parse_string))),
+        quoted(quotes).and_then(parse_string),
         parse_string,
     ))(input)
 }
@@ -274,7 +274,7 @@ fn parse_string(input: &str) -> SResult<Value> {
 }
 
 fn parse_number(input: &str) -> SResult<Value> {
-    map(terminated(double, eof), |v| {
+    let res = map(terminated(double, eof), |v| {
         if ((v as i64) as f64 - v).abs() == 0.0 {
             // can be safely converted to Integer without precision loss
             Value::Integer(v as i64)
@@ -282,11 +282,18 @@ fn parse_number(input: &str) -> SResult<Value> {
             Value::Float(NotNan::new(v).expect("not a float"))
         }
     })(input)
-    .map_err(|e| match e {
-        // double might return Failure(an unrecoverable error) - make it recoverable
-        nom::Err::Failure(_) => nom::Err::Error((input, nom::error::ErrorKind::Float)),
-        e => e,
-    })
+        .map_err(|e| match e {
+            // double might return Failure(an unrecoverable error) - make it recoverable
+            nom::Err::Failure(_) => nom::Err::Error((input, nom::error::ErrorKind::Float)),
+            e => e,
+        });
+    match res {
+        // check if it is a valid octal number(start with 0) - keep parsed as a decimal though
+        Ok((_, Value::Integer(_))) if input.starts_with('0') && input.contains(|c| c == '8' || c == '9') => {
+            Err(nom::Err::Error((input, nom::error::ErrorKind::OctDigit)))
+        }
+        res => res,
+    }
 }
 
 fn parse_null(input: &str) -> SResult<Value> {

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -182,6 +182,9 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
             let value = String::from_utf8_lossy(bytes);
             filter.re_pattern.captures_iter(value.as_ref()).for_each(|c| {
                 let key = parse_key(extract_capture(&c, 1), filter.quotes.as_slice());
+                if key.contains(' ') {
+                    return;
+                }
                 let value = extract_capture(&c, 2);
                 // trim trailing comma for value
                 let value = value.trim_end_matches(|c| c == ',');

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -983,6 +983,12 @@ mod tests {
                     "a" => "foo"
                 })),
             ),
+            // ignore if key contains spaces
+            (
+                r#"%{data::keyvalue("="," ")}"#,
+                "a key=value",
+                Ok(Value::from(btreemap! {})),
+            ),
         ]);
     }
 

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -967,11 +967,20 @@ mod tests {
                     "server" => "localhost",
                 })),
             ),
+            // append values with the same key
             (
                 r#"%{data::keyvalue}"#,
                 r#"a=1, a=1, a=2"#,
                 Ok(Value::from(btreemap! {
                     "a" => vec![1, 1, 2]
+                })),
+            ),
+            // trim string values
+            (
+                r#"%{data::keyvalue("="," ")}"#,
+                r#"a= foo"#,
+                Ok(Value::from(btreemap! {
+                    "a" => "foo"
                 })),
             ),
         ]);

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -254,8 +254,10 @@ mod tests {
 
     fn test_grok_pattern(tests: Vec<(&str, &str, Result<Value, Error>)>) {
         for (filter, k, v) in tests {
-            let rules = parse_grok_rules(&[filter.to_string()], BTreeMap::new())
-                .unwrap_or_else(|error| panic!("failed to parse {k} with filter {filter}: {error}"));
+            let rules =
+                parse_grok_rules(&[filter.to_string()], BTreeMap::new()).unwrap_or_else(|error| {
+                    panic!("failed to parse {k} with filter {filter}: {error}")
+                });
             let parsed = parse_grok(k, &rules);
 
             if v.is_ok() {

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -255,7 +255,7 @@ mod tests {
     fn test_grok_pattern(tests: Vec<(&str, &str, Result<Value, Error>)>) {
         for (filter, k, v) in tests {
             let rules = parse_grok_rules(&[filter.to_string()], BTreeMap::new())
-                .expect(&format!("failed ot parse {k} with filter {filter}"));
+                .unwrap_or_else(|_| panic!("failed to parse {k} with filter {filter}"));
             let parsed = parse_grok(k, &rules);
 
             if v.is_ok() {
@@ -275,7 +275,7 @@ mod tests {
     fn test_full_grok(tests: Vec<(&str, &str, Result<Value, Error>)>) {
         for (filter, k, v) in tests {
             let rules = parse_grok_rules(&[filter.to_string()], BTreeMap::new())
-                .expect(&format!("failed to parse {k} with filter {filter}"));
+                .unwrap_or_else(|_| panic!("failed to parse {k} with filter {filter}"));
             let parsed = parse_grok(k, &rules);
 
             assert_eq!(parsed, v, "failed to parse {k} with filter {filter}");

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -140,7 +140,6 @@ mod tests {
     use crate::value::Value;
     use chrono::{Datelike, NaiveDate, Timelike, Utc};
     use ordered_float::NotNan;
-    // use ordered_float::NotNan;
     use tracing_test::traced_test;
 
     use super::super::parse_grok_rules::parse_grok_rules;
@@ -966,6 +965,13 @@ mod tests {
                     "host" => "174.138.82.103",
                     "request" => "HEAD http://174.138.82.103:80/sql/sql-admin/ HTTP/1.1",
                     "server" => "localhost",
+                })),
+            ),
+            (
+                r#"%{data::keyvalue}"#,
+                r#"a=1, a=1, a=2"#,
+                Ok(Value::from(btreemap! {
+                    "a" => vec![1, 1, 2]
                 })),
             ),
         ]);

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -989,6 +989,22 @@ mod tests {
                 "a key=value",
                 Ok(Value::from(btreemap! {})),
             ),
+            // parses valid octal numbers (start with 0) as decimals
+            (
+                r#"%{data::keyvalue}"#,
+                "a=07",
+                Ok(Value::from(btreemap! {
+                    "a" => 7
+                })),
+            ),
+            // parses invalid octal numbers (start with 0) as strings
+            (
+                r#"%{data::keyvalue}"#,
+                "a=08",
+                Ok(Value::from(btreemap! {
+                    "a" => "08"
+                })),
+            ),
         ]);
     }
 

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -255,7 +255,7 @@ mod tests {
     fn test_grok_pattern(tests: Vec<(&str, &str, Result<Value, Error>)>) {
         for (filter, k, v) in tests {
             let rules = parse_grok_rules(&[filter.to_string()], BTreeMap::new())
-                .unwrap_or_else(|_| panic!("failed to parse {k} with filter {filter}"));
+                .unwrap_or_else(|error| panic!("failed to parse {k} with filter {filter}: {error}"));
             let parsed = parse_grok(k, &rules);
 
             if v.is_ok() {

--- a/src/datadog/grok/patterns/core.pattern
+++ b/src/datadog/grok/patterns/core.pattern
@@ -13,7 +13,7 @@ qs %{quotedString}
 uuid [A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}
 
 notSpace \S+
-data .*?
+data .*
 greedyData .*
 space \s+
 


### PR DESCRIPTION
Enables parsing multiline logs with `parse_groks` VRL function and Datadog grok lib.