### PR TITLE
fix(stdlib): Parsing nginx error log message with comma

### DIFF
--- a/changelog.d/1280.fix.md
+++ b/changelog.d/1280.fix.md
@@ -1,0 +1,3 @@
+Fix `parse_nginx_log` function when a format is set to error and an error message contains comma.
+
+authors: JakubOnderka

--- a/src/stdlib/log_util.rs
+++ b/src/stdlib/log_util.rs
@@ -182,7 +182,7 @@ pub(crate) static REGEX_NGINX_ERROR_LOG: Lazy<Regex> = Lazy::new(|| {
         (?P<pid>\d+)\#                                                           # Match any number
         (?P<tid>\d+):                                                            # Match any number
         (\s+\*(?P<cid>\d+))?                                                     # Match any number
-        \s+(?P<message>[^,]*)                                                    # Match any character
+        \s+(?P<message>.+?)                                                      # Match any character
         (,\s+excess:\s+(?P<excess>[^\s]+)\sby\szone\s"(?P<zone>[^,]+)")?         # Match any character after ', excess: ' until ' by zone ' and the rest of characters
         (,\s+client:\s+(?P<client>[^,]+))?                                       # Match any character after ', client: '
         (,\s+server:\s+(?P<server>[^,]*))?                                       # Match any character after ', server: '

--- a/src/stdlib/parse_nginx_log.rs
+++ b/src/stdlib/parse_nginx_log.rs
@@ -668,5 +668,26 @@ mod tests {
             }),
             tdef: TypeDef::object(kind_error()).fallible(),
         }
+
+        error_message_with_comma {
+            args: func_args![
+                value: r#"2022/05/30 20:56:22 [info] 3134#0: *99247 epoll_wait() reported that client prematurely closed connection, so upstream connection is closed too (104: Connection reset by peer) while reading upstream, client: 10.244.0.0, server: example.org, request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm/php8.3-fpm.sock:", host: "example:8080""#,
+                format: "error"
+            ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2022-05-30T20:56:22Z").unwrap().into()),
+                "severity" => "info",
+                "pid" => 3134,
+                "tid" => 0,
+                "cid" => 99_247,
+                "message" => "epoll_wait() reported that client prematurely closed connection, so upstream connection is closed too (104: Connection reset by peer) while reading upstream",
+                "client" => "10.244.0.0",
+                "server" => "example.org",
+                "request" => "GET / HTTP/1.1",
+                "host" => "example:8080",
+                "upstream" => "fastcgi://unix:/run/php-fpm/php8.3-fpm.sock:",
+            }),
+            tdef: TypeDef::object(kind_error()).fallible(),
+        }
     ];
 }


### PR DESCRIPTION
## Summary

Fixes `parse_nginx_log` VRL function when format is set to `error` and error message contains comma.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard test suite.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

- Closes: [#305](https://github.com/vectordotdev/vrl/issues/305)
