### PR TITLE
performance(stdlib): Optimise is_nullish

### DIFF
--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -66,17 +66,17 @@ pub(crate) fn regex_kind(
     inner_type
 }
 
-pub(crate) fn is_nullish(value: &crate::value::Value) -> bool {
+pub(crate) fn is_nullish(value: &Value) -> bool {
     match value {
-        crate::value::Value::Bytes(v) => {
-            let s = &String::from_utf8_lossy(v)[..];
-
-            match s {
-                "-" => true,
-                _ => s.chars().all(char::is_whitespace),
+        Value::Bytes(v) => {
+            if v.is_empty() || v.as_ref() == b"-" {
+                return true;
             }
+
+            let s = value.as_str().expect("value should be bytes");
+            s.chars().all(char::is_whitespace)
         }
-        crate::value::Value::Null => true,
+        Value::Null => true,
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

`vrl_stdlib/functions/is_nullish/hyphen` is faster by 15.612%
`vrl_stdlib/functions/is_nullish/not_empty` is faster by 13.092%

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard test cases and criterion benchmark

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.