### PR TITLE
fix(punycode): make no validation punycode encoding more consistent

### DIFF
--- a/changelog.d/1115.fix.md
+++ b/changelog.d/1115.fix.md
@@ -1,0 +1,1 @@
+`encode_punycode` with `validate` flag set to false should be more consistent with `validate` set to true, turning all uppercase character to lowercase besides doing punycode encoding

--- a/src/stdlib/encode_punycode.rs
+++ b/src/stdlib/encode_punycode.rs
@@ -83,14 +83,21 @@ impl FunctionExpression for EncodePunycodeFn {
                 .map_err(|errors| format!("unable to encode to punycode: {errors}"))?;
             Ok(encoded.into())
         } else {
-            if string.is_ascii() {
+            if string
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.')
+            {
                 return Ok(string.into());
             }
 
             let encoded = string
                 .split('.')
                 .map(|part| {
-                    if part.starts_with(PUNYCODE_PREFIX) || part.is_ascii() {
+                    if part.starts_with(PUNYCODE_PREFIX)
+                        || part
+                            .chars()
+                            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+                    {
                         part.to_string()
                     } else {
                         format!(
@@ -131,8 +138,20 @@ mod test {
             tdef: TypeDef::bytes().fallible(),
         }
 
+        mixed_case_ignore_validation {
+            args: func_args![value: value!("www.CAFé.com"), validate: false],
+            want: Ok(value!("www.xn--caf-dma.com")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
         ascii_string {
             args: func_args![value: value!("www.cafe.com")],
+            want: Ok(value!("www.cafe.com")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        ascii_string_ignore_validation {
+            args: func_args![value: value!("www.cafe.com"), validate: false],
             want: Ok(value!("www.cafe.com")),
             tdef: TypeDef::bytes().fallible(),
         }

--- a/src/stdlib/encode_punycode.rs
+++ b/src/stdlib/encode_punycode.rs
@@ -93,17 +93,14 @@ impl FunctionExpression for EncodePunycodeFn {
             let encoded = string
                 .split('.')
                 .map(|part| {
-                    if part.starts_with(PUNYCODE_PREFIX)
-                        || part
-                            .chars()
-                            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
-                    {
-                        part.to_string()
+                    if part.starts_with(PUNYCODE_PREFIX) || part.chars().all(|c| c.is_ascii()) {
+                        part.to_lowercase()
                     } else {
                         format!(
                             "{}{}",
                             PUNYCODE_PREFIX,
-                            idna::punycode::encode_str(part).unwrap_or(part.to_string())
+                            idna::punycode::encode_str(&part.to_lowercase())
+                                .unwrap_or(part.to_lowercase())
                         )
                     }
                 })


### PR DESCRIPTION
`encode_punycode` with `validate: true` flag utilizes `idna` crate directly for encoding, which besides doing the punycode encoding, also normalizes the passed string by turning all characters into lowercase character. This changes checks done in `validate: false` branch of the code to be consistent with `idna` implementation and to do same normalization.

Related: #1104

---
>Sponsored by [Quad9](https://quad9.net/)