### PR TITLE
fix(convert): Revert PR #1108 "return error when conversion exceeds f64 bounds"

### DIFF
--- a/changelog.d/1179.fix.md
+++ b/changelog.d/1179.fix.md
@@ -1,0 +1,2 @@
+Reverted `to_float` [change](https://github.com/vectordotdev/vrl/pull/1107) because the new logic is too restrictive
+e.g. attempting to convert "0" returns an error.

--- a/src/compiler/conversion/mod.rs
+++ b/src/compiler/conversion/mod.rs
@@ -159,11 +159,6 @@ impl Conversion {
                 let parsed = s
                     .parse::<f64>()
                     .with_context(|_| FloatParseSnafu { s: s.clone() })?;
-                if !parsed.is_normal() {
-                    return Err(Error::NanFloat {
-                        s: format!("Invalid float \"{s}\": not a normal f64 number"),
-                    });
-                }
                 let f = NotNan::new(parsed).map_err(|_| Error::NanFloat { s: s.to_string() })?;
                 f.into()
             }

--- a/src/compiler/conversion/tests/mod.rs
+++ b/src/compiler/conversion/tests/mod.rs
@@ -2,8 +2,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use ordered_float::NotNan;
 
-use crate::compiler::conversion::{parse_bool, Conversion, Error};
-use crate::compiler::TimeZone;
+use crate::compiler::conversion::parse_bool;
 
 #[cfg(unix)] // see https://github.com/vectordotdev/vector/issues/1201
 mod unix;
@@ -91,35 +90,4 @@ fn parse_bool_errors() {
     assert!(parse_bool("X").is_err());
     assert!(parse_bool("yes or no").is_err());
     assert!(parse_bool("123.4").is_err());
-}
-
-fn convert_float(input: impl ToString) -> Result<StubValue, Error> {
-    let input = input.to_string();
-    let converter = Conversion::parse("float", TimeZone::Local).expect("float conversion");
-    converter.convert::<StubValue>(input.into())
-}
-
-#[test]
-fn convert_float_ok() {
-    let max_float = format!("17976931348623157{}", "0".repeat(292));
-    let min_float = format!("-{max_float}");
-
-    assert_eq!(convert_float(max_float), Ok(StubValue::Float(f64::MAX)));
-    assert_eq!(convert_float("1"), Ok(StubValue::Float(1.0)));
-    assert_eq!(convert_float("1.23"), Ok(StubValue::Float(1.23)));
-    assert_eq!(convert_float("-1"), Ok(StubValue::Float(-1.0)));
-    assert_eq!(convert_float("-1.23"), Ok(StubValue::Float(-1.23)));
-    assert_eq!(convert_float(min_float), Ok(StubValue::Float(f64::MIN)));
-}
-
-#[test]
-fn convert_float_errors() {
-    let exceeds_max_float = format!("17976931348623159{}", "0".repeat(292)); // last number inc by 2
-    let exceeds_min_float = format!("-{exceeds_max_float}");
-
-    assert!(convert_float("abc").is_err());
-    assert!(convert_float("1.23.4").is_err());
-    assert!(convert_float(exceeds_max_float).is_err());
-    assert!(convert_float(exceeds_min_float).is_err());
-    assert!(convert_float("0.0").is_err());
 }


### PR DESCRIPTION
## Summary

Reverts vectordotdev/vrl#1108
Due to https://github.com/vectordotdev/vector/issues/21970. We don't have numbers to prove this, but parsing `"0"` might be a common operation. And we don't want `parse_float` and `to_float` to diverge.

To err on the side of caution let's revert this change. We will work to provide safe arithemtic operations in the future (inspired by Rust APIs).