### PR TITLE
chore(releasing): Prepare 0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@
 
 <!-- changelog start -->
 
+## [0.22.0 (2025-02-19)]
+
+
+### Breaking Changes & Upgrade Guide
+
+- Removed deprecated `ellipsis` argument from the `truncate` function. Use `suffix` instead. (https://github.com/vectordotdev/vrl/pull/1188)
+- Fix `slice` type_def. This is a breaking change because it might change the fallibility of the `slice` function and this VRL scripts will
+  need to be updated accordingly.
+
+  authors: pront (https://github.com/vectordotdev/vrl/pull/1246)
+
+### New Features
+
+- Added new `to_syslog_facility_code` function to convert syslog facility keyword to syslog facility code. (https://github.com/vectordotdev/vrl/pull/1221)
+- Downgrade "can't abort infallible function" error to a warning. (https://github.com/vectordotdev/vrl/pull/1247)
+- `ip_cidr_contains` method now also accepts an array of CIDRs.
+
+  authors: JakubOnderka (https://github.com/vectordotdev/vrl/pull/1248)
+- Faster converting bytes to Unicode string by using SIMD instructions provided by simdutf8 crate.
+  simdutf8 is up to 23 times faster than the std library on valid non-ASCII, up to four times on pure
+  ASCII is the same method provided by Rust's standard library. This will speed up almost all VRL methods
+  like `parse_json` or `parse_regex`.
+
+  authors: JakubOnderka (https://github.com/vectordotdev/vrl/pull/1249)
+- Added `shannon_entropy` function to generate [entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) from a string.
+
+  authors: esensar (https://github.com/vectordotdev/vrl/pull/1267)
+
+### Fixes
+
+- Fix decimals parsing in parse_duration function
+
+  authors: sainad2222 (https://github.com/vectordotdev/vrl/pull/1223)
+- Fix `parse_nginx_log` function when a format is set to error and an error message contains comma.
+
+  authors: JakubOnderka (https://github.com/vectordotdev/vrl/pull/1280)
+
+
 ## [0.21.0 (2025-01-13)]
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,7 +3579,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrl"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aes",
  "aes-siv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/changelog.d/1188.breaking.md
+++ b/changelog.d/1188.breaking.md
@@ -1,1 +1,0 @@
-Removed deprecated `ellipsis` argument from the `truncate` function. Use `suffix` instead.

--- a/changelog.d/1221.feature.md
+++ b/changelog.d/1221.feature.md
@@ -1,1 +1,0 @@
-Added new `to_syslog_facility_code` function to convert syslog facility keyword to syslog facility code.

--- a/changelog.d/1223.fix.md
+++ b/changelog.d/1223.fix.md
@@ -1,3 +1,0 @@
-Fix decimals parsing in parse_duration function
-
-authors: sainad2222

--- a/changelog.d/1246.breaking.md
+++ b/changelog.d/1246.breaking.md
@@ -1,4 +1,0 @@
-Fix `slice` type_def. This is a breaking change because it might change the fallibility of the `slice` function and this VRL scripts will
-need to be updated accordingly.
-
-authors: pront

--- a/changelog.d/1247.feature.md
+++ b/changelog.d/1247.feature.md
@@ -1,1 +1,0 @@
-Downgrade "can't abort infallible function" error to a warning.

--- a/changelog.d/1248.feature.md
+++ b/changelog.d/1248.feature.md
@@ -1,3 +1,0 @@
-`ip_cidr_contains` method now also accepts an array of CIDRs.
-
-authors: JakubOnderka

--- a/changelog.d/1249.feature.md
+++ b/changelog.d/1249.feature.md
@@ -1,6 +1,0 @@
-Faster converting bytes to Unicode string by using SIMD instructions provided by simdutf8 crate.
-simdutf8 is up to 23 times faster than the std library on valid non-ASCII, up to four times on pure
-ASCII is the same method provided by Rust's standard library. This will speed up almost all VRL methods
-like `parse_json` or `parse_regex`.
-
-authors: JakubOnderka

--- a/changelog.d/1267.feature.md
+++ b/changelog.d/1267.feature.md
@@ -1,3 +1,0 @@
-Added `shannon_entropy` function to generate [entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) from a string.
-
-authors: esensar

--- a/changelog.d/1280.fix.md
+++ b/changelog.d/1280.fix.md
@@ -1,3 +1,0 @@
-Fix `parse_nginx_log` function when a format is set to error and an error message contains comma.
-
-authors: JakubOnderka

--- a/release/create_release_pull_request.py
+++ b/release/create_release_pull_request.py
@@ -81,7 +81,7 @@ def create_pull_request(branch_name, new_version, dry_run=False):
         try:
             subprocess.run(
                 ["gh", "pr", "create", "--title", title, "--body", body, "--head", branch_name,
-                 "--base", "main"], check=True, cwd=REPO_ROOT_DIR)
+                 "--base", "main", "--label", "no-changelog"], check=True, cwd=REPO_ROOT_DIR)
         except subprocess.CalledProcessError as e:
             print(f"Failed to create pull request: {e}")
 

--- a/release/create_release_pull_request.py
+++ b/release/create_release_pull_request.py
@@ -9,9 +9,10 @@ import semver
 
 from utils.validate_version import assert_version_is_not_published
 
-SCRIPTS_DIR = os.path.dirname(abspath(getsourcefile(lambda: 0)))
-REPO_ROOT_DIR = os.path.dirname(SCRIPTS_DIR)
+RELEASE_DIR = os.path.dirname(abspath(getsourcefile(lambda: 0)))
+REPO_ROOT_DIR = os.path.dirname(RELEASE_DIR)
 CHANGELOG_DIR = os.path.join(REPO_ROOT_DIR, "changelog.d")
+SCRIPTS_DIR = os.path.join(REPO_ROOT_DIR, "scripts")
 
 
 def overwrite_version(version):

--- a/release/create_release_pull_request.py
+++ b/release/create_release_pull_request.py
@@ -13,7 +13,7 @@ RELEASE_DIR = os.path.dirname(abspath(getsourcefile(lambda: 0)))
 REPO_ROOT_DIR = os.path.dirname(RELEASE_DIR)
 CHANGELOG_DIR = os.path.join(REPO_ROOT_DIR, "changelog.d")
 SCRIPTS_DIR = os.path.join(REPO_ROOT_DIR, "scripts")
-
+SCRIPT_FILENAME = os.path.basename(getsourcefile(lambda: 0))
 
 def overwrite_version(version):
     toml_path = os.path.join(REPO_ROOT_DIR, "Cargo.toml")
@@ -73,7 +73,7 @@ def create_branch(branch_name, dry_run=False):
 
 def create_pull_request(branch_name, new_version, dry_run=False):
     title = f"chore(releasing): Prepare {new_version} release"
-    body = "Generated with `./scripts/create-release-pull-request.py`."
+    body = f"Generated with {SCRIPT_FILENAME}"
     print(f"Creating pull request with title: {title}")
     if dry_run:
         print("Dry-run mode: Skipping PR creation.")


### PR DESCRIPTION
Generated with `./scripts/create-release-pull-request.py`.

Ref: https://github.com/vectordotdev/vector/issues/22445