### PR TITLE
performance(stdlib,value): Faster JSON parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "sha3",
+ "simdutf8",
  "snafu 0.8.5",
  "snap",
  "strip-ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default = ["compiler", "value", "diagnostic", "path", "parser", "stdlib", "datad
 
 # Main features (on by default)
 compiler = ["diagnostic", "path", "parser", "value", "dep:paste", "dep:chrono", "dep:serde", "dep:regex", "dep:bytes", "dep:ordered-float", "dep:chrono-tz", "dep:snafu", "dep:thiserror", "dep:dyn-clone", "dep:indoc", "dep:thiserror", "dep:lalrpop-util"]
-value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json"]
+value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json", "dep:simdutf8"]
 diagnostic = ["dep:codespan-reporting", "dep:termcolor"]
 path = ["value", "dep:once_cell", "dep:serde", "dep:snafu", "dep:regex"]
 parser = ["path", "diagnostic", "value", "dep:thiserror", "dep:ordered-float", "dep:lalrpop-util"]
@@ -182,6 +182,7 @@ rust_decimal = { version = "1", optional = true }
 seahash = { version = "4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
+simdutf8 = { version = "0.1.5", optional = true }
 fancy-regex = { version = "0.14.0", default-features = false, optional = true }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }

--- a/changelog.d/1249.feature.md
+++ b/changelog.d/1249.feature.md
@@ -1,0 +1,6 @@
+Faster converting bytes to Unicode string by using SIMD instructions provided by simdutf8 crate.
+simdutf8 is up to 23 times faster than the std library on valid non-ASCII, up to four times on pure
+ASCII is the same method provided by Rust's standard library. This will speed up almost all VRL methods
+like `parse_json` or `parse_regex`.
+
+authors: JakubOnderka

--- a/src/compiler/value/convert.rs
+++ b/src/compiler/value/convert.rs
@@ -83,13 +83,10 @@ impl VrlValueConvert for Value {
     }
 
     fn try_bytes_utf8_lossy(&self) -> Result<Cow<'_, str>, ValueError> {
-        match self.as_bytes() {
-            Some(bytes) => Ok(String::from_utf8_lossy(bytes)),
-            None => Err(ValueError::Expected {
-                got: self.kind(),
-                expected: Kind::bytes(),
-            }),
-        }
+        self.as_str().ok_or(ValueError::Expected {
+            got: self.kind(),
+            expected: Kind::bytes(),
+        })
     }
 
     fn try_boolean(self) -> Result<bool, ValueError> {

--- a/src/datadog/grok/matchers/date.rs
+++ b/src/datadog/grok/matchers/date.rs
@@ -255,9 +255,9 @@ pub fn time_format_to_regex(format: &str, with_captures: bool) -> Result<RegexRe
 }
 
 pub fn apply_date_filter(value: &Value, filter: &DateFilter) -> Result<Value, InternalError> {
-    let original_value = String::from_utf8_lossy(value.as_bytes().ok_or_else(|| {
-        InternalError::FailedToApplyFilter(filter.to_string(), value.to_string())
-    })?);
+    let original_value = value
+        .as_str()
+        .ok_or_else(|| InternalError::FailedToApplyFilter(filter.to_string(), value.to_string()))?;
     let (strp_format, mut datetime) =
         adjust_strp_format_and_value(&filter.strp_format, &original_value);
 

--- a/src/stdlib/format_timestamp.rs
+++ b/src/stdlib/format_timestamp.rs
@@ -5,11 +5,10 @@ use chrono::{
     DateTime, Utc,
 };
 
-fn format_timestamp_with_tz(ts: Value, format: Value, timezone: Option<Value>) -> Resolved {
+fn format_timestamp_with_tz(ts: Value, format: &Value, timezone: Option<Value>) -> Resolved {
     let ts: DateTime<Utc> = ts.try_timestamp()?;
 
-    let format_bytes = format.try_bytes()?;
-    let format = String::from_utf8_lossy(&format_bytes);
+    let format = format.try_bytes_utf8_lossy()?;
 
     let timezone_bytes = timezone.map(VrlValueConvert::try_bytes).transpose()?;
     let timezone = timezone_bytes.as_ref().map(|b| String::from_utf8_lossy(b));
@@ -96,7 +95,7 @@ impl FunctionExpression for FormatTimestampFn {
             .map(|tz| tz.resolve(ctx))
             .transpose()?;
 
-        format_timestamp_with_tz(ts, bytes, tz)
+        format_timestamp_with_tz(ts, &bytes, tz)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -6,14 +6,13 @@ use parse_size::Config;
 use rust_decimal::{prelude::FromPrimitive, prelude::ToPrimitive, Decimal};
 use std::collections::HashMap;
 
-fn parse_bytes(bytes: Value, unit: Value, base: &Bytes) -> Resolved {
+fn parse_bytes(bytes: &Value, unit: Value, base: &Bytes) -> Resolved {
     let (units, parse_config) = match base.as_ref() {
         b"2" => (&*BIN_UNITS, Config::new().with_binary()),
         b"10" => (&*DEC_UNITS, Config::new().with_decimal()),
         _ => unreachable!("enum invariant"),
     };
-    let bytes = bytes.try_bytes()?;
-    let value = String::from_utf8_lossy(&bytes);
+    let value = bytes.try_bytes_utf8_lossy()?;
     let value: &str = value.as_ref();
     let conversion_factor = {
         let bytes = unit.try_bytes()?;
@@ -155,7 +154,7 @@ impl FunctionExpression for ParseBytesFn {
         let bytes = self.value.resolve(ctx)?;
         let unit = self.unit.resolve(ctx)?;
 
-        parse_bytes(bytes, unit, &self.base)
+        parse_bytes(&bytes, unit, &self.base)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_duration.rs
+++ b/src/stdlib/parse_duration.rs
@@ -4,13 +4,11 @@ use regex::Regex;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use std::{collections::HashMap, str::FromStr};
 
-fn parse_duration(bytes: Value, unit: Value) -> Resolved {
-    let bytes = bytes.try_bytes()?;
-    let value = String::from_utf8_lossy(&bytes);
+fn parse_duration(bytes: &Value, unit: &Value) -> Resolved {
+    let value = bytes.try_bytes_utf8_lossy()?;
     let mut value = &value[..];
     let conversion_factor = {
-        let bytes = unit.try_bytes()?;
-        let string = String::from_utf8_lossy(&bytes);
+        let string = unit.try_bytes_utf8_lossy()?;
 
         UNITS
             .get(string.as_ref())
@@ -122,7 +120,7 @@ impl FunctionExpression for ParseDurationFn {
         let bytes = self.value.resolve(ctx)?;
         let unit = self.unit.resolve(ctx)?;
 
-        parse_duration(bytes, unit)
+        parse_duration(&bytes, &unit)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_json.rs
+++ b/src/stdlib/parse_json.rs
@@ -10,14 +10,12 @@ use crate::stdlib::json_utils::json_type_def::json_type_def;
 
 fn parse_json(value: Value, lossy: Option<Value>) -> Resolved {
     let lossy = lossy.map(Value::try_boolean).transpose()?.unwrap_or(true);
-    let bytes = if lossy {
-        value.try_bytes_utf8_lossy()?.into_owned().into()
+    Ok(if lossy {
+        serde_json::from_str(&value.try_bytes_utf8_lossy()?)
     } else {
-        value.try_bytes()?
-    };
-    let value = serde_json::from_slice::<'_, Value>(&bytes)
-        .map_err(|e| format!("unable to parse json: {e}"))?;
-    Ok(value)
+        serde_json::from_slice(&value.try_bytes()?)
+    }
+    .map_err(|e| format!("unable to parse json: {e}"))?)
 }
 
 // parse_json_with_depth method recursively traverses the value and returns raw JSON-formatted bytes

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -3,9 +3,8 @@ use regex::Regex;
 
 use super::util;
 
-fn parse_regex(value: Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
-    let bytes = value.try_bytes()?;
-    let value = String::from_utf8_lossy(&bytes);
+fn parse_regex(value: &Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
+    let value = value.try_bytes_utf8_lossy()?;
     let parsed = pattern
         .captures(&value)
         .map(|capture| util::capture_regex_to_map(pattern, &capture, numeric_groups))
@@ -109,7 +108,7 @@ impl FunctionExpression for ParseRegexFn {
         let numeric_groups = self.numeric_groups.resolve(ctx)?;
         let pattern = &self.pattern;
 
-        parse_regex(value, numeric_groups.try_boolean()?, pattern)
+        parse_regex(&value, numeric_groups.try_boolean()?, pattern)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -4,9 +4,8 @@ use crate::compiler::prelude::*;
 
 use super::util;
 
-fn parse_regex_all(value: Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
-    let bytes = value.try_bytes()?;
-    let value = String::from_utf8_lossy(&bytes);
+fn parse_regex_all(value: &Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
+    let value = value.try_bytes_utf8_lossy()?;
     Ok(pattern
         .captures_iter(&value)
         .map(|capture| util::capture_regex_to_map(pattern, &capture, numeric_groups).into())
@@ -121,7 +120,7 @@ impl FunctionExpression for ParseRegexAllFn {
             .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
             .clone();
 
-        parse_regex_all(value, numeric_groups.try_boolean()?, &pattern)
+        parse_regex_all(&value, numeric_groups.try_boolean()?, &pattern)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {

--- a/src/stdlib/strlen.rs
+++ b/src/stdlib/strlen.rs
@@ -1,9 +1,9 @@
 use crate::compiler::prelude::*;
 
-fn strlen(value: Value) -> Resolved {
-    let v = value.try_bytes()?;
+fn strlen(value: &Value) -> Resolved {
+    let v = value.try_bytes_utf8_lossy()?;
 
-    Ok(String::from_utf8_lossy(&v).chars().count().into())
+    Ok(v.chars().count().into())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -51,7 +51,7 @@ impl FunctionExpression for StrlenFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
 
-        strlen(value)
+        strlen(&value)
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -2,10 +2,10 @@
 
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, SecondsFormat, Utc};
-use ordered_float::NotNan;
-use std::{cmp::Ordering, collections::BTreeMap};
-
 pub use iter::{IterItem, ValueIter};
+use ordered_float::NotNan;
+use std::borrow::Cow;
+use std::{cmp::Ordering, collections::BTreeMap};
 
 pub use super::value::regex::ValueRegex;
 use super::KeyString;
@@ -189,6 +189,26 @@ impl PartialOrd for Value {
             _ => None,
         }
     }
+}
+
+/// Converts a slice of bytes to a string, including invalid characters.
+#[must_use]
+pub fn simdutf_bytes_utf8_lossy(v: &[u8]) -> Cow<'_, str> {
+    simdutf8::basic::from_utf8(v).map_or_else(
+        |_| {
+            const REPLACEMENT: &str = "\u{FFFD}";
+
+            let mut res = String::with_capacity(v.len());
+            for chunk in v.utf8_chunks() {
+                res.push_str(chunk.valid());
+                if !chunk.invalid().is_empty() {
+                    res.push_str(REPLACEMENT);
+                }
+            }
+            Cow::Owned(res)
+        },
+        Cow::Borrowed,
+    )
 }
 
 /// Converts a timestamp to a `String`.

--- a/src/value/value/convert.rs
+++ b/src/value/value/convert.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use crate::value::value::regex::ValueRegex;
+use crate::value::value::simdutf_bytes_utf8_lossy;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use ordered_float::NotNan;
 use regex::Regex;
-
-use crate::value::value::regex::ValueRegex;
 
 use super::super::{KeyString, Kind, ObjectMap, Value};
 
@@ -131,7 +131,7 @@ impl Value {
     /// Returns self as `Cow<str>`, only if self is `Value::Bytes`
     pub fn as_str(&self) -> Option<Cow<'_, str>> {
         self.as_bytes()
-            .map(|bytes| String::from_utf8_lossy(bytes.as_ref()))
+            .map(|bytes| simdutf_bytes_utf8_lossy(bytes.as_ref()))
     }
 
     /// Converts the Value into a byte representation regardless of its original type.


### PR DESCRIPTION
## Summary

This merge requests speeds up JSON parsing when `lossy` is set to true:

* it avoids double validation if bytes are valid UTF-8 string by using specific method from serde-json
* uses simdutf8 crate for faster UTF-8 validation
  * this crate is already included when default features are on
  * string validation by this crate is 4-11 times faster than Rust stdlib validation
  * converting to lossy string can be slower in case string is not UTF-8 valid (it should be very rare)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard tests

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
