### PR TITLE
chore(parse_groks): expose internal errors

### DIFF
--- a/changelog.d/1113.breaking.md
+++ b/changelog.d/1113.breaking.md
@@ -1,0 +1,5 @@
+Currently if a grok filter as part of a `parse_groks` operation fails to apply due to an error against the input, the error is not surfaced and the field the filter applies to is not parsed, leading to data loss.
+
+This fix corrects that to surface errors while applying the grok filters.
+
+Existing parse_grok rules may need to be adjusted in order to correct filter queries that are now correctly surfaced as errors.

--- a/changelog.d/1113.breaking.md
+++ b/changelog.d/1113.breaking.md
@@ -1,5 +1,0 @@
-Currently if a grok filter as part of a `parse_groks` operation fails to apply due to an error against the input, the error is not surfaced and the field the filter applies to is not parsed, leading to data loss.
-
-This fix corrects that to surface errors while applying the grok filters.
-
-Existing parse_grok rules may need to be adjusted in order to correct filter queries that are now correctly surfaced as errors.

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -21,7 +21,7 @@ use ordered_float::NotNan;
 use super::super::{
     ast::{Function, FunctionArgument},
     grok_filter::GrokFilter,
-    parse_grok::Error as GrokRuntimeError,
+    parse_grok::RecoverableGrokError,
     parse_grok_rules::Error as GrokStaticError,
 };
 
@@ -166,7 +166,7 @@ pub fn regex_from_config(
 }
 
 impl KeyValueFilter {
-    pub fn apply_filter(&self, value: &Value) -> Result<Value, GrokRuntimeError> {
+    pub fn apply_filter(&self, value: &Value) -> Result<Value, RecoverableGrokError> {
         match value {
             Value::Bytes(bytes) => {
                 let mut result = Value::Object(BTreeMap::default());
@@ -176,7 +176,7 @@ impl KeyValueFilter {
                 });
                 Ok(result)
             }
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
+            _ => Err(RecoverableGrokError::FailedToApplyFilter(
                 self.to_string(),
                 value.to_string(),
             )),

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -21,7 +21,7 @@ use ordered_float::NotNan;
 use super::super::{
     ast::{Function, FunctionArgument},
     grok_filter::GrokFilter,
-    parse_grok::RecoverableGrokError,
+    parse_grok::InternalError,
     parse_grok_rules::Error as GrokStaticError,
 };
 
@@ -166,7 +166,7 @@ pub fn regex_from_config(
 }
 
 impl KeyValueFilter {
-    pub fn apply_filter(&self, value: &Value) -> Result<Value, RecoverableGrokError> {
+    pub fn apply_filter(&self, value: &Value) -> Result<Value, InternalError> {
         match value {
             Value::Bytes(bytes) => {
                 let mut result = Value::Object(BTreeMap::default());
@@ -176,7 +176,7 @@ impl KeyValueFilter {
                 });
                 Ok(result)
             }
-            _ => Err(RecoverableGrokError::FailedToApplyFilter(
+            _ => Err(InternalError::FailedToApplyFilter(
                 self.to_string(),
                 value.to_string(),
             )),

--- a/src/datadog/grok/grok.rs
+++ b/src/datadog/grok/grok.rs
@@ -12,7 +12,7 @@ use std::collections::{btree_map, BTreeMap};
 use std::panic;
 use std::sync::Arc;
 
-use super::parse_grok::FatalGrokError;
+use super::parse_grok::FatalError;
 
 use onig::{Captures, Regex};
 use thiserror::Error;
@@ -110,17 +110,14 @@ impl Pattern {
 
     /// Matches this compiled `Pattern` against the text and returns the matches.
     #[inline]
-    pub fn match_against<'a>(
-        &'a self,
-        text: &'a str,
-    ) -> Result<Option<Matches<'a>>, FatalGrokError> {
+    pub fn match_against<'a>(&'a self, text: &'a str) -> Result<Option<Matches<'a>>, FatalError> {
         let result = panic::catch_unwind(|| self.regex.captures(text));
 
         match result {
             Ok(Some(cap)) => Ok(Some(Matches::new(cap, &self.names))),
             Ok(None) => Ok(None),
             // https://github.com/rust-onig/rust-onig/issues/178
-            Err(_) => Err(FatalGrokError::RegexEngineError),
+            Err(_) => Err(FatalError::RegexEngineError),
         }
     }
 }

--- a/src/datadog/grok/grok.rs
+++ b/src/datadog/grok/grok.rs
@@ -12,7 +12,7 @@ use std::collections::{btree_map, BTreeMap};
 use std::panic;
 use std::sync::Arc;
 
-use super::parse_grok::Error as GrokRuntimeError;
+use super::parse_grok::FatalGrokError;
 
 use onig::{Captures, Regex};
 use thiserror::Error;
@@ -113,16 +113,14 @@ impl Pattern {
     pub fn match_against<'a>(
         &'a self,
         text: &'a str,
-    ) -> Result<Option<Matches<'a>>, GrokRuntimeError> {
+    ) -> Result<Option<Matches<'a>>, FatalGrokError> {
         let result = panic::catch_unwind(|| self.regex.captures(text));
 
         match result {
             Ok(Some(cap)) => Ok(Some(Matches::new(cap, &self.names))),
             Ok(None) => Ok(None),
             // https://github.com/rust-onig/rust-onig/issues/178
-            Err(_) => Err(GrokRuntimeError::FailedToMatch(
-                "Regex search error in the underlying engine".into(),
-            )),
+            Err(_) => Err(FatalGrokError::RegexEngineError),
         }
     }
 }

--- a/src/datadog/grok/grok_filter.rs
+++ b/src/datadog/grok/grok_filter.rs
@@ -12,7 +12,7 @@ use super::{
     ast::{Function, FunctionArgument},
     filters::{array, keyvalue, keyvalue::KeyValueFilter},
     matchers::date::{apply_date_filter, DateFilter},
-    parse_grok::Error as GrokRuntimeError,
+    parse_grok::RecoverableGrokError,
     parse_grok_rules::Error as GrokStaticError,
 };
 
@@ -119,16 +119,16 @@ impl TryFrom<&Function> for GrokFilter {
 
 /// Applies a given Grok filter to the value and returns the result or error.
 /// For detailed description and examples of specific filters check out https://docs.datadoghq.com/logs/log_configuration/parsing/?tab=filters
-pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRuntimeError> {
+pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, RecoverableGrokError> {
     match filter {
         GrokFilter::Integer => match value {
             Value::Bytes(v) => Ok(String::from_utf8_lossy(v)
                 .parse::<i64>()
                 .map_err(|_e| {
-                    GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                    RecoverableGrokError::FailedToApplyFilter(filter.to_string(), value.to_string())
                 })?
                 .into()),
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
+            _ => Err(RecoverableGrokError::FailedToApplyFilter(
                 filter.to_string(),
                 value.to_string(),
             )),
@@ -137,10 +137,10 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
             Value::Bytes(v) => Ok(String::from_utf8_lossy(v)
                 .parse::<f64>()
                 .map_err(|_e| {
-                    GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                    RecoverableGrokError::FailedToApplyFilter(filter.to_string(), value.to_string())
                 })
                 .map(|f| (f as i64).into())?),
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
+            _ => Err(RecoverableGrokError::FailedToApplyFilter(
                 filter.to_string(),
                 value.to_string(),
             )),
@@ -149,7 +149,10 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
             Value::Bytes(v) => {
                 let v = Ok(Value::from_f64_or_zero(
                     String::from_utf8_lossy(v).parse::<f64>().map_err(|_e| {
-                        GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                        RecoverableGrokError::FailedToApplyFilter(
+                            filter.to_string(),
+                            value.to_string(),
+                        )
                     })?,
                 ));
                 match v {
@@ -159,7 +162,7 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
                     _ => v,
                 }
             }
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
+            _ => Err(RecoverableGrokError::FailedToApplyFilter(
                 filter.to_string(),
                 value.to_string(),
             )),
@@ -175,11 +178,14 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
                 )),
                 Value::Bytes(v) => {
                     let v = String::from_utf8_lossy(v).parse::<f64>().map_err(|_e| {
-                        GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                        RecoverableGrokError::FailedToApplyFilter(
+                            filter.to_string(),
+                            value.to_string(),
+                        )
                     })?;
                     Ok(Value::Float(NotNan::new(v * scale_factor).expect("NaN")))
                 }
-                _ => Err(GrokRuntimeError::FailedToApplyFilter(
+                _ => Err(RecoverableGrokError::FailedToApplyFilter(
                     filter.to_string(),
                     value.to_string(),
                 )),
@@ -233,7 +239,7 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
                     Ok(value.to_owned())
                 }
             }
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
+            _ => Err(RecoverableGrokError::FailedToApplyFilter(
                 filter.to_string(),
                 value.to_string(),
             )),
@@ -249,7 +255,7 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
                 delimiter.as_ref().map(|s| s.as_str()),
             )
             .map_err(|_e| {
-                GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                RecoverableGrokError::FailedToApplyFilter(filter.to_string(), value.to_string())
             })
             .and_then(|values| {
                 if let Some(value_filter) = value_filter.as_ref() {
@@ -262,7 +268,7 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
                 }
                 Ok(values.into())
             }),
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
+            _ => Err(RecoverableGrokError::FailedToApplyFilter(
                 filter.to_string(),
                 value.to_string(),
             )),
@@ -274,10 +280,10 @@ fn parse_value<V: Into<Value>>(
     value: &Value,
     filter: &GrokFilter,
     parse: impl Fn(&Bytes) -> V,
-) -> Result<Value, GrokRuntimeError> {
+) -> Result<Value, RecoverableGrokError> {
     match value {
         Value::Bytes(bytes) => Ok(parse(bytes).into()),
-        _ => Err(GrokRuntimeError::FailedToApplyFilter(
+        _ => Err(RecoverableGrokError::FailedToApplyFilter(
             filter.to_string(),
             value.to_string(),
         )),
@@ -288,14 +294,14 @@ fn parse_value_error_prone<V: Into<Value>, E: std::error::Error>(
     value: &Value,
     filter: &GrokFilter,
     parse: impl Fn(&Bytes) -> Result<V, E>,
-) -> Result<Value, GrokRuntimeError> {
+) -> Result<Value, RecoverableGrokError> {
     match value {
         Value::Bytes(bytes) => parse(bytes)
             .map_err(|_e| {
-                GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                RecoverableGrokError::FailedToApplyFilter(filter.to_string(), value.to_string())
             })
             .map(Into::into),
-        _ => Err(GrokRuntimeError::FailedToApplyFilter(
+        _ => Err(RecoverableGrokError::FailedToApplyFilter(
             filter.to_string(),
             value.to_string(),
         )),

--- a/src/datadog/grok/matchers/date.rs
+++ b/src/datadog/grok/matchers/date.rs
@@ -9,7 +9,7 @@ use peeking_take_while::PeekableExt;
 use regex::Regex;
 use tracing::warn;
 
-use super::super::parse_grok::RecoverableGrokError;
+use super::super::parse_grok::InternalError;
 
 /// converts Joda time format to strptime format
 pub fn convert_time_format(format: &str) -> Result<String, String> {
@@ -242,12 +242,9 @@ pub fn time_format_to_regex(format: &str, with_captures: bool) -> Result<RegexRe
     Ok(RegexResult { regex, with_tz })
 }
 
-pub fn apply_date_filter(
-    value: &Value,
-    filter: &DateFilter,
-) -> Result<Value, RecoverableGrokError> {
+pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, InternalError> {
     let original_value = String::from_utf8_lossy(value.as_bytes().ok_or_else(|| {
-        RecoverableGrokError::FailedToApplyFilter(filter.to_string(), value.to_string())
+        InternalError::FailedToApplyFilter(filter.to_string(), value.to_string())
     })?);
     let (strp_format, mut datetime) =
         adjust_strp_format_and_value(&filter.strp_format, &original_value);
@@ -267,16 +264,13 @@ pub fn apply_date_filter(
         let tz = tz.as_str();
         let tz: Tz = tz.parse().map_err(|error| {
             warn!(message = "Error parsing tz", tz = %tz, % error);
-            RecoverableGrokError::FailedToApplyFilter(
-                filter.to_string(),
-                original_value.to_string(),
-            )
+            InternalError::FailedToApplyFilter(filter.to_string(), original_value.to_string())
         })?;
         replace_sec_fraction_with_dot(filter, &mut datetime);
         let naive_date = NaiveDateTime::parse_from_str(&datetime, &strp_format).map_err(|error|
         {
             warn!(message = "Error parsing date", value = %original_value, format = %strp_format, % error);
-            RecoverableGrokError::FailedToApplyFilter(
+            InternalError::FailedToApplyFilter(
                 filter.to_string(),
                 original_value.to_string(),
             )
@@ -285,10 +279,7 @@ pub fn apply_date_filter(
             .from_local_datetime(&naive_date)
             .single()
             .ok_or_else(|| {
-                RecoverableGrokError::FailedToApplyFilter(
-                    filter.to_string(),
-                    original_value.to_string(),
-                )
+                InternalError::FailedToApplyFilter(filter.to_string(), original_value.to_string())
             })?;
         Ok(Value::from(
             Utc.from_utc_datetime(&dt.naive_utc()).timestamp_millis(),
@@ -299,10 +290,7 @@ pub fn apply_date_filter(
             // parse as a tz-aware complete date/time
             let timestamp = DateTime::parse_from_str(&datetime, &strp_format).map_err(|error| {
                 warn!(message = "Error parsing date", date = %original_value, % error);
-                RecoverableGrokError::FailedToApplyFilter(
-                    filter.to_string(),
-                    original_value.to_string(),
-                )
+                InternalError::FailedToApplyFilter(filter.to_string(), original_value.to_string())
             })?;
             Ok(Value::from(timestamp.to_utc().timestamp_millis()))
         } else if let Ok(dt) = NaiveDateTime::parse_from_str(&datetime, &strp_format) {
@@ -310,14 +298,14 @@ pub fn apply_date_filter(
             if let Some(tz) = &filter.target_tz {
                 let tzs = parse_timezone(tz).map_err(|error| {
                     warn!(message = "Error parsing tz", tz = %tz, % error);
-                    RecoverableGrokError::FailedToApplyFilter(
+                    InternalError::FailedToApplyFilter(
                         filter.to_string(),
                         original_value.to_string(),
                     )
                 })?;
                 let dt = tzs.from_local_datetime(&dt).single().ok_or_else(|| {
                     warn!(message = "Error parsing date", date = %original_value);
-                    RecoverableGrokError::FailedToApplyFilter(
+                    InternalError::FailedToApplyFilter(
                         filter.to_string(),
                         original_value.to_string(),
                     )
@@ -340,10 +328,7 @@ pub fn apply_date_filter(
             // try parsing as a naive date
             let nd = NaiveDate::parse_from_str(&datetime, &strp_format).map_err(|error| {
                 warn!(message = "Error parsing date", date = %original_value, % error);
-                RecoverableGrokError::FailedToApplyFilter(
-                    filter.to_string(),
-                    original_value.to_string(),
-                )
+                InternalError::FailedToApplyFilter(filter.to_string(), original_value.to_string())
             })?;
             let datetime_tz = UTC
                 .from_local_datetime(&NaiveDateTime::new(
@@ -353,7 +338,7 @@ pub fn apply_date_filter(
                 .single()
                 .ok_or_else(|| {
                     warn!(message = "Error parsing date", date = %original_value);
-                    RecoverableGrokError::FailedToApplyFilter(
+                    InternalError::FailedToApplyFilter(
                         filter.to_string(),
                         original_value.to_string(),
                     )

--- a/src/datadog/grok/matchers/date.rs
+++ b/src/datadog/grok/matchers/date.rs
@@ -9,7 +9,7 @@ use peeking_take_while::PeekableExt;
 use regex::Regex;
 use tracing::warn;
 
-use super::super::parse_grok::Error as GrokRuntimeError;
+use super::super::parse_grok::RecoverableGrokError;
 
 /// converts Joda time format to strptime format
 pub fn convert_time_format(format: &str) -> Result<String, String> {
@@ -242,9 +242,12 @@ pub fn time_format_to_regex(format: &str, with_captures: bool) -> Result<RegexRe
     Ok(RegexResult { regex, with_tz })
 }
 
-pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, GrokRuntimeError> {
+pub fn apply_date_filter(
+    value: &Value,
+    filter: &DateFilter,
+) -> Result<Value, RecoverableGrokError> {
     let original_value = String::from_utf8_lossy(value.as_bytes().ok_or_else(|| {
-        GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+        RecoverableGrokError::FailedToApplyFilter(filter.to_string(), value.to_string())
     })?);
     let (strp_format, mut datetime) =
         adjust_strp_format_and_value(&filter.strp_format, &original_value);
@@ -264,13 +267,16 @@ pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, Gr
         let tz = tz.as_str();
         let tz: Tz = tz.parse().map_err(|error| {
             warn!(message = "Error parsing tz", tz = %tz, % error);
-            GrokRuntimeError::FailedToApplyFilter(filter.to_string(), original_value.to_string())
+            RecoverableGrokError::FailedToApplyFilter(
+                filter.to_string(),
+                original_value.to_string(),
+            )
         })?;
         replace_sec_fraction_with_dot(filter, &mut datetime);
         let naive_date = NaiveDateTime::parse_from_str(&datetime, &strp_format).map_err(|error|
         {
             warn!(message = "Error parsing date", value = %original_value, format = %strp_format, % error);
-            GrokRuntimeError::FailedToApplyFilter(
+            RecoverableGrokError::FailedToApplyFilter(
                 filter.to_string(),
                 original_value.to_string(),
             )
@@ -279,7 +285,7 @@ pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, Gr
             .from_local_datetime(&naive_date)
             .single()
             .ok_or_else(|| {
-                GrokRuntimeError::FailedToApplyFilter(
+                RecoverableGrokError::FailedToApplyFilter(
                     filter.to_string(),
                     original_value.to_string(),
                 )
@@ -293,7 +299,7 @@ pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, Gr
             // parse as a tz-aware complete date/time
             let timestamp = DateTime::parse_from_str(&datetime, &strp_format).map_err(|error| {
                 warn!(message = "Error parsing date", date = %original_value, % error);
-                GrokRuntimeError::FailedToApplyFilter(
+                RecoverableGrokError::FailedToApplyFilter(
                     filter.to_string(),
                     original_value.to_string(),
                 )
@@ -304,14 +310,14 @@ pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, Gr
             if let Some(tz) = &filter.target_tz {
                 let tzs = parse_timezone(tz).map_err(|error| {
                     warn!(message = "Error parsing tz", tz = %tz, % error);
-                    GrokRuntimeError::FailedToApplyFilter(
+                    RecoverableGrokError::FailedToApplyFilter(
                         filter.to_string(),
                         original_value.to_string(),
                     )
                 })?;
                 let dt = tzs.from_local_datetime(&dt).single().ok_or_else(|| {
                     warn!(message = "Error parsing date", date = %original_value);
-                    GrokRuntimeError::FailedToApplyFilter(
+                    RecoverableGrokError::FailedToApplyFilter(
                         filter.to_string(),
                         original_value.to_string(),
                     )
@@ -334,7 +340,7 @@ pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, Gr
             // try parsing as a naive date
             let nd = NaiveDate::parse_from_str(&datetime, &strp_format).map_err(|error| {
                 warn!(message = "Error parsing date", date = %original_value, % error);
-                GrokRuntimeError::FailedToApplyFilter(
+                RecoverableGrokError::FailedToApplyFilter(
                     filter.to_string(),
                     original_value.to_string(),
                 )
@@ -347,7 +353,7 @@ pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, Gr
                 .single()
                 .ok_or_else(|| {
                     warn!(message = "Error parsing date", date = %original_value);
-                    GrokRuntimeError::FailedToApplyFilter(
+                    RecoverableGrokError::FailedToApplyFilter(
                         filter.to_string(),
                         original_value.to_string(),
                     )

--- a/src/stdlib/parse_groks.rs
+++ b/src/stdlib/parse_groks.rs
@@ -51,7 +51,8 @@ mod non_wasm {
             let bytes = value.try_bytes_utf8_lossy()?;
 
             let v = parse_grok::parse_grok(bytes.as_ref(), &self.grok_rules)
-                .map_err(|err| format!("unable to parse grok: {err}"))?;
+                .map_err(|err| format!("unable to parse grok: {err}"))?
+                .parsed;
 
             Ok(v)
         }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

`parse_grok` follows the Datadog Log's Grok algorithm's behavior where errors in applying filters are non fatal.
This change surfaces those filter errors to the caller, and differentiates between fatal and non fatal, as outlined by the Datadog Log's Grok algorithm, allowing the caller to decide whether to align with that or differ.

The stdlib `parse_groks` was unmodified, as such this is not a change to user facing behavior. If we decide to change that, we can do it in a follow up change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Added/corrected unit tests

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
