### PR TITLE
feat(stdlib) Add new `parse_bytes` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +3657,7 @@ dependencies = [
  "once_cell",
  "onig",
  "ordered-float",
+ "parse-size",
  "paste",
  "peeking_take_while",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/vectordotdev/vrl"
 readme = "README.md"
 keywords = ["vector", "datadog", "compiler"]
 categories = ["compilers"]
-rust-version = "1.80" # msrv
+rust-version = "1.81" # msrv
 
 [workspace]
 members = [
@@ -161,7 +161,7 @@ once_cell = { version = "1", default-features = false, features = ["std"], optio
 ordered-float = { version = "4", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 paste = { version = "1", default-features = false, optional = true }
-parse-size = { version = "1.0.0",  optional = true }
+parse-size = { version = "1.1.0",  optional = true }
 peeking_take_while = { version = "1", default-features = false, optional = true }
 percent-encoding = { version = "2", optional = true }
 pest = { version = "2", default-features = false, optional = true, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ stdlib = [
   "dep:nom",
   "dep:ofb",
   "dep:once_cell",
+  "dep:parse-size",
   "dep:percent-encoding",
   "dep:prost",
   "dep:prost-reflect",
@@ -159,6 +160,7 @@ once_cell = { version = "1", default-features = false, features = ["std"], optio
 ordered-float = { version = "4", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 paste = { version = "1", default-features = false, optional = true }
+parse-size = { version = "1.0.0",  optional = true }
 peeking_take_while = { version = "1", default-features = false, optional = true }
 percent-encoding = { version = "2", optional = true }
 pest = { version = "2", default-features = false, optional = true, features = ["std"] }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -173,6 +173,7 @@ owo-colors,https://github.com/jam1garner/owo-colors,MIT,jam1garner <8260240+jam1
 pad,https://github.com/ogham/rust-pad,MIT,Ben S <ogham@bsago.me>
 parking,https://github.com/smol-rs/parking,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, The Rust Project Developers"
 parking_lot,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
+parse-size,https://github.com/kennytm/parse-size,MIT,kennytm <kennytm@gmail.com>
 paste,https://github.com/dtolnay/paste,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 peeking_take_while,https://github.com/fitzgen/peeking_take_while,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 pest,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -102,6 +102,7 @@ criterion_group!(
               parse_aws_alb_log,
               parse_aws_cloudwatch_log_subscription_message,
               parse_aws_vpc_flow_log,
+              parse_bytes,
               parse_common_log,
               parse_csv,
               parse_duration,
@@ -1641,6 +1642,15 @@ bench_function! {
             "thread": "3814",
             "timestamp": (DateTime::parse_from_rfc3339("2021-03-01T12:00:19Z").unwrap().with_timezone(&Utc)),
         })),
+    }
+}
+
+bench_function! {
+    parse_bytes => vrl::stdlib::ParseBytes;
+
+    literal {
+        args: func_args![value: "1024KiB", unit: "MiB"],
+        want: Ok(1.0),
     }
 }
 

--- a/changelog.d/1198.feature.md
+++ b/changelog.d/1198.feature.md
@@ -1,0 +1,1 @@
+Added new `parse_bytes` function to parse given bytes string such as `1MiB` or `1TB` either in binary or decimal base.

--- a/lib/tests/tests/functions/parse_bytes.vrl
+++ b/lib/tests/tests/functions/parse_bytes.vrl
@@ -1,0 +1,3 @@
+# result: 1024.0
+
+parse_bytes!("1KB", unit: "B")

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -141,6 +141,7 @@ cfg_if::cfg_if! {
         mod parse_aws_alb_log;
         mod parse_aws_cloudwatch_log_subscription_message;
         mod parse_aws_vpc_flow_log;
+        mod parse_bytes;
         mod parse_cef;
         mod parse_cbor;
         mod parse_common_log;
@@ -326,6 +327,7 @@ cfg_if::cfg_if! {
         pub use parse_aws_alb_log::ParseAwsAlbLog;
         pub use parse_aws_cloudwatch_log_subscription_message::ParseAwsCloudWatchLogSubscriptionMessage;
         pub use parse_aws_vpc_flow_log::ParseAwsVpcFlowLog;
+        pub use parse_bytes::ParseBytes;
         pub use parse_cbor::ParseCbor;
         pub use parse_cef::ParseCef;
         pub use parse_common_log::ParseCommonLog;
@@ -517,6 +519,7 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(ParseAwsAlbLog),
         Box::new(ParseAwsCloudWatchLogSubscriptionMessage),
         Box::new(ParseAwsVpcFlowLog),
+        Box::new(ParseBytes),
         Box::new(ParseCbor),
         Box::new(ParseCef),
         Box::new(ParseCommonLog),

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -100,11 +100,23 @@ impl Function for ParseBytes {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "milliseconds",
-            source: r#"parse_bytes!("1GB", unit: "B", base: "10")"#,
-            result: Ok("1_000_000_000"),
-        }]
+        &[
+            Example {
+                title: "kilobytes in default binary units",
+                source: r#"parse_bytes!("1KiB", unit: "B")"#,
+                result: Ok("1024.0"),
+            },
+            Example {
+                title: "gigabytes in decimal units",
+                source: r#"parse_bytes!("1GB", unit: "B", base: "10")"#,
+                result: Ok("1000000000.0"),
+            },
+            Example {
+                title: "gigabytes in ambiguous decimal units",
+                source: r#"parse_bytes!("1GB", unit: "MB", base: "2")"#,
+                result: Ok("1024.0"),
+            },
+        ]
     }
 
     fn compile(

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -45,7 +45,7 @@ static BIN_UNITS: Lazy<HashMap<String, Decimal>> = Lazy::new(|| {
         ("TiB", Decimal::new(1_099_511_627_776, 0)),
         ("PiB", Decimal::new(1_125_899_906_842_624, 0)),
         ("EiB", Decimal::new(1_152_921_504_606_846_976, 0)),
-        // decimal units also support ambiguous units
+        // binary units also support ambiguous units
         ("KB", Decimal::new(1_024, 0)),
         ("MB", Decimal::new(1_048_576, 0)),
         ("GB", Decimal::new(1_073_741_824, 0)),

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -270,7 +270,7 @@ mod tests {
             args: func_args![value: "768MB",
                              unit: "PB",
                              base: "10"],
-            want: Ok(0.000000768),
+            want: Ok(0.000_000_768),
             tdef: TypeDef::float().fallible(),
         }
 

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -41,7 +41,7 @@ static RE: Lazy<Regex> = Lazy::new(|| {
     )
     .unwrap()
 });
-
+// The largest unit is EB, which is smaller than i64::MAX
 static UNITS: Lazy<HashMap<String, Decimal>> = Lazy::new(|| {
     vec![
         ("B", Decimal::new(1, 0)),
@@ -50,6 +50,7 @@ static UNITS: Lazy<HashMap<String, Decimal>> = Lazy::new(|| {
         ("GB", Decimal::new(1_000_000_000, 0)),
         ("TB", Decimal::new(1_000_000_000_000, 0)),
         ("PB", Decimal::new(1_000_000_000_000_000, 0)),
+        ("EB", Decimal::new(1_000_000_000_000_000_000, 0)),
     ]
     .into_iter()
     .map(|(k, v)| (k.to_owned(), v))
@@ -159,6 +160,13 @@ mod tests {
             args: func_args![value: "768MB",
                              unit: "PB"],
             want: Ok(0.000000768),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        eb_tb {
+            args: func_args![value: "1EB",
+                             unit: "TB"],
+            want: Ok(value!(1_000_000.0)),
             tdef: TypeDef::float().fallible(),
         }
 

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -109,7 +109,7 @@ impl Function for ParseBytes {
         let unit = arguments.required("unit");
         let base = arguments
             .optional_enum("base", &base_sets(), state)?
-            .unwrap_or_else(|| value!("10"))
+            .unwrap_or_else(|| value!("2"))
             .try_bytes()
             .expect("base not bytes");
 
@@ -165,72 +165,121 @@ mod tests {
     test_function![
         parse_bytes => ParseBytes;
 
+        mib_b {
+            args: func_args![value: "1MiB",
+                             unit: "B"],
+            want: Ok(value!(1_048_576.0)),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        b_kib {
+            args: func_args![value: "512B",
+                             unit: "KiB"],
+            want: Ok(0.5),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        gib_mib {
+            args: func_args![value: "3.5GiB",
+                             unit: "KiB"],
+            want: Ok(3_670_016.0),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        tib_gib {
+            args: func_args![value: "12 TiB",
+                             unit: "GiB"],
+            want: Ok(12_288.0),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        mib_pib {
+            args: func_args![value: "256TiB",
+                             unit: "PiB"],
+            want: Ok(0.25),
+            tdef: TypeDef::float().fallible(),
+        }
+
+        eib_tib {
+            args: func_args![value: "1EiB",
+                             unit: "TiB"],
+            want: Ok(value!(1_048_576.0)),
+            tdef: TypeDef::float().fallible(),
+        }
+
         mb_b {
             args: func_args![value: "1MB",
-                             unit: "B"],
+                             unit: "B",
+                             base: "10"],
             want: Ok(value!(1_000_000.0)),
             tdef: TypeDef::float().fallible(),
         }
 
         b_kb {
             args: func_args![value: "3B",
-                             unit: "kB"],
+                             unit: "kB",
+                             base: "10"],
             want: Ok(0.003),
             tdef: TypeDef::float().fallible(),
         }
 
         gb_mb {
             args: func_args![value: "3.007GB",
-                             unit: "kB"],
+                             unit: "kB",
+                             base: "10"],
             want: Ok(3_007_000.0),
             tdef: TypeDef::float().fallible(),
         }
 
         tb_gb {
             args: func_args![value: "12 TB",
-                             unit: "GB"],
+                             unit: "GB",
+                             base: "10"],
             want: Ok(12_000.0),
             tdef: TypeDef::float().fallible(),
         }
 
         mb_pb {
             args: func_args![value: "768MB",
-                             unit: "PB"],
+                             unit: "PB",
+                             base: "10"],
             want: Ok(0.000000768),
             tdef: TypeDef::float().fallible(),
         }
 
         eb_tb {
             args: func_args![value: "1EB",
-                             unit: "TB"],
+                             unit: "TB",
+                             base: "10"],
             want: Ok(value!(1_000_000.0)),
             tdef: TypeDef::float().fallible(),
         }
 
         error_invalid {
             args: func_args![value: "foo",
-                             unit: "kB"],
+                             unit: "KiB"],
             want: Err("unable to parse duration: 'foo'"),
             tdef: TypeDef::float().fallible(),
         }
 
         error_kb {
             args: func_args![value: "1",
-                             unit: "kB"],
+                             unit: "KiB"],
             want: Err("unable to parse duration: '1'"),
             tdef: TypeDef::float().fallible(),
         }
 
         error_unit {
-            args: func_args![value: "1YB",
-                             unit: "MB"],
-            want: Err("unknown duration unit: 'YB'"),
+            args: func_args![value: "1YiB",
+                             unit: "MiB"],
+            want: Err("unknown duration unit: 'YiB'"),
             tdef: TypeDef::float().fallible(),
         }
 
         error_format {
-            args: func_args![value: "100kB",
-                             unit: "ZB"],
+            args: func_args![value: "100KiB",
+                             unit: "ZB",
+                             base: "10"],
             want: Err("unknown unit format: 'ZB'"),
             tdef: TypeDef::float().fallible(),
         }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change
 

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

#49 discuss adding new function for parsing bytes, so I try to add this function here

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

```bash
cargo test
./scripts/check.sh
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

Close #49 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

If #1197 could be merged (also opened by me), I want to port the similar feature here to parse multiple bytes unit at once.
