### PR TITLE
feat(stdlib): ip_cidr_contains now accepts array of CIDR

### DIFF
--- a/changelog.d/1248.feature.md
+++ b/changelog.d/1248.feature.md
@@ -1,0 +1,3 @@
+`ip_cidr_contains` method now also accepts an array of CIDRs.
+
+authors: JakubOnderka


### PR DESCRIPTION
## Summary

In our environment, we have to check if IP address is private or globally routable. Currently we have to call `ip_cidr_contains` multiple times like

```
ip_cidr_contains!("10.0.0.0/8", .ip) ||  ip_cidr_contains!("172.16.0.0/12", .ip) || ip_cidr_contains!("192.168.0.0/16", .ip)
```

after this change, we will be able to call this method just once:

```
ip_cidr_contains!(["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"], .ip)
```

so it will make our code cleaner and it should be also faster.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard test case.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.
