### PR TITLE
enhancement(stdlib): Add support for `keys` parameter to `object_from_array`

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -1356,6 +1356,14 @@ bench_function! {
         args: func_args![values: value!([["zero",null], ["one",true], ["two","foo"], ["three",3]])],
         want: Ok(value!({"zero":null, "one":true, "two":"foo", "three":3})),
     }
+
+    values_and_keys {
+        args: func_args![
+            keys: value!(["zero", "one", "two", "three"]),
+            values: value!([null, true, "foo", 3]),
+        ],
+        want: Ok(value!({"zero":null, "one":true, "two":"foo", "three":3})),
+    }
 }
 
 bench_function! {

--- a/src/stdlib/object_from_array.rs
+++ b/src/stdlib/object_from_array.rs
@@ -1,7 +1,7 @@
 use super::util::ConstOrExpr;
 use crate::compiler::prelude::*;
 
-fn make_object1(values: Vec<Value>) -> Resolved {
+fn make_object_1(values: Vec<Value>) -> Resolved {
     values
         .into_iter()
         .map(make_key_value)
@@ -9,7 +9,7 @@ fn make_object1(values: Vec<Value>) -> Resolved {
         .map(Value::Object)
 }
 
-fn make_object2(keys: Vec<Value>, values: Vec<Value>) -> Resolved {
+fn make_object_2(keys: Vec<Value>, values: Vec<Value>) -> Resolved {
     keys.into_iter()
         .zip(values)
         .map(|(key, value)| Ok((make_key_string(key)?, value)))
@@ -97,8 +97,8 @@ impl FunctionExpression for OFAFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let values = self.values.resolve(ctx)?.try_array()?;
         match &self.keys {
-            None => make_object1(values),
-            Some(keys) => make_object2(keys.resolve(ctx)?.try_array()?, values),
+            None => make_object_1(values),
+            Some(keys) => make_object_2(keys.resolve(ctx)?.try_array()?, values),
         }
     }
 

--- a/src/stdlib/object_from_array.rs
+++ b/src/stdlib/object_from_array.rs
@@ -1,7 +1,7 @@
 use super::util::ConstOrExpr;
 use crate::compiler::prelude::*;
 
-fn make_object(values: Vec<Value>) -> Resolved {
+fn make_object1(values: Vec<Value>) -> Resolved {
     values
         .into_iter()
         .map(make_key_value)
@@ -9,17 +9,29 @@ fn make_object(values: Vec<Value>) -> Resolved {
         .map(Value::Object)
 }
 
+fn make_object2(keys: Vec<Value>, values: Vec<Value>) -> Resolved {
+    keys.into_iter()
+        .zip(values)
+        .map(|(key, value)| Ok((make_key_string(key)?, value)))
+        .collect::<Result<_, _>>()
+        .map(Value::Object)
+}
+
 fn make_key_value(value: Value) -> ExpressionResult<(KeyString, Value)> {
     value.try_array().map_err(Into::into).and_then(|array| {
         let mut iter = array.into_iter();
-        let key: KeyString = match iter.next() {
-            None => return Err("array value too short".into()),
-            Some(Value::Bytes(key)) => String::from_utf8_lossy(&key).into(),
-            Some(_) => return Err("object keys must be strings".into()),
+        let Some(key) = iter.next() else {
+            return Err("array value too short".into());
         };
-        let value = iter.next().unwrap_or(Value::Null);
-        Ok((key, value))
+        Ok((make_key_string(key)?, iter.next().unwrap_or(Value::Null)))
     })
+}
+
+fn make_key_string(key: Value) -> ExpressionResult<KeyString> {
+    match key {
+        Value::Bytes(key) => Ok(String::from_utf8_lossy(&key).into()),
+        _ => Err("object keys must be strings".into()),
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -31,19 +43,33 @@ impl Function for ObjectFromArray {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "values",
-            kind: kind::ARRAY,
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "values",
+                kind: kind::ARRAY,
+                required: true,
+            },
+            Parameter {
+                keyword: "keys",
+                kind: kind::ARRAY,
+                required: false,
+            },
+        ]
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "create an object from an array of keys/value pairs",
-            source: r#"object_from_array([["a", 1], ["b"], ["c", true, 3, 4]])"#,
-            result: Ok(r#"{"a": 1, "b": null, "c": true}"#),
-        }]
+        &[
+            Example {
+                title: "create an object from an array of keys/value pairs",
+                source: r#"object_from_array([["a", 1], ["b"], ["c", true, 3, 4]])"#,
+                result: Ok(r#"{"a": 1, "b": null, "c": true}"#),
+            },
+            Example {
+                title: "create an object from a separate arrays of keys and values",
+                source: r#"object_from_array(keys: ["a", "b", "c"], values: [1, null, true])"#,
+                result: Ok(r#"{"a": 1, "b": null, "c": true}"#),
+            },
+        ]
     }
 
     fn compile(
@@ -53,19 +79,27 @@ impl Function for ObjectFromArray {
         arguments: ArgumentList,
     ) -> Compiled {
         let values = ConstOrExpr::new(arguments.required("values"), state);
+        let keys = arguments
+            .optional("keys")
+            .map(|keys| ConstOrExpr::new(keys, state));
 
-        Ok(OFAFn { values }.as_expr())
+        Ok(OFAFn { keys, values }.as_expr())
     }
 }
 
 #[derive(Clone, Debug)]
 struct OFAFn {
+    keys: Option<ConstOrExpr>,
     values: ConstOrExpr,
 }
 
 impl FunctionExpression for OFAFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        make_object(self.values.resolve(ctx)?.try_array()?)
+        let values = self.values.resolve(ctx)?.try_array()?;
+        match &self.keys {
+            None => make_object1(values),
+            Some(keys) => make_object2(keys.resolve(ctx)?.try_array()?, values),
+        }
     }
 
     fn type_def(&self, _state: &TypeState) -> TypeDef {
@@ -84,6 +118,12 @@ mod tests {
 
         makes_object_simple {
             args: func_args![values: value!([["foo", 1], ["bar", 2]])],
+            want: Ok(value!({"foo": 1, "bar": 2})),
+            tdef: TypeDef::object(Collection::any()),
+        }
+
+        uses_keys_parameter {
+            args: func_args![keys: value!(["foo", "bar"]), values: value!([1, 2])],
             want: Ok(value!({"foo": 1, "bar": 2})),
             tdef: TypeDef::object(Collection::any()),
         }


### PR DESCRIPTION
## Summary

Continuing #1164 

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance
- [x] Enhancement

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

#1157