### PR TITLE
feat(stdlib): allow parsing multiple durations at once in `parse_duration` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3642,7 @@ dependencies = [
  "hex",
  "hmac",
  "hostname",
+ "humantime",
  "iana-time-zone",
  "idna",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ stdlib = [
   "dep:hex",
   "dep:hmac",
   "dep:hostname",
+  "dep:humantime",
   "dep:iana-time-zone",
   "dep:idna",
   "dep:indexmap",
@@ -197,6 +198,7 @@ snafu = { version = "0.8", optional = true }
 webbrowser = { version = "1.0", default-features = false, optional = true }
 woothee = { version = "0.13", optional = true }
 community-id = { version = "0.2", optional = true }
+humantime = { version = "2.1.0", optional = true}
 
 zstd = { version = "0.13", default-features = false, features = ["wasm"], optional = true }
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -114,6 +114,7 @@ hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@ko
 hmac,https://github.com/RustCrypto/MACs,MIT OR Apache-2.0,RustCrypto Developers
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
 hostname,https://github.com/svartalf/hostname,MIT,"fengcen <fengcen.love@gmail.com>, svartalf <self@svartalf.info>"
+humantime,https://github.com/tailhook/humantime,MIT OR Apache-2.0,Paul Colomiets <paul@colomiets.name>
 iana-time-zone,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,"Andrew Straw <strawman@astraw.com>, René Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>"
 iana-time-zone-haiku,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,René Kijewski <crates.io@k6i.de>
 icu_collections,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers

--- a/changelog.d/1197.feature.md
+++ b/changelog.d/1197.feature.md
@@ -1,0 +1,1 @@
+Support multiple-units duration string for `parse_duration` function such as `1h2s`.

--- a/changelog.d/1197.feature.md
+++ b/changelog.d/1197.feature.md
@@ -1,1 +1,1 @@
-Support multiple-units duration string for `parse_duration` function such as `1h2s`.
+Added support for multi-unit duration strings (e.g., `1h2s`, `2m3s`) in the `parse_duration` function.

--- a/changelog.d/1198.feature.md
+++ b/changelog.d/1198.feature.md
@@ -1,3 +1,0 @@
-Added `parse_bytes` function to parse bytes either from SI or binary unit depending on the given `base` argument.
-
-authors: titaneric

--- a/changelog.d/1198.feature.md
+++ b/changelog.d/1198.feature.md
@@ -1,0 +1,3 @@
+Added `parse_bytes` function to parse bytes either from SI or binary unit depending on the given `base` argument.
+
+authors: titaneric

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -16,12 +16,14 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
             .get(string.as_ref())
             .ok_or(format!("unknown unit format: '{string}'"))?
     };
-    let mut num = 0.0;
+    let mut sum = 0.0;
     while !value.is_empty() {
         let captures = RE
             .captures(value)
             .ok_or(format!("unable to parse duration: '{value}'"))?;
-        let capture_match = captures.get(0).unwrap();
+        let capture_match = captures
+            .get(0)
+            .ok_or(format!("unable to capture matched duration: '{value}'"))?;
 
         let value_decimal = Decimal::from_str(&captures["value"])
             .map_err(|error| format!("unable to parse number: {error}"))?;
@@ -32,10 +34,10 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
         let number = number
             .to_f64()
             .ok_or(format!("unable to format duration: '{number}'"))?;
-        num += number;
+        sum += number;
         value = &value[capture_match.end()..];
     }
-    Ok(Value::from_f64_or_zero(num))
+    Ok(Value::from_f64_or_zero(sum))
 }
 
 static RE: Lazy<Regex> = Lazy::new(|| {

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -41,6 +41,7 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
 static RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r"(?ix)                        # i: case-insensitive, x: ignore whitespace + comments
+            \A
             (?P<value>[0-9]*\.?[0-9]+) # value: integer or float
             \s?                        # optional space between value and unit
             (?P<unit>[µa-z]{1,2})      # unit: one or two letters",
@@ -178,7 +179,12 @@ mod tests {
             want: Ok(86401.0),
             tdef: TypeDef::float().fallible(),
         }
-
+        error_multiple_units_space_not_allowed {
+            args: func_args![value: "1d 1s",
+                             unit: "s"],
+            want: Err("unable to parse duration: ' 1s'"),
+            tdef: TypeDef::float().fallible(),
+        }
         error_multiple_units {
             args: func_args![value: "1d foo",
                              unit: "s"],

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -19,7 +19,7 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
     let mut num = 0.0;
     while !value.is_empty() {
         let captures = RE
-            .captures(&value)
+            .captures(value)
             .ok_or(format!("unable to parse duration: '{value}'"))?;
         let capture_match = captures.get(0).unwrap();
 

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -1,67 +1,43 @@
 use crate::compiler::prelude::*;
+use humantime::parse_duration as ht_parse_duration;
 use once_cell::sync::Lazy;
-use regex::Regex;
-use rust_decimal::{prelude::ToPrimitive, Decimal};
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
+use std::time::Duration;
 
 fn parse_duration(bytes: Value, unit: Value) -> Resolved {
     let bytes = bytes.try_bytes()?;
     let value = String::from_utf8_lossy(&bytes);
-    let mut value = &value[..];
+    // Remove all spaces and replace the micro symbol with the ASCII equivalent
+    // since the `humantime` does not support them.
+    let trimmed_value = value.replace(" ", "").replace("µs", "us");
+
     let conversion_factor = {
         let bytes = unit.try_bytes()?;
         let string = String::from_utf8_lossy(&bytes);
 
-        UNITS
+        *UNITS
             .get(string.as_ref())
             .ok_or(format!("unknown unit format: '{string}'"))?
     };
-    let mut sum = 0.0;
-    while !value.is_empty() {
-        let captures = RE
-            .captures(value)
-            .ok_or(format!("unable to parse duration: '{value}'"))?;
-        let capture_match = captures
-            .get(0)
-            .ok_or(format!("unable to capture matched duration: '{value}'"))?;
+    let duration = ht_parse_duration(&trimmed_value)
+        .map_err(|_| format!("unable to parse duration: '{value}'"))?;
+    let number = duration.div_duration_f64(conversion_factor);
 
-        let value_decimal = Decimal::from_str(&captures["value"])
-            .map_err(|error| format!("unable to parse number: {error}"))?;
-        let unit = UNITS
-            .get(&captures["unit"])
-            .ok_or(format!("unknown duration unit: '{}'", &captures["unit"]))?;
-        let number = value_decimal * unit / conversion_factor;
-        let number = number
-            .to_f64()
-            .ok_or(format!("unable to format duration: '{number}'"))?;
-        sum += number;
-        value = &value[capture_match.end()..];
-    }
-    Ok(Value::from_f64_or_zero(sum))
+    Ok(Value::from_f64_or_zero(number))
 }
 
-static RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r"(?ix)                        # i: case-insensitive, x: ignore whitespace + comments
-            (?P<value>[0-9]*\.?[0-9]+) # value: integer or float
-            \s?                        # optional space between value and unit
-            (?P<unit>[µa-z]{1,2})      # unit: one or two letters",
-    )
-    .unwrap()
-});
-
-static UNITS: Lazy<HashMap<String, Decimal>> = Lazy::new(|| {
+static UNITS: Lazy<HashMap<String, Duration>> = Lazy::new(|| {
     vec![
-        ("ns", Decimal::new(1, 9)),
-        ("us", Decimal::new(1, 6)),
-        ("µs", Decimal::new(1, 6)),
-        ("ms", Decimal::new(1, 3)),
-        ("cs", Decimal::new(1, 2)),
-        ("ds", Decimal::new(1, 1)),
-        ("s", Decimal::new(1, 0)),
-        ("m", Decimal::new(60, 0)),
-        ("h", Decimal::new(3_600, 0)),
-        ("d", Decimal::new(86_400, 0)),
+        ("ns", Duration::from_nanos(1)),
+        ("us", Duration::from_micros(1)),
+        ("µs", Duration::from_micros(1)),
+        ("ms", Duration::from_millis(1)),
+        ("cs", Duration::from_millis(10)),
+        ("ds", Duration::from_millis(100)),
+        ("s", Duration::from_secs(1)),
+        ("m", Duration::from_secs(60)),
+        ("h", Duration::from_secs(3_600)),
+        ("d", Duration::from_secs(86_400)),
     ]
     .into_iter()
     .map(|(k, v)| (k.to_owned(), v))
@@ -167,6 +143,13 @@ mod tests {
             tdef: TypeDef::float().fallible(),
         }
 
+        us_ms {
+            args: func_args![value: "100µs",
+                             unit: "ms"],
+            want: Ok(0.1),
+            tdef: TypeDef::float().fallible(),
+        }
+
         d_s {
             args: func_args![value: "1d",
                              unit: "s"],
@@ -209,10 +192,17 @@ mod tests {
             tdef: TypeDef::float().fallible(),
         }
 
-        us_ms {
+        us_space_ms {
             args: func_args![value: "1 µs",
                              unit: "ms"],
             want: Ok(0.001),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        w_ns {
+            args: func_args![value: "1w",
+                             unit: "ns"],
+            want: Ok(604800000000000.0),
             tdef: TypeDef::float().fallible(),
         }
 
@@ -230,13 +220,6 @@ mod tests {
             tdef: TypeDef::float().fallible(),
         }
 
-        error_unit {
-            args: func_args![value: "1w",
-                             unit: "ns"],
-            want: Err("unknown duration unit: 'w'"),
-            tdef: TypeDef::float().fallible(),
-        }
-
         error_format {
             args: func_args![value: "1s",
                              unit: "w"],
@@ -247,7 +230,7 @@ mod tests {
         error_failed_2nd_unit {
             args: func_args![value: "1d foo",
                              unit: "s"],
-            want: Err("unable to parse duration: ' foo'"),
+            want: Err("unable to parse duration: '1d foo'"),
             tdef: TypeDef::float().fallible(),
         }
     ];

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -9,7 +9,7 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
     let value = String::from_utf8_lossy(&bytes);
     // Remove all spaces and replace the micro symbol with the ASCII equivalent
     // since the `humantime` does not support them.
-    let trimmed_value = value.replace(" ", "").replace("µs", "us");
+    let trimmed_value = value.replace(' ', "").replace("µs", "us");
 
     let conversion_factor = {
         let bytes = unit.try_bytes()?;
@@ -20,7 +20,7 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
             .ok_or(format!("unknown unit format: '{string}'"))?
     };
     let duration = ht_parse_duration(&trimmed_value)
-        .map_err(|_| format!("unable to parse duration: '{value}'"))?;
+        .map_err(|e| format!("unable to parse duration: '{e}'"))?;
     let number = duration.div_duration_f64(conversion_factor);
 
     Ok(Value::from_f64_or_zero(number))
@@ -202,21 +202,21 @@ mod tests {
         w_ns {
             args: func_args![value: "1w",
                              unit: "ns"],
-            want: Ok(604800000000000.0),
+            want: Ok(604_800_000_000_000.0),
             tdef: TypeDef::float().fallible(),
         }
 
         error_invalid {
             args: func_args![value: "foo",
                              unit: "ms"],
-            want: Err("unable to parse duration: 'foo'"),
+            want: Err("unable to parse duration: 'expected number at 0'"),
             tdef: TypeDef::float().fallible(),
         }
 
         error_ns {
             args: func_args![value: "1",
                              unit: "ns"],
-            want: Err("unable to parse duration: '1'"),
+            want: Err("unable to parse duration: 'time unit needed, for example 1sec or 1ms'"),
             tdef: TypeDef::float().fallible(),
         }
 
@@ -230,7 +230,7 @@ mod tests {
         error_failed_2nd_unit {
             args: func_args![value: "1d foo",
                              unit: "s"],
-            want: Err("unable to parse duration: '1d foo'"),
+            want: Err("unable to parse duration: 'unknown time unit \"dfoo\", supported units: ns, us, ms, sec, min, hours, days, weeks, months, years (and few variations)'"),
             tdef: TypeDef::float().fallible(),
         }
     ];

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -2,12 +2,12 @@ use crate::compiler::prelude::*;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
-use std::borrow::Cow;
 use std::{collections::HashMap, str::FromStr};
 
 fn parse_duration(bytes: Value, unit: Value) -> Resolved {
     let bytes = bytes.try_bytes()?;
-    let mut value = String::from_utf8_lossy(&bytes);
+    let value = String::from_utf8_lossy(&bytes);
+    let mut value = &value[..];
     let conversion_factor = {
         let bytes = unit.try_bytes()?;
         let string = String::from_utf8_lossy(&bytes);
@@ -33,7 +33,7 @@ fn parse_duration(bytes: Value, unit: Value) -> Resolved {
             .to_f64()
             .ok_or(format!("unable to format duration: '{number}'"))?;
         num += number;
-        value = Cow::Owned(value[capture_match.end()..].to_string());
+        value = &value[capture_match.end()..];
     }
     Ok(Value::from_f64_or_zero(num))
 }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Hi, I hope that `parse_duration` could parse multiple duration at once, so I have opened #1198 as a referenced issue.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

```
cargo test
./scripts/check.sh
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

Closes #1196 
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
