### PR TITLE
Revert "chore(deps): bump lalrpop from 0.20.2 to 0.22.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,11 +188,11 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
-version = "4.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
- "term 1.0.0",
+ "term",
 ]
 
 [[package]]
@@ -1550,6 +1550,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1615,24 +1624,30 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.22.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06093b57658c723a21da679530e061a8c25340fa5a6f98e313b542268c7e2a1f"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set 0.8.0",
+ "bit-set 0.5.3",
  "ena",
- "itertools 0.13.0",
- "lalrpop-util",
+ "itertools 0.11.0",
+ "lalrpop-util 0.20.2",
  "petgraph",
  "regex",
  "regex-syntax 0.8.5",
- "sha3",
  "string_cache",
- "term 1.0.0",
+ "term",
+ "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 
 [[package]]
 name = "lalrpop-util"
@@ -2309,7 +2324,7 @@ dependencies = [
  "encode_unicode",
  "is-terminal",
  "lazy_static",
- "term 0.7.0",
+ "term",
  "unicode-width 0.1.14",
 ]
 
@@ -3136,16 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4175de05129f31b80458c6df371a15e7fc3fd367272e6bf938e5c351c7ea0"
-dependencies = [
- "home",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +3247,15 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinystr"
@@ -3618,7 +3632,7 @@ dependencies = [
  "influxdb-line-protocol",
  "itertools 0.13.0",
  "lalrpop",
- "lalrpop-util",
+ "lalrpop-util 0.22.0",
  "md-5",
  "mlua",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ proptest = { version = "1" }
 proptest-derive = { version = "0.5" }
 
 [build-dependencies]
-lalrpop = { version = "0.22", default-features = false }
+lalrpop = { version = "0.20", default-features = false }
 
 [[bench]]
 name = "kind"


### PR DESCRIPTION
Reverts vectordotdev/vrl#1175

This got merged with failing checks.
https://github.com/vectordotdev/vrl/actions/runs/12169161359/job/33941527890

Fixed by adding more checks:
<img width="912" alt="image" src="https://github.com/user-attachments/assets/ced0c24f-84e9-4334-9945-0d802f636b2b">
