### PR TITLE
fix(stdlib): Fix parsing nginx error log delaying request

### DIFF
--- a/changelog.d/1285.fix.md
+++ b/changelog.d/1285.fix.md
@@ -1,0 +1,3 @@
+The `parse_nginx_log` function can now parse `delaying requests` error messages.
+
+authors: JakubOnderka

--- a/src/stdlib/log_util.rs
+++ b/src/stdlib/log_util.rs
@@ -183,7 +183,7 @@ pub(crate) static REGEX_NGINX_ERROR_LOG: LazyLock<Regex> = LazyLock::new(|| {
         (?P<tid>\d+):                                                            # Match any number
         (\s+\*(?P<cid>\d+))?                                                     # Match any number
         \s+(?P<message>.+?)                                                      # Match any character
-        (,\s+excess:\s+(?P<excess>[^\s]+)\sby\szone\s"(?P<zone>[^,]+)")?         # Match any character after ', excess: ' until ' by zone ' and the rest of characters
+        (,\s+excess:\s+(?P<excess>[^\s,]+),?\sby\szone\s"(?P<zone>[^,]+)")?      # Match any character after ', excess: ' until ' by zone ' and the rest of characters
         (,\s+client:\s+(?P<client>[^,]+))?                                       # Match any character after ', client: '
         (,\s+server:\s+(?P<server>[^,]*))?                                       # Match any character after ', server: '
         (,\s+request:\s+"(?P<request>[^"]*)")?                                   # Match any character after ', request: '

--- a/src/stdlib/parse_nginx_log.rs
+++ b/src/stdlib/parse_nginx_log.rs
@@ -669,6 +669,28 @@ mod tests {
             tdef: TypeDef::object(kind_error()).fallible(),
         }
 
+        error_rate_delaying {
+            args: func_args![
+                value: r#"2022/05/30 20:56:22 [error] 7164#7164: *38068741 delaying requests, excess: 50.416, by zone "api_access_token", client: 10.244.0.0, server: test.local, request: "GET / HTTP/2.0", host: "127.0.0.1:8080""#,
+                format: "error"
+            ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2022-05-30T20:56:22Z").unwrap().into()),
+                "severity" => "error",
+                "pid" => 7164,
+                "tid" => 7164,
+                "cid" => 38_068_741,
+                "message" => "delaying requests",
+                "excess" => 50.416,
+                "zone" => "api_access_token",
+                "client" => "10.244.0.0",
+                "server" => "test.local",
+                "request" => "GET / HTTP/2.0",
+                "host" => "127.0.0.1:8080",
+            }),
+            tdef: TypeDef::object(kind_error()).fallible(),
+        }
+
         error_message_with_comma {
             args: func_args![
                 value: r#"2022/05/30 20:56:22 [info] 3134#0: *99247 epoll_wait() reported that client prematurely closed connection, so upstream connection is closed too (104: Connection reset by peer) while reading upstream, client: 10.244.0.0, server: example.org, request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm/php8.3-fpm.sock:", host: "example:8080""#,


### PR DESCRIPTION
## Summary

`parse_nginx_log` can currently successfully parse `limiting requests` log, but `delaying requests` has little bit different and contains one extra comma.

```
2022/05/30 20:56:22 [error] 7164#7164: *38068741 limiting requests, excess: 50.416 by zone "api_access_token"
2022/05/30 20:56:22 [error] 7164#7164: *38068741 delaying requests, excess: 50.416, by zone "api_access_token"
```

https://github.com/nginx/nginx/blob/d25139db01b636a8212c13e1feeca37eaadad0b5/src/http/modules/ngx_http_limit_req_module.c#L301

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard test case.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
