### PR TITLE
fix(diagnostics): add 'set_semantic_meaning' to the side effects list

### DIFF
--- a/changelog.d/1148.fix.md
+++ b/changelog.d/1148.fix.md
@@ -1,0 +1,1 @@
+Removed false warning when using `set_semantic_meaning`.

--- a/src/compiler/unused_expression_checker.rs
+++ b/src/compiler/unused_expression_checker.rs
@@ -30,6 +30,9 @@ use crate::parser::{Literal, Program, Span};
 use std::collections::{BTreeMap, HashMap};
 use tracing::warn;
 
+const SIDE_EFFECT_FUNCTIONS: [&str; 5] =
+    ["del", "log", "assert", "assert_eq", "set_semantic_meaning"];
+
 #[must_use]
 pub fn check_for_unused_results(ast: &Program) -> DiagnosticList {
     let expression_visitor = AstVisitor { ast };
@@ -351,23 +354,19 @@ impl AstVisitor<'_> {
             state.mark_level_as_expecting_result();
         }
 
-        match function_call.ident.0.as_str() {
-            //  All bets are off for functions with side-effects.
-            "del" | "log" | "assert" | "assert_eq" => (),
-            _ => {
-                if let Some(closure) = &function_call.closure {
-                    for variable in &closure.variables {
-                        state.mark_identifier_pending_usage(&variable.node, &variable.span);
-                    }
-                    state.mark_level_as_expecting_result();
-                    self.visit_block(&closure.block, state);
-                    state.mark_level_as_not_expecting_result();
-                } else if state.is_unused() {
-                    state.append_diagnostic(
-                        format!("unused result for function call `{function_call}`"),
-                        span,
-                    );
+        if !SIDE_EFFECT_FUNCTIONS.contains(&function_call.ident.0.as_str()) {
+            if let Some(closure) = &function_call.closure {
+                for variable in &closure.variables {
+                    state.mark_identifier_pending_usage(&variable.node, &variable.span);
                 }
+                state.mark_level_as_expecting_result();
+                self.visit_block(&closure.block, state);
+                state.mark_level_as_not_expecting_result();
+            } else if state.is_unused() {
+                state.append_diagnostic(
+                    format!("unused result for function call `{function_call}`"),
+                    span,
+                );
             }
         }
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This modifies internal state and it's return value is always returns `null`. Should not expect result usage. 

This is true for all functions returning `null` so we could follow up with an enhancement to the unused expression detector.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->
Pointed Vector to this VRL branch and tested with:

```
sources:
  demo_logs:
    type: demo_logs
    format: json
transforms:
  remap:
    type: remap
    inputs: [demo_logs]
    source: |
      set_semantic_meaning(.foo, "a")
      .foo = "bar"
sinks:
  console:
    type: console
    inputs: [remap]
    encoding:
      codec: json

```




## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

- Closes: https://github.com/vectordotdev/vrl/issues/1149

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
