### PR TITLE
enhancement(stdlib): Allow `zip` function to take two array parameters

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2939,14 +2939,14 @@ bench_function! {
     zip => vrl::stdlib::Zip;
 
     one_parameter {
-        args: func_args![array0: value!([["one", "two", "three", "four"], ["one", 2, null, true]])],
+        args: func_args![array_0: value!([["one", "two", "three", "four"], ["one", 2, null, true]])],
         want: Ok(value!([["one","one"], ["two",2], ["three",null], ["four",true]])),
     }
 
     two_parameters {
         args: func_args![
-            array0: value!(["one", "two", "three", "four"]),
-            array1: value!(["one", 2, null, true]),
+            array_0: value!(["one", "two", "three", "four"]),
+            array_1: value!(["one", 2, null, true]),
         ],
         want: Ok(value!([["one","one"], ["two",2], ["three",null], ["four",true]])),
     }

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2938,8 +2938,16 @@ bench_function! {
 bench_function! {
     zip => vrl::stdlib::Zip;
 
-    default {
-        args: func_args![array: value!([["one", "two", "three", "four"], ["one", 2, null, true]])],
+    one_parameter {
+        args: func_args![array0: value!([["one", "two", "three", "four"], ["one", 2, null, true]])],
+        want: Ok(value!([["one","one"], ["two",2], ["three",null], ["four",true]])),
+    }
+
+    two_parameters {
+        args: func_args![
+            array0: value!(["one", "two", "three", "four"]),
+            array1: value!(["one", 2, null, true]),
+        ],
         want: Ok(value!([["one","one"], ["two",2], ["three",null], ["four",true]])),
     }
 }

--- a/src/stdlib/zip.rs
+++ b/src/stdlib/zip.rs
@@ -41,12 +41,12 @@ impl Function for Zip {
     fn parameters(&self) -> &'static [Parameter] {
         &[
             Parameter {
-                keyword: "array0",
+                keyword: "array_0",
                 kind: kind::ARRAY,
                 required: true,
             },
             Parameter {
-                keyword: "array1",
+                keyword: "array_1",
                 kind: kind::ARRAY,
                 required: false,
             },
@@ -74,24 +74,24 @@ impl Function for Zip {
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let array0 = arguments.required("array0");
-        let array1 = arguments.optional("array1");
-        Ok(ZipFn { array0, array1 }.as_expr())
+        let array_0 = arguments.required("array_0");
+        let array_1 = arguments.optional("array_1");
+        Ok(ZipFn { array_0, array_1 }.as_expr())
     }
 }
 
 #[derive(Debug, Clone)]
 struct ZipFn {
-    array0: Box<dyn Expression>,
-    array1: Option<Box<dyn Expression>>,
+    array_0: Box<dyn Expression>,
+    array_1: Option<Box<dyn Expression>>,
 }
 
 impl FunctionExpression for ZipFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let array0 = self.array0.resolve(ctx)?;
-        match &self.array1 {
-            None => zip_all(array0),
-            Some(array1) => zip2(array0, array1.resolve(ctx)?),
+        let array_0 = self.array_0.resolve(ctx)?;
+        match &self.array_1 {
+            None => zip_all(array_0),
+            Some(array_1) => zip2(array_0, array_1.resolve(ctx)?),
         }
     }
 
@@ -110,49 +110,49 @@ mod tests {
         zip => Zip;
 
         zips_two_arrays {
-            args: func_args![array0: value!([[1, 2, 3], [4, 5, 6]])],
+            args: func_args![array_0: value!([[1, 2, 3], [4, 5, 6]])],
             want: Ok(value!([[1, 4], [2, 5], [3, 6]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         zips_three_arrays {
-            args: func_args![array0: value!([[1, 2, 3], [4, 5, 6], [7, 8, 9]])],
+            args: func_args![array_0: value!([[1, 2, 3], [4, 5, 6], [7, 8, 9]])],
             want: Ok(value!([[1, 4, 7], [2, 5, 8], [3, 6, 9]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         zips_two_parameters {
-            args: func_args![array0: value!([1, 2, 3]), array1: value!([4, 5, 6])],
+            args: func_args![array_0: value!([1, 2, 3]), array_1: value!([4, 5, 6])],
             want: Ok(value!([[1, 4], [2, 5], [3, 6]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         uses_shortest_length1 {
-            args: func_args![array0: value!([[1, 2, 3], [4, 5]])],
+            args: func_args![array_0: value!([[1, 2, 3], [4, 5]])],
             want: Ok(value!([[1, 4], [2, 5]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         uses_shortest_length2 {
-            args: func_args![array0: value!([[1, 2], [4, 5, 6]])],
+            args: func_args![array_0: value!([[1, 2], [4, 5, 6]])],
             want: Ok(value!([[1, 4], [2, 5]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         requires_outer_array {
-            args: func_args![array0: 1],
+            args: func_args![array_0: 1],
             want: Err("expected array, got integer"),
             tdef: TypeDef::array(Collection::any()),
         }
 
         requires_inner_arrays1 {
-            args: func_args![array0: value!([true, []])],
+            args: func_args![array_0: value!([true, []])],
             want: Err("expected array, got boolean"),
             tdef: TypeDef::array(Collection::any()),
         }
 
         requires_inner_arrays2 {
-            args: func_args![array0: value!([[], null])],
+            args: func_args![array_0: value!([[], null])],
             want: Err("expected array, got null"),
             tdef: TypeDef::array(Collection::any()),
         }

--- a/src/stdlib/zip.rs
+++ b/src/stdlib/zip.rs
@@ -1,6 +1,15 @@
 use crate::compiler::prelude::*;
 
-fn zip(value: Value) -> Resolved {
+fn zip2(value0: Value, value1: Value) -> Resolved {
+    Ok(value0
+        .try_array()?
+        .into_iter()
+        .zip(value1.try_array()?.into_iter())
+        .map(|(v0, v1)| Value::Array(vec![v0, v1]))
+        .collect())
+}
+
+fn zip_all(value: Value) -> Resolved {
     Ok(MultiZip(
         value
             .try_array()?
@@ -30,19 +39,33 @@ impl Function for Zip {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "array",
-            kind: kind::ARRAY,
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "array0",
+                kind: kind::ARRAY,
+                required: true,
+            },
+            Parameter {
+                keyword: "array1",
+                kind: kind::ARRAY,
+                required: false,
+            },
+        ]
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "merge three arrays into an array of 3-tuples",
-            source: r#"zip([["a", "b", "c"], [1, null, true], [4, 5, 6]])"#,
-            result: Ok(r#"[["a", 1, 4], ["b", null, 5], ["c", true, 6]]"#),
-        }]
+        &[
+            Example {
+                title: "merge an array of three arrays into an array of 3-tuples",
+                source: r#"zip([["a", "b", "c"], [1, null, true], [4, 5, 6]])"#,
+                result: Ok(r#"[["a", 1, 4], ["b", null, 5], ["c", true, 6]]"#),
+            },
+            Example {
+                title: "merge two array parameters",
+                source: "zip([1, 2, 3, 4], [5, 6, 7])",
+                result: Ok("[[1, 5], [2, 6], [3, 7]]"),
+            },
+        ]
     }
 
     fn compile(
@@ -51,19 +74,25 @@ impl Function for Zip {
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let array = arguments.required("array");
-        Ok(ZipFn { array }.as_expr())
+        let array0 = arguments.required("array0");
+        let array1 = arguments.optional("array1");
+        Ok(ZipFn { array0, array1 }.as_expr())
     }
 }
 
 #[derive(Debug, Clone)]
 struct ZipFn {
-    array: Box<dyn Expression>,
+    array0: Box<dyn Expression>,
+    array1: Option<Box<dyn Expression>>,
 }
 
 impl FunctionExpression for ZipFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        zip(self.array.resolve(ctx)?)
+        let array0 = self.array0.resolve(ctx)?;
+        match &self.array1 {
+            None => zip_all(array0),
+            Some(array1) => zip2(array0, array1.resolve(ctx)?),
+        }
     }
 
     fn type_def(&self, _state: &TypeState) -> TypeDef {
@@ -81,43 +110,49 @@ mod tests {
         zip => Zip;
 
         zips_two_arrays {
-            args: func_args![array: value!([[1, 2, 3], [4, 5, 6]])],
+            args: func_args![array0: value!([[1, 2, 3], [4, 5, 6]])],
             want: Ok(value!([[1, 4], [2, 5], [3, 6]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         zips_three_arrays {
-            args: func_args![array: value!([[1, 2, 3], [4, 5, 6], [7, 8, 9]])],
+            args: func_args![array0: value!([[1, 2, 3], [4, 5, 6], [7, 8, 9]])],
             want: Ok(value!([[1, 4, 7], [2, 5, 8], [3, 6, 9]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
+        zips_two_parameters {
+            args: func_args![array0: value!([1, 2, 3]), array1: value!([4, 5, 6])],
+            want: Ok(value!([[1, 4], [2, 5], [3, 6]])),
+            tdef: TypeDef::array(Collection::any()),
+        }
+
         uses_shortest_length1 {
-            args: func_args![array: value!([[1, 2, 3], [4, 5]])],
+            args: func_args![array0: value!([[1, 2, 3], [4, 5]])],
             want: Ok(value!([[1, 4], [2, 5]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         uses_shortest_length2 {
-            args: func_args![array: value!([[1, 2], [4, 5, 6]])],
+            args: func_args![array0: value!([[1, 2], [4, 5, 6]])],
             want: Ok(value!([[1, 4], [2, 5]])),
             tdef: TypeDef::array(Collection::any()),
         }
 
         requires_outer_array {
-            args: func_args![array: 1],
+            args: func_args![array0: 1],
             want: Err("expected array, got integer"),
             tdef: TypeDef::array(Collection::any()),
         }
 
         requires_inner_arrays1 {
-            args: func_args![array: value!([true, []])],
+            args: func_args![array0: value!([true, []])],
             want: Err("expected array, got boolean"),
             tdef: TypeDef::array(Collection::any()),
         }
 
         requires_inner_arrays2 {
-            args: func_args![array: value!([[], null])],
+            args: func_args![array0: value!([[], null])],
             want: Err("expected array, got null"),
             tdef: TypeDef::array(Collection::any()),
         }

--- a/src/stdlib/zip.rs
+++ b/src/stdlib/zip.rs
@@ -4,7 +4,7 @@ fn zip2(value0: Value, value1: Value) -> Resolved {
     Ok(value0
         .try_array()?
         .into_iter()
-        .zip(value1.try_array()?.into_iter())
+        .zip(value1.try_array()?)
         .map(|(v0, v1)| Value::Array(vec![v0, v1]))
         .collect())
 }


### PR DESCRIPTION
The 2-parameter micro benchmark shows that this two-parameter mode runs 50% faster than a single array of two arrays.

## Summary

Enhance the `zip` function to take two forms: `zip([[foo], [bar]])` or `zip([foo], [bar])`. I plan to further enhance it to accept more parameters once this approach is ratified.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance
- [X] Enhancement of existing feature

## Is this a breaking change?

- [ ] Yes
- [X] No

## How did you test this PR?

Unit tests are included.

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

Next part of #1157.