### PR TITLE
feat(stdlib): Add `main` log format to `parse_nginx_log` function

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -1969,6 +1969,22 @@ bench_function! {
         })),
     }
 
+    main {
+        args: func_args![
+            value: r#"172.24.0.3 - - [31/Dec/2024:17:32:06 +0000] "GET / HTTP/1.1" 200 615 "-" "curl/8.11.1" "1.2.3.4, 10.10.1.1""#,
+            format: "main"
+        ],
+        want: Ok(value!({
+            "remote_addr": "172.24.0.3",
+            "timestamp": (DateTime::parse_from_rfc3339("2024-12-31T17:32:06Z").unwrap().with_timezone(&Utc)),
+            "request": "GET / HTTP/1.1",
+            "status": 200,
+            "body_bytes_size": 615,
+            "http_user_agent": "curl/8.11.1",
+            "http_x_forwarded_for": "1.2.3.4, 10.10.1.1",
+        })),
+    }
+
     error {
         args: func_args![value: r#"2021/04/01 13:02:31 [error] 31#31: *1 open() "/usr/share/nginx/html/not-found" failed (2: No such file or directory), client: 172.17.0.1, server: localhost, request: "POST /not-found HTTP/1.1", host: "localhost:8081""#,
                          format: "error"

--- a/changelog.d/1202.feature.md
+++ b/changelog.d/1202.feature.md
@@ -1,0 +1,1 @@
+Add `main` log format for `parse_nginx_log`.

--- a/src/stdlib/log_util.rs
+++ b/src/stdlib/log_util.rs
@@ -149,6 +149,30 @@ pub(crate) static REGEX_INGRESS_NGINX_UPSTREAMINFO_LOG: Lazy<Regex> = Lazy::new(
     .expect("failed compiling regex for Ingress Nginx upstreaminfo log")
 });
 
+// - Main Nginx docs:
+//   - https://nginx.org/en/linux_packages.html
+//   - https://hg.nginx.org/pkg-oss/file/tip/alpine/alpine/nginx.conf
+//   - https://hg.nginx.org/pkg-oss/file/tip/debian/debian/nginx.conf
+//   - https://hg.nginx.org/pkg-oss/file/tip/rpm/SOURCES/nginx.conf
+pub(crate) static REGEX_NGINX_MAIN_LOG: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?x)                                             # Ignore whitespace and comments in the regex expression.
+        ^\s*                                                # Start with any number of whitespaces
+        (-|(?P<remote_addr>\S+))\s+                         # Match `-` or any non space character
+        \-\s+                                               # Always a dash
+        (-|(?P<remote_user>\S+))\s+                         # Match `-` or any non space character
+        \[(?P<timestamp>[^\]]+)\]\s+                        # Match date between brackets
+        "(?P<request>[^"]*)"\s+                             # Match any non double-quote character
+        (?P<status>\d+)\s+                                  # Match numbers
+        (?P<body_bytes_size>\d+)\s+                         # Match numbers
+        "(-|(?P<http_referer>[^"]*))"\s+                    # Match `-` or any non double-quote character
+        "(-|(?P<http_user_agent>[^"]+))"\s+                 # Match `-` or any non double-quote character
+        "(-|(?P<http_x_forwarded_for>[^"]+))"               # Match `-` or any non double-quote character
+        \s*$                                                # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for Nginx main log")
+});
+
 pub(crate) static REGEX_NGINX_ERROR_LOG: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"(?x)                                                                  # Ignore whitespace and comments in the regex expression.


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

This PR adds support for the `main` log format to `parse_nginx_logs`, which is defined by the default configuration file for official Nginx Docker images.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

- New test cases have been added to cover the `main` log format for Nginx log lines
- Test input correspond to actual log lines emitted by Nginx when:
    - accessed directly (client -> Nginx)
    - accessed behind a single reverse proxy (client -> proxy -> Nginx)
    - accessed behind a chain of two reverse proxies (client -> proxy1 -> proxy2 -> Nginx)

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

PR adding documentation: https://github.com/vectordotdev/vector/pull/22119

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
Closes #1201

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

### Notes for reviewers
- With the exception of the `timestamp` field, the name of the parsed fields match the name of the fields as defined by the Nginx log format (see #1201 and reference links)
