### PR TITLE
feat(stdlib): add `shannon_entropy` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,6 +3685,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "uaparser",
+ "unicode-segmentation",
  "url",
  "utf8-width",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ ofb = { version = "0.6", optional = true }
 # Protobuf support.
 prost = { version = "0.13", default-features = false, optional = true, features = ["std"] }
 prost-reflect = { version = "0.14", default-features = false, optional = true }
+unicode-segmentation = "1.12.0"
 
 # Dependencies used for non-WASM
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -143,6 +143,7 @@ criterion_group!(
               sha1,
               sha2,
               sha3,
+              shannon_entropy,
               sieve,
               slice,
               split,
@@ -2527,6 +2528,25 @@ bench_function! {
     default {
         args: func_args![value: "foo"],
         want: Ok("4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7")
+    }
+}
+
+bench_function! {
+    shannon_entropy => vrl::stdlib::ShannonEntropy;
+
+    default {
+        args: func_args![value: value!("Supercalifragilisticexpialidocious")],
+        want: Ok(value!(3.736_987_930_635_821)),
+    }
+
+    codepoint_segmentation {
+        args: func_args![value: value!("Supercalifragilisticexpialidocious"), segmentation: value!("codepoint")],
+        want: Ok(value!(3.736_987_930_635_821)),
+    }
+
+    grapheme_segmentation {
+        args: func_args![value: value!("test123%456.فوائد.net."), segmentation: value!("grapheme")],
+        want: Ok(value!(3.936_260_027_531_526_3)),
     }
 }
 

--- a/changelog.d/1267.feature.md
+++ b/changelog.d/1267.feature.md
@@ -1,0 +1,3 @@
+Added `shannon_entropy` function to generate [entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) from a string.
+
+authors: esensar

--- a/lib/tests/tests/functions/shannon_entropy/codepoints.vrl
+++ b/lib/tests/tests/functions/shannon_entropy/codepoints.vrl
@@ -1,0 +1,5 @@
+# result: true
+
+# fancy f - not regular f
+# this string has 4 bytes, but only 3 chars, changing entropy
+floor(shannon_entropy("ƒoo", segmentation: "codepoint"), precision: 4) != floor(shannon_entropy("ƒoo"), precision: 4)

--- a/lib/tests/tests/functions/shannon_entropy/default.vrl
+++ b/lib/tests/tests/functions/shannon_entropy/default.vrl
@@ -1,0 +1,3 @@
+# result: 3.7369
+
+floor(shannon_entropy("Supercalifragilisticexpialidocious"), precision: 4)

--- a/lib/tests/tests/functions/shannon_entropy/utf8.vrl
+++ b/lib/tests/tests/functions/shannon_entropy/utf8.vrl
@@ -1,0 +1,4 @@
+# result: true
+
+# UTF-8 example
+floor(shannon_entropy("test123%456.فوائد.net.", segmentation: "grapheme"), precision: 4) != floor(shannon_entropy("test123%456.فوائد.net."), precision: 4)

--- a/lib/tests/tests/functions/shannon_entropy/utf8_emojis.vrl
+++ b/lib/tests/tests/functions/shannon_entropy/utf8_emojis.vrl
@@ -1,0 +1,9 @@
+# result: true
+
+# UTF-8 example
+utf8string = "🙋🏿🇯🇵"
+bytes_result = floor(shannon_entropy(utf8string), precision: 4)
+codepoints_result = floor(shannon_entropy(utf8string, segmentation: "codepoint"), precision: 4)
+grapheme_result = floor(shannon_entropy(utf8string, segmentation: "grapheme"), precision: 4)
+
+bytes_result != codepoints_result && bytes_result != grapheme_result && codepoints_result != grapheme_result

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -159,6 +159,7 @@ cfg_if::cfg_if! {
         mod sha1;
         mod sha2;
         mod sha3;
+        mod shannon_entropy;
         mod sieve;
         mod slice;
         mod split;
@@ -345,6 +346,7 @@ cfg_if::cfg_if! {
         pub use set::Set;
         pub use sha2::Sha2;
         pub use sha3::Sha3;
+        pub use shannon_entropy::ShannonEntropy;
         pub use sieve::Sieve;
         pub use slice::Slice;
         pub use split::Split;
@@ -541,6 +543,7 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(Sha1),
         Box::new(Sha2),
         Box::new(Sha3),
+        Box::new(ShannonEntropy),
         Box::new(Sieve),
         Box::new(ScreamingSnakecase),
         Box::new(Snakecase),

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -141,7 +141,7 @@ impl Function for ShannonEntropy {
     fn compile(
         &self,
         state: &state::TypeState,
-        _ctx: &mut FunctionCompileContext,
+        _ctx: &mut CompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -39,7 +39,7 @@ fn shannon_entropy(value: &Value, segmentation: &Segmentation) -> Resolved {
             let mut total_len = 0;
 
             for char in chars {
-                *counts.entry(char).or_default() += 1;
+                counts.entry(char).and_modify(|c| *c += 1).or_insert(1);
                 total_len += 1;
             }
 
@@ -52,7 +52,7 @@ fn shannon_entropy(value: &Value, segmentation: &Segmentation) -> Resolved {
             let mut total_len = 0;
 
             for grapheme in graphemes {
-                *counts.entry(grapheme).or_default() += 1;
+                counts.entry(grapheme).and_modify(|c| *c += 1).or_insert(1);
                 total_len += 1;
             }
 

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -1,0 +1,232 @@
+use std::{collections::HashMap, str::FromStr};
+
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::compiler::prelude::*;
+
+#[allow(clippy::cast_precision_loss)] //TODO evaluate removal options
+fn shannon_entropy(value: &Value, segmentation: &Segmentation) -> Resolved {
+    let (occurence_counts, total_length): (Vec<usize>, usize) = match segmentation {
+        Segmentation::Byte => {
+            // Optimized version for bytes, since there is a limited number of options, that could
+            // easily be kept track of
+            let bytes = value.clone().try_bytes()?;
+            let mut counts = [0usize; 256];
+            let total_len = bytes.len() as f64;
+
+            for b in bytes {
+                counts[b as usize] += 1;
+            }
+
+            let mut entropy = 0.0;
+
+            for count in counts {
+                if count == 0 {
+                    continue;
+                }
+
+                let p = count as f64 / total_len;
+
+                entropy -= p * p.log2();
+            }
+
+            return Ok(Value::from_f64_or_zero(entropy));
+        }
+        Segmentation::Codepoint => {
+            let string = value.try_bytes_utf8_lossy()?;
+            let chars = string.chars();
+            let mut counts = HashMap::new();
+            let mut total_len = 0;
+
+            for char in chars {
+                *counts.entry(char).or_default() += 1;
+                total_len += 1;
+            }
+
+            (counts.into_values().collect(), total_len)
+        }
+        Segmentation::Grapheme => {
+            let string = value.try_bytes_utf8_lossy()?;
+            let graphemes = string.graphemes(true);
+            let mut counts = HashMap::new();
+            let mut total_len = 0;
+
+            for grapheme in graphemes {
+                *counts.entry(grapheme).or_default() += 1;
+                total_len += 1;
+            }
+
+            (counts.into_values().collect(), total_len)
+        }
+    };
+
+    Ok(Value::from_f64_or_zero(
+        occurence_counts
+            .iter()
+            // Calculate probability of each item by diving occurence count by total length
+            .map(|occurence_count| *occurence_count as f64 / total_length as f64)
+            // Calculate entropy using definition: sum(-p * log2(p))
+            .fold(0f64, |acc, p| acc - (p * p.log2())),
+    ))
+}
+
+#[derive(Default, Debug, Clone)]
+enum Segmentation {
+    #[default]
+    Byte,
+    Codepoint,
+    Grapheme,
+}
+
+impl FromStr for Segmentation {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "byte" => Ok(Self::Byte),
+            "codepoint" => Ok(Self::Codepoint),
+            "grapheme" => Ok(Self::Grapheme),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ShannonEntropy;
+
+impl Function for ShannonEntropy {
+    fn identifier(&self) -> &'static str {
+        "shannon_entropy"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "segmentation",
+                kind: kind::BYTES,
+                required: false,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "shannon_entropy simple",
+                source: r#"floor(shannon_entropy("vector.dev"), precision: 4)"#,
+                result: Ok("2.9219"),
+            },
+            Example {
+                title: "shannon_entropy UTF-8 wrong segmentation",
+                source: r#"floor(shannon_entropy("test123%456.فوائد.net."), precision: 4)"#,
+                result: Ok("4.0784"),
+            },
+            Example {
+                title: "shannon_entropy UTF-8 grapheme segmentation",
+                source: r#"shannon_entropy("👨‍👩‍👧‍👦", segmentation: "grapheme")"#,
+                result: Ok("0.0"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        let segmentation = arguments
+            .optional_enum(
+                "segmentation",
+                &["byte".into(), "codepoint".into(), "grapheme".into()],
+                state,
+            )?
+            .map(|s| {
+                Segmentation::from_str(&s.try_bytes_utf8_lossy().expect("segmentation not bytes"))
+                    .expect("validated enum")
+            })
+            .unwrap_or_default();
+
+        Ok(ShannonEntropyFn {
+            value,
+            segmentation,
+        }
+        .as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ShannonEntropyFn {
+    value: Box<dyn Expression>,
+    segmentation: Segmentation,
+}
+
+impl FunctionExpression for ShannonEntropyFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+
+        shannon_entropy(&value, &self.segmentation)
+    }
+
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        TypeDef::float().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value;
+
+    test_function![
+        shannon_entropy => ShannonEntropy;
+
+        simple_example {
+            args: func_args![value: value!("vector.dev")],
+            want: Ok(value!(2.921_928_094_887_362_3)),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        longer_example {
+            args: func_args![value: value!("Supercalifragilisticexpialidocious")],
+            want: Ok(value!(3.736_987_930_635_820_5)),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        fancy_foo_example {
+            args: func_args![value: value!("ƒoo")],
+            want: Ok(value!(1.5)),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        fancy_foo_codepoint_segmentation_example {
+            args: func_args![value: value!("ƒoo"), segmentation: value!("codepoint")],
+            want: Ok(value!(0.918_295_834_054_489_6)),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        utf_8_byte_segmentation_example {
+            args: func_args![value: value!("test123%456.فوائد.net.")],
+            want: Ok(value!(4.078_418_520_441_603)),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        utf_8_codepoint_segmentation_example {
+            args: func_args![value: value!("test123%456.فوائد.net."), segmentation: value!("codepoint")],
+            want: Ok(value!(3.936_260_027_531_526_3)),
+            tdef: TypeDef::float().infallible(),
+        }
+
+        utf_8_example {
+            args: func_args![value: value!("test123%456.فوائد.net."), segmentation: value!("grapheme")],
+            want: Ok(value!(3.936_260_027_531_526_3)),
+            tdef: TypeDef::float().infallible(),
+        }
+    ];
+}

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -4,7 +4,11 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::compiler::prelude::*;
 
-#[allow(clippy::cast_precision_loss)] //TODO evaluate removal options
+// Casting to f64 in this function is only done to enable proper division (when calculating probability)
+// Since numbers being casted represent lenghts of input strings and number of character occurences,
+// we can assume that there will never really be precision loss here, because that would mean that
+// the string is at least 2^52 bytes in size (4.5 PB)
+#[allow(clippy::cast_precision_loss)]
 fn shannon_entropy(value: &Value, segmentation: &Segmentation) -> Resolved {
     let (occurence_counts, total_length): (Vec<usize>, usize) = match segmentation {
         Segmentation::Byte => {

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -188,12 +188,12 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::stdlib::util::round_to_precision;
+    use crate::{stdlib::util::round_to_precision, value};
 
     #[test]
     fn simple_example() {
         assert_eq!(
-            2.9219,
+            value!(2.9219),
             execute_function_with_precision(
                 &ShannonEntropyFn {
                     value: expr!("vector.dev"),
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn longer_example() {
         assert_eq!(
-            3.737,
+            value!(3.737),
             execute_function_with_precision(
                 &ShannonEntropyFn {
                     value: expr!("Supercalifragilisticexpialidocious"),
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn fancy_foo_example() {
         assert_eq!(
-            1.5,
+            value!(1.5),
             execute_function(&ShannonEntropyFn {
                 value: expr!("ƒoo"),
                 segmentation: Segmentation::default()
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn fancy_foo_codepoint_segmentation_example() {
         assert_eq!(
-            0.9183,
+            value!(0.9183),
             execute_function_with_precision(
                 &ShannonEntropyFn {
                     value: expr!("ƒoo"),
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn utf_8_byte_segmentation_example() {
         assert_eq!(
-            4.0784,
+            value!(4.0784),
             execute_function_with_precision(
                 &ShannonEntropyFn {
                     value: expr!("test123%456.فوائد.net."),
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn utf_8_codepoint_segmentation_example() {
         assert_eq!(
-            3.9363,
+            value!(3.9363),
             execute_function_with_precision(
                 &ShannonEntropyFn {
                     value: expr!("test123%456.فوائد.net."),
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn utf_8_example() {
         assert_eq!(
-            3.9363,
+            value!(3.9363),
             execute_function_with_precision(
                 &ShannonEntropyFn {
                     value: expr!("test123%456.فوائد.net."),
@@ -293,15 +293,17 @@ mod tests {
         function.resolve(&mut ctx)
     }
 
-    fn execute_function(function: &ShannonEntropyFn) -> f64 {
+    fn execute_function(function: &ShannonEntropyFn) -> Value {
         prepare_function(function)
             .map_err(|e| format!("{:#}", anyhow::anyhow!(e)))
             .unwrap()
-            .try_float()
-            .unwrap()
     }
 
-    fn execute_function_with_precision(function: &ShannonEntropyFn, precision: i64) -> f64 {
-        round_to_precision(execute_function(function), precision, f64::round)
+    fn execute_function_with_precision(function: &ShannonEntropyFn, precision: i64) -> Value {
+        Value::from_f64_or_zero(round_to_precision(
+            execute_function(function).try_float().unwrap(),
+            precision,
+            f64::round,
+        ))
     }
 }


### PR DESCRIPTION
## Summary

Adds `shannon_entropy` function for calculating
[shannon entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) of strings, providing 3 different segmentation modes (bytes, codepoints and graphemes).

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Through the added unit and VRL tests.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool). (*unicode-segmentation was already a transitive dependency, so there are no changes to licenses*)
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

Fixes: #1258
Documentation: https://github.com/vectordotdev/vector/pull/22428

---
>Sponsored by [Quad9](https://quad9.net/)