### PR TITLE
fix(parse_ruby_hash): drop initial colon in key parsing

### DIFF
--- a/changelog.d/1050.fix.md
+++ b/changelog.d/1050.fix.md
@@ -1,0 +1,1 @@
+The `parse_ruby_hash` parser is extended to match Datadog implementation. Previously it would parse the key in `{:key => "value"}` as `:key`, now it will parse it as `key`.

--- a/src/parsing/ruby_hash.rs
+++ b/src/parsing/ruby_hash.rs
@@ -117,7 +117,7 @@ fn parse_colon_key<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
             char(':'),
             alt((parse_str('"'), parse_str('\''), parse_symbol_key)),
         ),
-        |res| res.into(),
+        KeyString::from,
     )(input)
 }
 

--- a/src/parsing/ruby_hash.rs
+++ b/src/parsing/ruby_hash.rs
@@ -117,7 +117,7 @@ fn parse_colon_key<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
             char(':'),
             alt((parse_str('"'), parse_str('\''), parse_symbol_key)),
         ),
-        |res| (String::from(":") + res).into(),
+        |res| res.into(),
     )(input)
 }
 
@@ -215,13 +215,24 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_symbol_value() {
-        let result = parse_ruby_hash(r#"{ "key" => :foo }"#).unwrap();
+    fn test_parse_symbol_key() {
+        let result = parse_ruby_hash(r#"{ :key => "foo", :number => 500 }"#).unwrap();
         assert!(result.is_object());
         let result = result.as_object().unwrap();
         let value = result.get("key").unwrap();
         assert!(value.is_bytes());
-        assert_eq!(value.as_bytes().unwrap(), ":foo");
+        assert_eq!(value.as_bytes().unwrap(), "foo");
+        assert!(result.get("number").unwrap().is_float());
+    }
+
+    #[test]
+    fn test_parse_symbol_colon_separator() {
+        let result = parse_ruby_hash(r#"{ key: "foo" }"#).unwrap();
+        assert!(result.is_object());
+        let result = result.as_object().unwrap();
+        let value = result.get("key").unwrap();
+        assert!(value.is_bytes());
+        assert_eq!(value.as_bytes().unwrap(), "foo");
     }
 
     #[test]
@@ -257,9 +268,9 @@ mod tests {
         .unwrap();
         assert!(result.is_object());
         let result = result.as_object().unwrap();
-        assert!(result.get(":colon").unwrap().is_bytes());
-        assert!(result.get(":double").unwrap().is_bytes());
-        assert!(result.get(":simple").unwrap().is_bytes());
+        assert!(result.get("colon").unwrap().is_bytes());
+        assert!(result.get("double").unwrap().is_bytes());
+        assert!(result.get("simple").unwrap().is_bytes());
     }
 
     #[test]
@@ -267,7 +278,7 @@ mod tests {
         let result = parse_ruby_hash(r#"{ :with_underscore => "hello world" }"#).unwrap();
         assert!(result.is_object());
         let result = result.as_object().unwrap();
-        assert!(result.get(":with_underscore").unwrap().is_bytes());
+        assert!(result.get("with_underscore").unwrap().is_bytes());
     }
 
     #[test]
@@ -320,7 +331,7 @@ mod tests {
             parse_ruby_hash(r#"{:hello=>"world",'number'=>42,"weird"=>'format\'here'}"#).unwrap();
         assert!(result.is_object());
         let result = result.as_object().unwrap();
-        assert!(result.get(":hello").unwrap().is_bytes());
+        assert!(result.get("hello").unwrap().is_bytes());
         assert!(result.get("number").unwrap().is_float());
     }
 

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "proptest"))]
 use proptest::prelude::*;
+use proptest_derive::Arbitrary;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +13,7 @@ use super::{parse_target_path, parse_value_path, BorrowedSegment, PathParseError
 use crate::value::KeyString;
 
 /// A lookup path.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 #[serde(try_from = "String", into = "String")]
 pub struct OwnedValuePath {
     pub segments: Vec<OwnedSegment>,

--- a/src/path/owned.rs
+++ b/src/path/owned.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "proptest"))]
 use proptest::prelude::*;
-use proptest_derive::Arbitrary;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,7 @@ use super::{parse_target_path, parse_value_path, BorrowedSegment, PathParseError
 use crate::value::KeyString;
 
 /// A lookup path.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct OwnedValuePath {
     pub segments: Vec<OwnedSegment>,


### PR DESCRIPTION
This makes a fix to the `parse_ruby_hash` parser to align more with the Datadog [implementation](https://docs.datadoghq.com/service_management/events/pipelines_and_processors/grok_parser/?tab=filters#matcher-and-filter). Specifically if there's a colon within the key, the parser will drop it instead of retaining it as before.
