### PR TITLE
chore(parsing): Make node processing in `parsing::xml` public

### DIFF
--- a/changelog.d/1242.enhancement.md
+++ b/changelog.d/1242.enhancement.md
@@ -1,0 +1,5 @@
+Makes `parsing::xml::process_node()` and its arguments public for XML parsing use-cases that need to mirror VRL's internal processing.
+
+Re-exports `Document` and `Node` from [roxmltree](https://crates.io/crates/roxmltree) to match the public API.
+
+Authors: leebenson

--- a/changelog.d/1242.enhancement.md
+++ b/changelog.d/1242.enhancement.md
@@ -1,5 +1,0 @@
-Makes `parsing::xml::process_node()` and its arguments public for XML parsing use-cases that need to mirror VRL's internal processing.
-
-Re-exports `Document` and `Node` from [roxmltree](https://crates.io/crates/roxmltree) to match the public API.
-
-Authors: leebenson


### PR DESCRIPTION
## Summary

Small PR to make `parsing::xml::process_node` and its arguments public, to match VRL's XML processing for sibling use-cases.

Also re-exports the parts of [roxmltree](https://crates.io/crates/roxmltree) necessary to parse a _Document_ and operate against a _Node_.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

```bash
./scripts/checks.sh
```

Note: since this PR simply changes the visibility of existing structs and functions, there should be no material impact.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

N/A.