### PR TITLE
chore(performance): reduce regex capture calls in parse_grok date filter

### DIFF
--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -266,8 +266,6 @@ mod tests {
                 });
             let parsed = parse_grok(k, &rules);
 
-            // println!("parsed: {parsed:?}");
-
             if v.is_ok() {
                 assert_eq!(
                     parsed.unwrap_or_else(|_| panic!("{filter} does not match {k}")),

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -266,6 +266,8 @@ mod tests {
                 });
             let parsed = parse_grok(k, &rules);
 
+            // println!("parsed: {parsed:?}");
+
             if v.is_ok() {
                 assert_eq!(
                     parsed.unwrap_or_else(|_| panic!("{filter} does not match {k}")),

--- a/src/datadog/grok/parse_grok_rules.rs
+++ b/src/datadog/grok/parse_grok_rules.rs
@@ -399,6 +399,8 @@ fn resolves_match_function(
                             regex: filter_re,
                             target_tz,
                             tz_aware: result.with_tz,
+                            with_tz_capture: result.with_tz_capture,
+                            with_fraction_second: result.with_fraction_second,
                         });
                         // get the regex without captures, so that we can append it to the grok pattern
                         let grok_re = date::time_format_to_regex(&format, false)


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Used a profiler to analyze the performance of the parse_groks algorithm and discovered a large amount of time spent in date filter , even with simple dates.
Code inspection revealed we are invoking the regex engine with a Captures call in order to ascertain knowedge that we already have when building the regexes.

Solution is to add metadata when building the regexes to avoid having to do that.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Used a profiler to do A/B testing and saw a 53% improvement.

<img width="578" alt="Screenshot 2024-11-08 at 2 11 18 PM" src="https://github.com/user-attachments/assets/531c4ead-b39d-4830-bd2c-351aceeb83af">


## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
