### PR TITLE
enhancement(punycode): improve performance for already coded cases

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -321,8 +321,18 @@ bench_function! {
         want: Ok("www.café.com"),
     }
 
+    encoded_no_validation {
+        args: func_args![value: "www.xn--caf-dma.com", validate: false],
+        want: Ok("www.café.com"),
+    }
+
     non_encoded {
         args: func_args![value: "www.cafe.com"],
+        want: Ok("www.cafe.com"),
+    }
+
+    non_encoded_no_validation {
+        args: func_args![value: "www.cafe.com", validate: false],
         want: Ok("www.cafe.com"),
     }
 }
@@ -477,8 +487,18 @@ bench_function! {
         want: Ok("www.xn--caf-dma.com"),
     }
 
+    idn_no_validation {
+        args: func_args![value: "www.CAFé.com", validate: false],
+        want: Ok("www.xn--caf-dma.com"),
+    }
+
     ascii {
         args: func_args![value: "www.cafe.com"],
+        want: Ok("www.cafe.com"),
+    }
+
+    ascii_no_validation {
+        args: func_args![value: "www.cafe.com", validate: false],
         want: Ok("www.cafe.com"),
     }
 }

--- a/changelog.d/1104.enhancement.md
+++ b/changelog.d/1104.enhancement.md
@@ -1,0 +1,1 @@
+`decode_punycode` and `encode_punycode` with `validate` flag set to false should be faster now, in cases when input data needs no encoding or decoding.

--- a/src/stdlib/decode_punycode.rs
+++ b/src/stdlib/decode_punycode.rs
@@ -71,6 +71,10 @@ impl FunctionExpression for DecodePunycodeFn {
         let value = self.value.resolve(ctx)?;
         let string = value.try_bytes_utf8_lossy()?;
 
+        if !string.contains(PUNYCODE_PREFIX) {
+            return Ok(string.into());
+        }
+
         let validate = self.validate.resolve(ctx)?.try_boolean()?;
 
         if validate {

--- a/src/stdlib/encode_punycode.rs
+++ b/src/stdlib/encode_punycode.rs
@@ -83,6 +83,10 @@ impl FunctionExpression for EncodePunycodeFn {
                 .map_err(|errors| format!("unable to encode to punycode: {errors}"))?;
             Ok(encoded.into())
         } else {
+            if string.is_ascii() {
+                return Ok(string.into());
+            }
+
             let encoded = string
                 .split('.')
                 .map(|part| {


### PR DESCRIPTION
This adds additional benchmarks for `encode_punycode` and `decode_punycode`, which demonstrate lower performance of these functions when `validate` flag is set to false. That is because without validation, a quick manual encoding / decoding is done, but it does not check beforehand if it is required at all.

This adds these checks for both encoding and decoding (and does so in case of decoding even when `validate` flag is `true`), which shows a big speedup in the benchmark for `validate: false` and a minor speedup for decoding with `validate: true`.

---
>Sponsored by [Quad9](https://quad9.net/)