### PR TITLE
performance(stdlib): Optimise ip_cidr_contains when cidr is constant

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -747,6 +747,11 @@ bench_function! {
         want: Ok(true),
     }
 
+    ipv4_array {
+        args: func_args![cidr: value!(["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]), value: "192.168.10.32"],
+        want: Ok(true),
+    }
+
     ipv6 {
         args: func_args![cidr: "2001:4f8:3:ba::/64", value: "2001:4f8:3:ba:2e0:81ff:fe22:d1f1"],
         want: Ok(true),

--- a/changelog.d/1286.breaking.md
+++ b/changelog.d/1286.breaking.md
@@ -1,0 +1,38 @@
+The `ip_cidr_contains` function now validates the cidr argument during the compilation phase if it is a constant string or array. Previously, invalid constant CIDR values would only trigger an error during execution.
+
+Previous Behavior: Runtime Error
+
+Previously, if an invalid CIDR was passed as a constant, an error was thrown at runtime:
+
+```
+error[E000]: function call error for "ip_cidr_contains" at (0:45): unable to parse CIDR: couldn't parse address in network: invalid IP address syntax
+  ┌─ :1:1
+  │
+1 │ ip_cidr_contains!("INVALID", "192.168.10.32")
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to parse CIDR: couldn't parse address in network: invalid IP address syntax
+  │
+  = see language documentation at https://vrl.dev
+  = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+```
+
+New Behavior: Compilation Error
+
+```
+error[E610]: function compilation error: error[E403] invalid argument
+  ┌─ :1:1
+  │
+1 │ ip_cidr_contains!("INVALID", "192.168.10.32")
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │ │
+  │ invalid argument "ip_cidr_contains"
+  │ error: "cidr" must be valid cidr
+  │ received: "INVALID"
+  │
+  = learn more about error code 403 at https://errors.vrl.dev/403
+  = see language documentation at https://vrl.dev
+  = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+```
+
+This change improves error detection by identifying invalid CIDR values earlier, reducing unexpected failures at runtime and provides better performance.
+
+authors: JakubOnderka


### PR DESCRIPTION
## Summary

Currently, when `cidr` argument for `ip_cidr_contains` method is constant, it must be parsed every time when this method is called. 

With this patch, if cidr is constant, it is parsed just once during compilation phase.

Benchmark comparing current and new implementation when cidr is constant:

```
vrl_stdlib/functions/ip_cidr_contains/ipv4
                        time:   [43.337 ns 43.411 ns 43.516 ns]
                        thrpt:  [22.980 Melem/s 23.036 Melem/s 23.075 Melem/s]
                 change:
                        time:   [-40.526% -40.341% -40.142%] (p = 0.00 < 0.05)
                        thrpt:  [+67.062% +67.618% +68.141%]
                        Performance has improved.
vrl_stdlib/functions/ip_cidr_contains/ipv4_array
                        time:   [45.976 ns 46.024 ns 46.074 ns]
                        thrpt:  [21.704 Melem/s 21.728 Melem/s 21.750 Melem/s]
                 change:
                        time:   [-82.085% -81.788% -81.608%] (p = 0.00 < 0.05)
                        thrpt:  [+443.72% +449.09% +458.18%]
                        Performance has improved.
vrl_stdlib/functions/ip_cidr_contains/ipv6
                        time:   [102.05 ns 102.36 ns 102.84 ns]
                        thrpt:  [9.7241 Melem/s 9.7697 Melem/s 9.7993 Melem/s]
                 change:
                        time:   [-41.266% -40.910% -40.370%] (p = 0.00 < 0.05)
                        thrpt:  [+67.701% +69.234% +70.259%]
                        Performance has improved.
```

Error message during compilation when invalid cidr is provided:

```
error[E610]: function compilation error: error[E403] invalid argument
  ┌─ :2:13
  │
2 │ .contains = ip_cidr_contains!("127.0.0.0/33", "127.0.0.1")
  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  │             │
  │             invalid argument "ip_cidr_contains"
  │             error: "cidr" must be valid cidr
  │             received: "127.0.0.0/33"
  │
  = learn more about error code 403 at https://errors.vrl.dev/403
  = see language documentation at https://vrl.dev
  = try your code in the VRL REPL, learn more at https://vrl.dev/examples
```

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

It can be breaking when invalid constant CIDR is provided as method argument. Currently it will fail in runtime, with this patch it will fail during compilation.

## How did you test this PR?

Manual testing and standard test cases.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
