### PR TITLE
enhancement: Implement PartialOrd for Value

### DIFF
--- a/changelog.d/1117.enhancement.md
+++ b/changelog.d/1117.enhancement.md
@@ -1,0 +1,3 @@
+`vrl::value::Value` now implements `PartialCmp` that first checks whether the enum discriminants
+(that both are floats for example), and if they are calls `partial_cmp` on the inner values.
+Otherwise, it will return `None`.


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Add `impl PartialOrd for Value`.

## Change Type

New feature.

## Is this a breaking change?

No.

## How did you test this PR?

Add unit test that calls `partial_cmp` with different values.
