### PR TITLE
feat(stdlib): Add new `object_from_array` function

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -94,6 +94,7 @@ criterion_group!(
               // TODO: value is dynamic so we cannot assert equality
               //now,
               object,
+              object_from_array,
               parse_apache_log,
               parse_aws_alb_log,
               parse_aws_cloudwatch_log_subscription_message,
@@ -1345,6 +1346,15 @@ bench_function! {
     object {
         args: func_args![value: value!({"foo": "bar"})],
         want: Ok(value!({"foo": "bar"})),
+    }
+}
+
+bench_function! {
+    object_from_array => vrl::stdlib::ObjectFromArray;
+
+    default {
+        args: func_args![values: value!([["zero",null], ["one",true], ["two","foo"], ["three",3]])],
+        want: Ok(value!({"zero":null, "one":true, "two":"foo", "three":3})),
     }
 }
 

--- a/changelog.d/1164.feature.md
+++ b/changelog.d/1164.feature.md
@@ -1,0 +1,2 @@
+Added new `object_from_array` function to create an object from an array of
+value pairs such as what `zip` can produce.

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -132,6 +132,7 @@ cfg_if::cfg_if! {
         mod mod_func;
         mod now;
         mod object;
+        mod object_from_array;
         mod parse_apache_log;
         mod parse_aws_alb_log;
         mod parse_aws_cloudwatch_log_subscription_message;
@@ -313,6 +314,7 @@ cfg_if::cfg_if! {
         pub use mod_func::Mod;
         pub use now::Now;
         pub use object::Object;
+        pub use object_from_array::ObjectFromArray;
         pub use parse_apache_log::ParseApacheLog;
         pub use parse_aws_alb_log::ParseAwsAlbLog;
         pub use parse_aws_cloudwatch_log_subscription_message::ParseAwsCloudWatchLogSubscriptionMessage;
@@ -498,6 +500,7 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(Mod),
         Box::new(Now),
         Box::new(Object),
+        Box::new(ObjectFromArray),
         Box::new(ParseApacheLog),
         Box::new(ParseAwsAlbLog),
         Box::new(ParseAwsCloudWatchLogSubscriptionMessage),

--- a/src/stdlib/object_from_array.rs
+++ b/src/stdlib/object_from_array.rs
@@ -1,0 +1,130 @@
+use crate::compiler::prelude::*;
+
+fn make_object(values: Vec<Value>) -> Resolved {
+    values
+        .into_iter()
+        .map(make_key_value)
+        .collect::<Result<_, _>>()
+        .map(Value::Object)
+}
+
+fn make_key_value(value: Value) -> Result<(KeyString, Value), ExpressionError> {
+    value.try_array().map_err(Into::into).and_then(|array| {
+        let mut iter = array.into_iter();
+        let key: KeyString = match iter.next() {
+            None => return Err("array value too short".into()),
+            Some(Value::Bytes(key)) => String::from_utf8_lossy(&key).into(),
+            Some(_) => return Err("object keys must be strings".into()),
+        };
+        let value = iter.next().unwrap_or(Value::Null);
+        Ok((key, value))
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ObjectFromArray;
+
+impl Function for ObjectFromArray {
+    fn identifier(&self) -> &'static str {
+        "object_from_array"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "values",
+            kind: kind::ARRAY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "create an object from an array of keys/value pairs",
+            source: r#"object_from_array([["a", 1], ["b"], ["c", true, 3, 4]])"#,
+            result: Ok(r#"{"a": 1, "b": null, "c": true}"#),
+        }]
+    }
+
+    fn compile(
+        &self,
+        state: &TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let values = ConstOrExpr::new(arguments.required("values"), state);
+
+        Ok(OFAFn { values }.as_expr())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OFAFn {
+    values: ConstOrExpr,
+}
+
+impl FunctionExpression for OFAFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        make_object(self.values.resolve(ctx)?.try_array()?)
+    }
+
+    fn type_def(&self, _state: &TypeState) -> TypeDef {
+        TypeDef::object(Collection::any())
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ConstOrExpr {
+    Const(Value),
+    Expr(Box<dyn Expression>),
+}
+
+impl ConstOrExpr {
+    fn new(expr: Box<dyn Expression>, state: &TypeState) -> Self {
+        match expr.resolve_constant(state) {
+            Some(cnst) => Self::Const(cnst),
+            None => Self::Expr(expr),
+        }
+    }
+
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        match self {
+            Self::Const(value) => Ok(value.clone()),
+            Self::Expr(expr) => expr.resolve(ctx),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::value;
+
+    use super::*;
+
+    test_function![
+        object_from_array => ObjectFromArray;
+
+        makes_object_simple {
+            args: func_args![values: value!([["foo", 1], ["bar", 2]])],
+            want: Ok(value!({"foo": 1, "bar": 2})),
+            tdef: TypeDef::object(Collection::any()),
+        }
+
+        handles_missing_values {
+            args: func_args![values: value!([["foo", 1], ["bar"]])],
+            want: Ok(value!({"foo": 1, "bar": null})),
+            tdef: TypeDef::object(Collection::any()),
+        }
+
+        drops_extra_values {
+            args: func_args![values: value!([["foo", 1, 2, 3, 4]])],
+            want: Ok(value!({"foo": 1})),
+            tdef: TypeDef::object(Collection::any()),
+        }
+
+        errors_on_missing_keys {
+            args: func_args![values: value!([["foo", 1], []])],
+            want: Err("array value too short"),
+            tdef: TypeDef::object(Collection::any()),
+        }
+    ];
+}

--- a/src/stdlib/object_from_array.rs
+++ b/src/stdlib/object_from_array.rs
@@ -1,3 +1,4 @@
+use super::util::ConstOrExpr;
 use crate::compiler::prelude::*;
 
 fn make_object(values: Vec<Value>) -> Resolved {
@@ -8,7 +9,7 @@ fn make_object(values: Vec<Value>) -> Resolved {
         .map(Value::Object)
 }
 
-fn make_key_value(value: Value) -> Result<(KeyString, Value), ExpressionError> {
+fn make_key_value(value: Value) -> ExpressionResult<(KeyString, Value)> {
     value.try_array().map_err(Into::into).and_then(|array| {
         let mut iter = array.into_iter();
         let key: KeyString = match iter.next() {
@@ -69,28 +70,6 @@ impl FunctionExpression for OFAFn {
 
     fn type_def(&self, _state: &TypeState) -> TypeDef {
         TypeDef::object(Collection::any())
-    }
-}
-
-#[derive(Clone, Debug)]
-enum ConstOrExpr {
-    Const(Value),
-    Expr(Box<dyn Expression>),
-}
-
-impl ConstOrExpr {
-    fn new(expr: Box<dyn Expression>, state: &TypeState) -> Self {
-        match expr.resolve_constant(state) {
-            Some(cnst) => Self::Const(cnst),
-            None => Self::Expr(expr),
-        }
-    }
-
-    fn resolve(&self, ctx: &mut Context) -> Resolved {
-        match self {
-            Self::Const(value) => Ok(value.clone()),
-            Self::Expr(expr) => expr.resolve(ctx),
-        }
     }
 }
 

--- a/src/stdlib/zip.rs
+++ b/src/stdlib/zip.rs
@@ -1,3 +1,4 @@
+use super::util::ConstOrExpr;
 use crate::compiler::prelude::*;
 
 fn zip2(value0: Value, value1: Value) -> Resolved {
@@ -75,9 +76,7 @@ impl Function for Zip {
         arguments: ArgumentList,
     ) -> Compiled {
         let array_0 = ConstOrExpr::new(arguments.required("array_0"), state);
-        let array_1 = arguments
-            .optional("array_1")
-            .map(|a| ConstOrExpr::new(a, state));
+        let array_1 = ConstOrExpr::optional(arguments.optional("array_1"), state);
 
         Ok(ZipFn { array_0, array_1 }.as_expr())
     }
@@ -100,28 +99,6 @@ impl FunctionExpression for ZipFn {
 
     fn type_def(&self, _state: &TypeState) -> TypeDef {
         TypeDef::array(Collection::any())
-    }
-}
-
-#[derive(Clone, Debug)]
-enum ConstOrExpr {
-    Const(Value),
-    Expr(Box<dyn Expression>),
-}
-
-impl ConstOrExpr {
-    fn new(expr: Box<dyn Expression>, state: &TypeState) -> Self {
-        match expr.resolve_constant(state) {
-            Some(cnst) => Self::Const(cnst),
-            None => Self::Expr(expr),
-        }
-    }
-
-    fn resolve(&self, ctx: &mut Context) -> Resolved {
-        match self {
-            Self::Const(value) => Ok(value.clone()),
-            Self::Expr(expr) => expr.resolve(ctx),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a new `object_from_array` function as discussed in #1157 

## Change Type

- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Unit tests are included

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.