### PR TITLE
fix(sub): error instead of panic when subtraction yields NaN

### DIFF
--- a/changelog.d/2893.fix.md
+++ b/changelog.d/2893.fix.md
@@ -1,0 +1,1 @@
+Fix a panic in float subtraction that produces NaN values.

--- a/lib/tests/tests/expressions/arithmetic/subtraction/nan_result.vrl
+++ b/lib/tests/tests/expressions/arithmetic/subtraction/nan_result.vrl
@@ -1,0 +1,5 @@
+# result: can't subtract type float from float
+
+large = to_float!("1.7976931348623157e+308")
+inf_float = large + large
+inf_float - inf_float

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -2,12 +2,12 @@
 
 use std::ops::{Add, Mul, Rem};
 
-use bytes::{BufMut, Bytes, BytesMut};
 use crate::compiler::{
     value::{Kind, VrlValueConvert},
     ExpressionError,
 };
 use crate::value::{ObjectMap, Value};
+use bytes::{BufMut, Bytes, BytesMut};
 
 use super::ValueError;
 

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -165,7 +165,7 @@ impl VrlValueArithmetic for Value {
             }
             Value::Float(lhs) => {
                 let rhs = rhs.try_into_f64().map_err(|_| err())?;
-                safe_sub(*lhs, rhs).ok_or_else(&err)?
+                safe_sub(*lhs, rhs).ok_or_else(err)?
             }
             _ => return Err(err()),
         };

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -165,7 +165,7 @@ impl VrlValueArithmetic for Value {
             }
             Value::Float(lhs) => {
                 let rhs = rhs.try_into_f64().map_err(|_| err())?;
-                safe_sub(*lhs, rhs).ok_or_else(|| err())?
+                safe_sub(*lhs, rhs).ok_or_else(&err)?
             }
             _ => return Err(err()),
         };

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -1,9 +1,8 @@
 #![deny(clippy::arithmetic_side_effects)]
 
-use std::ops::{Add, Mul, Rem, Sub};
+use std::ops::{Add, Mul, Rem};
 
 use bytes::{BufMut, Bytes, BytesMut};
-
 use crate::compiler::{
     value::{Kind, VrlValueConvert},
     ExpressionError,
@@ -58,6 +57,15 @@ pub trait VrlValueArithmetic: Sized {
     /// Similar to [`std::cmp::Eq`], but does a lossless comparison for integers
     /// and floats.
     fn eq_lossy(&self, rhs: &Self) -> bool;
+}
+
+fn safe_sub(lhv: f64, rhv: f64) -> Option<Value> {
+    let result = lhv - rhv;
+    if result.is_nan() {
+        None
+    } else {
+        Some(Value::from_f64_or_zero(result))
+    }
 }
 
 impl VrlValueArithmetic for Value {
@@ -155,9 +163,9 @@ impl VrlValueArithmetic for Value {
                 let rhv = rhs.try_into_i64().map_err(|_| err())?;
                 i64::wrapping_sub(lhv, rhv).into()
             }
-            Value::Float(lhv) => {
-                let rhv = rhs.try_into_f64().map_err(|_| err())?;
-                lhv.sub(rhv).into()
+            Value::Float(lhs) => {
+                let rhs = rhs.try_into_f64().map_err(|_| err())?;
+                safe_sub(*lhs, rhs).ok_or_else(|| err())?
             }
             _ => return Err(err()),
         };


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
The `ordered_float` `sub` implementation panics for NaN results. 

Note that `inf` is a valid `f64` in Rust. In VRL we want to always throw an error for `NaN`s (at least this is the current status quo). 

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Unit test and config:
```
api:
  enabled: true

sources:
  demo_logs_1:
    type: demo_logs
    format: json


transforms:
  remap0:
    type: remap
    inputs: ["demo_logs_1"]
    source: |
      .a = to_float!("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
      .b = to_float!("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
      .result = .a - .b

sinks:
  console:
    type: console
    inputs: ["remap0"]
    encoding:
      codec: json
```
<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

- Closes: https://github.com/vectordotdev/vrl/issues/1107

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
