### PR TITLE
[DRAFT] Performance - Remove unneeded value clones

### DIFF
--- a/src/compiler/expression/abort.rs
+++ b/src/compiler/expression/abort.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::compiler::{
     expression::{ExpressionError, Resolved},
+    expression_error::Executed,
     state::{TypeInfo, TypeState},
     value::{Kind, VrlValueConvert},
     Context, Expression, Span, TypeDef,
@@ -62,6 +63,13 @@ impl Expression for Abort {
             span: self.span,
             message,
         })
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        if let Some(ref expr) = self.message {
+            expr.execute(ctx)?;
+        }
+        Ok(())
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/array.rs
+++ b/src/compiler/expression/array.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt, ops::Deref};
 use crate::value::Value;
 use crate::{
     compiler::{
-        expression::{Expr, Resolved},
+        expression::{Executed, Expr, Resolved},
         state::{TypeInfo, TypeState},
         Context, Expression, TypeDef,
     },
@@ -36,6 +36,13 @@ impl Expression for Array {
             .map(|expr| expr.resolve(ctx))
             .collect::<Result<Vec<_>, _>>()
             .map(Value::Array)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        for expr in &self.inner {
+            expr.execute(ctx)?;
+        }
+        Ok(())
     }
 
     fn resolve_constant(&self, state: &TypeState) -> Option<Value> {

--- a/src/compiler/expression/block.rs
+++ b/src/compiler/expression/block.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
     expression::{Expr, Resolved},
-    Context, Expression, TypeDef,
+    Context, Executed, Expression, TypeDef,
 };
 use crate::value::Kind;
 
@@ -49,11 +49,14 @@ impl Expression for Block {
         // in scope can be accessed here, so it doesn't need to be checked at runtime.
         let (last, other) = self.inner.split_last().expect("at least one expression");
 
-        other
-            .iter()
-            .try_for_each(|expr| expr.resolve(ctx).map(|_| ()))?;
+        other.iter().try_for_each(|expr| expr.execute(ctx))?;
 
         last.resolve(ctx)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        self.inner.iter().try_for_each(|expr| expr.execute(ctx))?;
+        Ok(())
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/container.rs
+++ b/src/compiler/expression/container.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::compiler::{
-    expression::{Array, Block, Group, Object, Resolved, Value},
+    expression::{Array, Block, Executed, Group, Object, Resolved, Value},
     state::{TypeInfo, TypeState},
     Context, Expression,
 };
@@ -35,6 +35,17 @@ impl Expression for Container {
             Block(v) => v.resolve(ctx),
             Array(v) => v.resolve(ctx),
             Object(v) => v.resolve(ctx),
+        }
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        use Variant::{Array, Block, Group, Object};
+
+        match &self.variant {
+            Group(v) => v.execute(ctx),
+            Block(v) => v.execute(ctx),
+            Array(v) => v.execute(ctx),
+            Object(v) => v.execute(ctx),
         }
     }
 

--- a/src/compiler/expression/group.rs
+++ b/src/compiler/expression/group.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
-    expression::{Expr, Resolved},
+    expression::{Executed, Expr, Resolved},
     Context, Expression,
 };
 
@@ -22,6 +22,10 @@ impl Group {
 impl Expression for Group {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         self.inner.resolve(ctx)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        self.inner.execute(ctx)
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/if_statement.rs
+++ b/src/compiler/expression/if_statement.rs
@@ -4,7 +4,7 @@ use crate::value::Value;
 
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
-    expression::{Block, Predicate, Resolved},
+    expression::{Block, Executed, Predicate, Resolved},
     value::VrlValueConvert,
     Context, Expression,
 };
@@ -27,6 +27,18 @@ impl Expression for IfStatement {
                 .as_ref()
                 .map_or(Ok(Value::Null), |block| block.resolve(ctx))
         }
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        let predicate = self.predicate.resolve(ctx)?.try_boolean()?;
+
+        if predicate {
+            self.if_block.execute(ctx)?;
+        } else if let Some(ref block) = self.else_block {
+            block.execute(ctx)?;
+        }
+
+        Ok(())
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/literal.rs
+++ b/src/compiler/expression/literal.rs
@@ -8,7 +8,7 @@ use ordered_float::NotNan;
 use regex::Regex;
 
 use crate::compiler::{
-    expression::Resolved,
+    expression::{Executed, Resolved},
     state::{TypeInfo, TypeState},
     Context, Expression, Span, TypeDef,
 };
@@ -49,6 +49,10 @@ impl Literal {
 impl Expression for Literal {
     fn resolve(&self, _: &mut Context) -> Resolved {
         Ok(self.to_value())
+    }
+
+    fn execute(&self, _: &mut Context) -> Executed {
+        Ok(())
     }
 
     fn resolve_constant(&self, _state: &TypeState) -> Option<Value> {

--- a/src/compiler/expression/not.rs
+++ b/src/compiler/expression/not.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
-    expression::{Expr, Resolved},
+    expression::{Executed, Expr, Resolved},
     parser::Node,
     value::{Kind, VrlValueConvert},
     Context, Expression, Span, TypeDef,
@@ -50,6 +50,10 @@ impl Not {
 impl Expression for Not {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         Ok((!self.inner.resolve(ctx)?.try_boolean()?).into())
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        self.inner.execute(ctx)
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/object.rs
+++ b/src/compiler/expression/object.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt, ops::Deref};
 use crate::value::{KeyString, Value};
 use crate::{
     compiler::{
-        expression::{Expr, Resolved},
+        expression::{Executed, Expr, Resolved},
         state::{TypeInfo, TypeState},
         Context, Expression, TypeDef,
     },
@@ -37,6 +37,13 @@ impl Expression for Object {
             .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.clone(), v)))
             .collect::<Result<BTreeMap<_, _>, _>>()
             .map(Value::Object)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        for expr in self.inner.values() {
+            expr.execute(ctx)?;
+        }
+        Ok(())
     }
 
     fn resolve_constant(&self, state: &TypeState) -> Option<Value> {

--- a/src/compiler/expression/op.rs
+++ b/src/compiler/expression/op.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
-    expression::{self, Expr, Resolved},
+    expression::{self, Executed, Expr, Resolved},
     parser::{ast, Node},
     value::VrlValueArithmetic,
     Context, Expression, TypeDef,
@@ -136,6 +136,12 @@ impl Expression for Op {
             And | Or | Err => unreachable!(),
         }
         .map_err(Into::into)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        self.lhs.execute(ctx)?;
+        self.rhs.execute(ctx)?;
+        Ok(())
     }
 
     #[allow(clippy::too_many_lines)]

--- a/src/compiler/expression/predicate.rs
+++ b/src/compiler/expression/predicate.rs
@@ -4,7 +4,7 @@ use crate::diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
 use crate::compiler::expression::Block;
 use crate::compiler::{
-    expression::{Expr, Resolved},
+    expression::{Executed, Expr, Resolved},
     parser::Node,
     state::{TypeInfo, TypeState},
     value::Kind,
@@ -57,6 +57,10 @@ impl Predicate {
 impl Expression for Predicate {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         self.inner.resolve(ctx)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        self.inner.execute(ctx)
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/query.rs
+++ b/src/compiler/expression/query.rs
@@ -1,5 +1,5 @@
 use crate::compiler::{
-    expression::{Container, Resolved, Variable},
+    expression::{Container, Executed, Resolved, Variable},
     parser::ast::Ident,
     state::ExternalEnv,
     state::{TypeInfo, TypeState},
@@ -123,6 +123,16 @@ impl Expression for Query {
         };
 
         Ok(value.get(&self.path).cloned().unwrap_or(Value::Null))
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        use Target::{Container, External, FunctionCall, Internal};
+
+        match &self.target {
+            FunctionCall(call) => call.execute(ctx),
+            Container(container) => container.execute(ctx),
+            External(..) | Internal(..) => Ok(()),
+        }
     }
 
     fn resolve_constant(&self, state: &TypeState) -> Option<Value> {

--- a/src/compiler/expression/return.rs
+++ b/src/compiler/expression/return.rs
@@ -1,12 +1,13 @@
 use std::fmt;
 
 use crate::compiler::{
-    expression::Resolved,
+    expression::{Executed, Resolved},
     state::{TypeInfo, TypeState},
     Context, Expression, Span, TypeDef,
 };
 use crate::diagnostic::{DiagnosticMessage, Label, Note};
 use crate::parser::ast::Node;
+use crate::value::Value;
 
 use super::{Expr, ExpressionError};
 
@@ -43,6 +44,14 @@ impl Expression for Return {
         Err(ExpressionError::Return {
             span: self.span,
             value: self.expr.resolve(ctx)?,
+        })
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        self.expr.resolve(ctx)?;
+        Err(ExpressionError::Return {
+            span: self.span,
+            value: Value::Null,
         })
     }
 

--- a/src/compiler/expression/unary.rs
+++ b/src/compiler/expression/unary.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::compiler::{
-    expression::{Not, Resolved},
+    expression::{Executed, Not, Resolved},
     state::{TypeInfo, TypeState},
     Context, Expression,
 };
@@ -29,6 +29,14 @@ impl Expression for Unary {
 
         match &self.variant {
             Not(v) => v.resolve(ctx),
+        }
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Executed {
+        use Variant::Not;
+
+        match &self.variant {
+            Not(v) => v.execute(ctx),
         }
     }
 

--- a/src/compiler/expression/variable.rs
+++ b/src/compiler/expression/variable.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
-    expression::{levenstein, Resolved},
+    expression::{levenstein, Executed, Resolved},
     parser::ast::Ident,
     state::LocalEnv,
     Context, Expression, Span, TypeDef,
@@ -42,6 +42,10 @@ impl Expression for Variable {
             .variable(&self.ident)
             .cloned()
             .unwrap_or(Value::Null))
+    }
+
+    fn execute(&self, _: &mut Context) -> Executed {
+        Ok(())
     }
 
     fn resolve_constant(&self, state: &TypeState) -> Option<Value> {

--- a/src/compiler/expression_error.rs
+++ b/src/compiler/expression_error.rs
@@ -4,6 +4,7 @@ use crate::diagnostic::{Diagnostic, DiagnosticMessage, Label, Note, Severity, Sp
 use crate::value::Value;
 
 pub type Resolved = Result<Value, ExpressionError>;
+pub type Executed = Result<(), ExpressionError>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExpressionError {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -11,7 +11,7 @@ pub use compiler::{CompilationResult, Compiler};
 pub use context::Context;
 pub use datetime::TimeZone;
 pub use expression::{Expression, FunctionExpression};
-pub use expression_error::{ExpressionError, Resolved};
+pub use expression_error::{Executed, ExpressionError, Resolved};
 pub use function::{Function, Parameter};
 pub use program::{Program, ProgramInfo};
 pub use state::{TypeInfo, TypeState};

--- a/src/compiler/prelude.rs
+++ b/src/compiler/prelude.rs
@@ -14,6 +14,7 @@ pub use crate::value::{
 };
 pub use crate::{expr, func_args, test_function, test_type_def};
 
+pub use super::Executed;
 pub use super::Resolved;
 pub use super::{
     expression,


### PR DESCRIPTION
I ran a pretty simple VRL that looks like:

```py
result = []
t = now()
for_each(array!(.SomeList)) -> |_, log| {
  log.index_timestamp = t
  result = push(result, log)
}
. = result
```

When `SomeList` was big (30MB), the script took forever to run (more than 30s, meaning quickwit killed my indexing actor, requiring me to restart quickwit-indexer).

So I started to investigate why, and what I've learned is that the VRL interpreter clones all over the place, which is pretty bad for large objects / arrays.

For example:
* Each expression returns a value, even assignment, in case the parent expression wants to use the value.
  * But for expressions inside a block (other than the last), there is no reason to return a value, meaning no reason to clone the entire big array / object.
* `src/compiler/expression/variable.rs` - `Variable::resolve()` clones the variable on lookup of an ident.

At first I thought rewriting everywhere to use `Rc<RefCell<Value>>` but it seemed like too much changes in the source code.

What I ended up with solves only the first example, by running `execute()` instead of `resolve()` which doesn't return a value.

The second example needs more thinking, maybe we can know when a variable is last used (has no references to) after the re-assignment, so we can use `remove_variable()` instead of `variable()`? Can be done in a future PR, as it's completely orthogonal to the optimization in this PR.

Another solution would be to add `map` and `filter`, which won't need to allocate and clone the entire value in each iteration.

The best solution would be to implement a JIT compiler using something like cranelift: https://github.com/vectordotdev/vrl/issues/1095.

DRAFT - still need to prove better performance with benchmarks, but I would still like to hear your opinions.

Seems like most of the time is on the `clone` of 2nd example :(

![image](https://github.com/user-attachments/assets/8cf609e9-0f6d-4473-a924-a6a7bb5a1552)
