### PR TITLE
performance(stdlib): Switch to much faster ua-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,12 +615,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
@@ -841,19 +835,6 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn 2.0.90",
 ]
 
@@ -1491,6 +1472,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1790,6 +1780,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f889fb66f7acdf83442c35775764b51fed3c606ab9cee51500dbde2cf528ca"
 
 [[package]]
 name = "nom"
@@ -2519,6 +2515,20 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-filtered"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c11639076bf147be211b90e47790db89f4c22b6c8a9ca6e960833869da67166"
+dependencies = [
+ "aho-corasick",
+ "indexmap",
+ "itertools 0.13.0",
+ "nohash",
+ "regex",
  "regex-syntax 0.8.5",
 ]
 
@@ -3255,17 +3265,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
-name = "uaparser"
-version = "0.6.4"
+name = "ua-parser"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c9e1c3f893758f154004195fc2d2c52fbda462df725220ceaef830ac29affa"
+checksum = "d7176a413a0b7e94926d11a2054c6db5ac7fa42bf4ebe7e9571152e3f024ddfd"
 dependencies = [
- "derive_more",
- "lazy_static",
  "regex",
+ "regex-filtered",
  "serde",
- "serde_derive",
- "serde_yaml",
 ]
 
 [[package]]
@@ -3408,7 +3415,7 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "community-id",
- "convert_case 0.7.1",
+ "convert_case",
  "crc",
  "criterion",
  "crypto_secretbox",
@@ -3466,6 +3473,7 @@ dependencies = [
  "seahash",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha-1",
  "sha2",
  "sha3",
@@ -3480,7 +3488,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-test",
- "uaparser",
+ "ua-parser",
  "unicode-segmentation",
  "url",
  "utf8-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ stdlib = [
   "dep:strip-ansi-escapes",
   "dep:syslog_loose",
   "dep:tokio",
-  "dep:uaparser",
+  "dep:ua-parser",
   "dep:url",
   "dep:utf8-width",
   "dep:uuid",
@@ -192,7 +192,7 @@ syslog_loose = { version = "0.21", optional = true }
 termcolor = { version = "1", optional = true }
 thiserror = { version = "2", optional = true }
 tracing = { version = "0.1", default-features = false }
-uaparser = { version = "0.6", default-features = false, optional = true }
+ua-parser = { version = "0.2", optional = true }
 utf8-width = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 snafu = { version = "0.8", optional = true }
@@ -250,6 +250,8 @@ proptest-derive = { version = "0.5" }
 
 [build-dependencies]
 lalrpop = { version = "0.22", default-features = false }
+serde_yaml = "0.9.34"
+ua-parser = { version = "0.2" }
 
 [[bench]]
 name = "kind"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -53,7 +53,6 @@ colorchoice,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The colorchoic
 combine,https://github.com/Marwes/combine,MIT,Markus Westerlind <marwes91@gmail.com>
 community-id,https://github.com/traceflight/rs-community-id,MIT OR Apache-2.0,Julian Wang <traceflight@outlook.com>
 concurrent-queue,https://github.com/smol-rs/concurrent-queue,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>"
-convert_case,https://github.com/rutrum/convert-case,MIT,David Purdum <purdum41@gmail.com>
 convert_case,https://github.com/rutrum/convert-case,MIT,rutrum <dave@rutrum.net>
 core-foundation,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
 cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
@@ -71,7 +70,6 @@ ctr,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Devel
 data-encoding,https://github.com/ia0/data-encoding,MIT,Julien Cretin <git@ia0.eu>
 dbl,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
-derive_more,https://github.com/JelteF/derive_more,MIT,Jelte Fennema <github-tech@jeltef.nl>
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 dirs-next,https://github.com/xdg-rs/dirs,MIT OR Apache-2.0,The @xdg-rs members
 dirs-sys-next,https://github.com/xdg-rs/dirs/tree/master/dirs-sys,MIT OR Apache-2.0,The @xdg-rs members
@@ -149,6 +147,7 @@ mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas
 moka,https://github.com/moka-rs/moka,MIT OR Apache-2.0,The moka Authors
 ndk-context,https://github.com/rust-windowing/android-ndk-rs,MIT OR Apache-2.0,The Rust Windowing contributors
 nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
+nohash,https://github.com/tetcoin/nohash,Apache-2.0 OR MIT,Parity Technologies <admin@parity.io>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-bigint,https://github.com/rust-num/num-bigint,MIT OR Apache-2.0,The Rust Project Developers
@@ -201,6 +200,7 @@ redox_users,https://gitlab.redox-os.org/redox-os/users,MIT,"Jose Narvaez <goyox8
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-automata,https://github.com/BurntSushi/regex-automata,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 regex-automata,https://github.com/rust-lang/regex/tree/master/regex-automata,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+regex-filtered,https://github.com/ua-parser/uap-rust,BSD-3-Clause,The regex-filtered Authors
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,The Rust Project Developers
 regex-syntax,https://github.com/rust-lang/regex/tree/master/regex-syntax,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 roxmltree,https://github.com/RazrFalcon/roxmltree,MIT OR Apache-2.0,Yevhenii Reizner <razrfalcon@gmail.com>
@@ -215,7 +215,6 @@ scopeguard,https://github.com/bluss/scopeguard,MIT OR Apache-2.0,bluss
 seahash,https://gitlab.redox-os.org/redox-os/seahash,MIT,"ticki <ticki@users.noreply.github.com>, Tom Almeida <tom@tommoa.me>"
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
-serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sha-1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha2,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
@@ -251,13 +250,12 @@ tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@to
 tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"
-uaparser,https://github.com/davidarmstronglewis/uap-rs,MIT,Ocean Lewis
+ua-parser,https://github.com/ua-parser/uap-rust,Apache-2.0,The ua-parser Authors
 ucd-trie,https://github.com/BurntSushi/ucd-generate,MIT OR Apache-2.0,Andrew Gallant <jamslam@gmail.com>
 unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
 unicode-segmentation,https://github.com/unicode-rs/unicode-segmentation,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unicode-width,https://github.com/unicode-rs/unicode-width,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 universal-hash,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
-unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 utf16_iter,https://github.com/hsivonen/utf16_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 utf8-width,https://github.com/magiclen/utf8-width,MIT,Magic Len <len@magiclen.org>

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,20 @@
 extern crate lalrpop;
 
 use std::{
+    borrow::Cow,
     env,
     fmt::Write as fmt_write,
     fs::{self, File},
     io::{BufRead, BufReader},
     path::Path,
 };
+use ua_parser::device::Flag;
 
 fn main() {
     read_grok_patterns();
+
+    #[cfg(feature = "stdlib")]
+    convert_user_agent_regexes();
 
     println!("cargo:rerun-if-changed=src/parser/parser.lalrpop");
     lalrpop::Configuration::new()
@@ -50,4 +55,75 @@ fn read_grok_patterns() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR isn't defined");
     let dest_path = Path::new(&out_dir).join("patterns.rs");
     fs::write(dest_path, output).expect("'patterns.rs' wasn't generated");
+}
+
+#[cfg(feature = "stdlib")]
+fn convert_user_agent_regexes() {
+    let regexes = fs::read("data/user_agent_regexes.yaml").expect("Could not read regexes");
+    let regexes: ua_parser::Regexes =
+        serde_yaml::from_slice(&regexes).expect("Regex file is not valid yaml");
+
+    fn write_item(output: &mut Vec<u8>, name: &'static str, value: Option<Cow<str>>) {
+        if let Some(value) = value {
+            output.extend(format!("    {}: Some(r#\"{}\"#.into()),\n", name, value).bytes());
+        } else {
+            output.extend(format!("    {}: None,\n", name).bytes());
+        }
+    }
+
+    let mut output = Vec::new();
+
+    output.extend(b"ua_parser::Regexes {\n");
+
+    output.extend(b"os_parsers: vec![\n");
+    for os in regexes.os_parsers {
+        output.extend(b"#[allow(clippy::needless_raw_string_hashes)]\n");
+        output.extend(b"ua_parser::os::Parser {\n");
+        output.extend(format!("    regex: r#\"{}\"#.into(),\n", os.regex).bytes());
+        write_item(&mut output, "os_replacement", os.os_replacement);
+        write_item(&mut output, "os_v1_replacement", os.os_v1_replacement);
+        write_item(&mut output, "os_v2_replacement", os.os_v2_replacement);
+        write_item(&mut output, "os_v3_replacement", os.os_v3_replacement);
+        write_item(&mut output, "os_v4_replacement", os.os_v4_replacement);
+        output.extend(b"},\n");
+    }
+    output.extend(b"],\n");
+
+    output.extend(b"user_agent_parsers: vec![\n");
+    for ua in regexes.user_agent_parsers {
+        output.extend(b"#[allow(clippy::needless_raw_string_hashes)]\n");
+        output.extend(b"ua_parser::user_agent::Parser {\n");
+        output.extend(format!("    regex: r#\"{}\"#.into(),\n", ua.regex).bytes());
+        write_item(&mut output, "family_replacement", ua.family_replacement);
+        write_item(&mut output, "v1_replacement", ua.v1_replacement);
+        write_item(&mut output, "v2_replacement", ua.v2_replacement);
+        write_item(&mut output, "v3_replacement", ua.v3_replacement);
+        write_item(&mut output, "v4_replacement", ua.v4_replacement);
+        output.extend(b"},\n");
+    }
+    output.extend(b"],\n");
+
+    output.extend(b"device_parsers: vec![\n");
+    for device in regexes.device_parsers {
+        output.extend(b"#[allow(clippy::needless_raw_string_hashes)]\n");
+        output.extend(b"ua_parser::device::Parser {\n");
+        output.extend(format!("    regex: r#\"{}\"#.into(),\n", device.regex).bytes());
+        match device.regex_flag {
+            Some(Flag::IgnoreCase) => {
+                output.extend(b"    regex_flag: Some(ua_parser::device::Flag::IgnoreCase),\n");
+            }
+            None => {
+                output.extend(b"    regex_flag: None,\n");
+            }
+        }
+        write_item(&mut output, "device_replacement", device.device_replacement);
+        write_item(&mut output, "brand_replacement", device.brand_replacement);
+        write_item(&mut output, "model_replacement", device.model_replacement);
+        output.extend(b"},\n");
+    }
+    output.extend(b"],\n}\n");
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR isn't defined");
+    let dest_path = Path::new(&out_dir).join("user_agent_regexes.rs");
+    fs::write(dest_path, output).expect("'user_agent_regexes.rs' wasn't generated");
 }

--- a/changelog.d/1317.enhancement.md
+++ b/changelog.d/1317.enhancement.md
@@ -1,0 +1,4 @@
+Improved the `parse_user_agent` method in enriched and reliable mode by switching to a faster library.
+The method's output remains unchanged as the new library utilizes the same data.
+
+authors: JakubOnderka

--- a/changelog.d/1317.enhancement.md
+++ b/changelog.d/1317.enhancement.md
@@ -1,4 +1,4 @@
-Improved the `parse_user_agent` method in enriched and reliable mode by switching to a faster library.
-The method's output remains unchanged as the new library utilizes the same data.
+The `parse_user_agent` method now uses the [ua-parser](https://crates.io/crates/ua-parser) library
+which is much faster than the previous library. The method's output remains unchanged.
 
 authors: JakubOnderka


### PR DESCRIPTION
## Summary

[ua-parser](https://crates.io/crates/ua-parser) crate is 55 times faster than uaparser and also allows to avoid dependency on serde_yaml (that reduces compiled binary size by 200 kb).

### Benchmark

vrl_stdlib/functions/parse_user_agent/fast: 
* 16.481 µs (for comparison, this test do not use ua-parser)

vrl_stdlib/functions/parse_user_agent/enriched: 
* before: 1.7729 ms (uaparser)
* after: 0.03228 ms  (ua-parser, 55 times faster)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

`cargo test` with more tests added.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
