### PR TITLE
fix(encode_proto): When encoding strings into numeric proto fields, attempt to convert them automatically

### DIFF
--- a/changelog.d/11001.fix.md
+++ b/changelog.d/11001.fix.md
@@ -1,1 +1,0 @@
-The `encode_proto` function will now automatically convert string fields to numeric proto fields automatically.

--- a/changelog.d/11001.fix.md
+++ b/changelog.d/11001.fix.md
@@ -1,0 +1,1 @@
+The `encode_proto` function will now automatically convert string fields to numeric proto fields automatically.

--- a/changelog.d/1114.fix.md
+++ b/changelog.d/1114.fix.md
@@ -1,0 +1,1 @@
+The `encode_proto` function was enhanced to automatically convert valid string fields to numeric proto fields.


### PR DESCRIPTION

## Summary
Before this change, attempting to convert a VRL value that contained bytes into a numeric proto field would fail since we expect the VRL value to be numeric too. This PR makes `encode_proto` automatically convert those strings into numeric values automatically. We still fail if the format is not valid.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
