### PR TITLE
chore(deps): remove prost-derive dep by turning on the 'derive' feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.46",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ cfb-mode = { version = "0.8", optional = true }
 ofb = { version = "0.6", optional = true }
 
 # Protobuf support.
-prost = { version = "0.13", default-features = false, optional = true, features = ["std"]}
+prost = { version = "0.13", default-features = false, optional = true, features = ["std", "derive"]}
 prost-reflect = { version = "0.14", default-features = false, optional = true}
 
 # Dependencies used for non-WASM


### PR DESCRIPTION
It is recommended [here](https://github.com/tokio-rs/prost/blob/master/prost/Cargo.toml#L21) to enable the `derive` feature. 