### PR TITLE
chore(ast): Allow all `parser::ast` nodes to be built publically

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -538,6 +538,15 @@ impl IntoIterator for Array {
     }
 }
 
+impl FromIterator<Node<Expr>> for Array {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Node<Expr>>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
 // -----------------------------------------------------------------------------
 // object
 // -----------------------------------------------------------------------------
@@ -577,6 +586,15 @@ impl IntoIterator for Object {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl FromIterator<(Node<String>, Node<Expr>)> for Object {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (Node<String>, Node<Expr>)>,
+    {
+        Self(iter.into_iter().collect())
     }
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1185,6 +1185,11 @@ impl Not {
     pub fn take(self) -> (Node<()>, Box<Node<Expr>>) {
         (self.0, self.1)
     }
+
+    #[must_use]
+    pub fn new(span: Span, expr: Node<Expr>) -> Self {
+        Self(Node::new(span, ()), Box::new(expr))
+    }
 }
 
 impl fmt::Display for Not {


### PR DESCRIPTION
- **Allow ast::Array and ast::Object to be built publicly**
- **Allow ast::Not nodes to be built publicly**

## Summary

In order to make extra tooling around VRL (mostly to be able to add preprocessing tooling on top of existing language features), it would be nice to be able to build all AST node types outside the crate.

Most of the nodes can be built, except those three, so I assume it’s fine to add support there. I do not know why the inner elements were made private for these, so instead of making those public, I added the "obvious" general constructors I could think of for them.

Regards,
Gerry
