### PR TITLE
fix(convert): return error when conversion exceeds f64 bounds

### DIFF
--- a/changelog.d/1107.breaking.md
+++ b/changelog.d/1107.breaking.md
@@ -1,0 +1,1 @@
+Fixes the `to_float` function to return an error instead of `f64::INFINITY` when parsing [non-normal](https://doc.rust-lang.org/std/primitive.f64.html#method.is_normal) numbers.

--- a/src/compiler/conversion/mod.rs
+++ b/src/compiler/conversion/mod.rs
@@ -159,6 +159,11 @@ impl Conversion {
                 let parsed = s
                     .parse::<f64>()
                     .with_context(|_| FloatParseSnafu { s: s.clone() })?;
+                if !parsed.is_normal() {
+                    return Err(Error::NanFloat {
+                        s: format!("Invalid float \"{s}\": not a normal f64 number"),
+                    });
+                }
                 let f = NotNan::new(parsed).map_err(|_| Error::NanFloat { s: s.to_string() })?;
                 f.into()
             }

--- a/src/compiler/conversion/tests/mod.rs
+++ b/src/compiler/conversion/tests/mod.rs
@@ -2,7 +2,8 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use ordered_float::NotNan;
 
-use crate::compiler::conversion::parse_bool;
+use crate::compiler::conversion::{parse_bool, Conversion, Error};
+use crate::compiler::TimeZone;
 
 #[cfg(unix)] // see https://github.com/vectordotdev/vector/issues/1201
 mod unix;
@@ -90,4 +91,35 @@ fn parse_bool_errors() {
     assert!(parse_bool("X").is_err());
     assert!(parse_bool("yes or no").is_err());
     assert!(parse_bool("123.4").is_err());
+}
+
+fn convert_float(input: impl ToString) -> Result<StubValue, Error> {
+    let input = input.to_string();
+    let converter = Conversion::parse("float", TimeZone::Local).expect("float conversion");
+    converter.convert::<StubValue>(input.into())
+}
+
+#[test]
+fn convert_float_ok() {
+    let max_float = format!("17976931348623157{}", "0".repeat(292));
+    let min_float = format!("-{max_float}");
+
+    assert_eq!(convert_float(max_float), Ok(StubValue::Float(f64::MAX)));
+    assert_eq!(convert_float("1"), Ok(StubValue::Float(1.0)));
+    assert_eq!(convert_float("1.23"), Ok(StubValue::Float(1.23)));
+    assert_eq!(convert_float("-1"), Ok(StubValue::Float(-1.0)));
+    assert_eq!(convert_float("-1.23"), Ok(StubValue::Float(-1.23)));
+    assert_eq!(convert_float(min_float), Ok(StubValue::Float(f64::MIN)));
+}
+
+#[test]
+fn convert_float_errors() {
+    let exceeds_max_float = format!("17976931348623159{}", "0".repeat(292)); // last number inc by 2
+    let exceeds_min_float = format!("-{exceeds_max_float}");
+
+    assert!(convert_float("abc").is_err());
+    assert!(convert_float("1.23.4").is_err());
+    assert!(convert_float(exceeds_max_float).is_err());
+    assert!(convert_float(exceeds_min_float).is_err());
+    assert!(convert_float("0.0").is_err());
 }


### PR DESCRIPTION
Prior to this commit, string values that would exceed the f64 bounds would return `f64::INFINITY`. This leaks a type into the VRL scripts that could cause a panic without support to check for the value.

Fixes #1107

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
