### PR TITLE
chore(stdlib): Simplify ip_subnet function code

### DIFF
--- a/src/stdlib/ip_subnet.rs
+++ b/src/stdlib/ip_subnet.rs
@@ -1,7 +1,5 @@
 use crate::compiler::prelude::*;
-use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::LazyLock;
 
 fn ip_subnet(value: &Value, mask: &Value) -> Resolved {
     let value: IpAddr = value
@@ -35,8 +33,6 @@ fn ip_subnet(value: &Value, mask: &Value) -> Resolved {
     };
     Ok(mask_ips(value, mask)?.to_string().into())
 }
-
-static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"/(?P<subnet>\d*)").unwrap());
 
 #[derive(Clone, Copy, Debug)]
 pub struct IpSubnet;
@@ -103,12 +99,9 @@ impl FunctionExpression for IpSubnetFn {
 
 /// Parses a subnet in the form "/8" returns the number.
 fn parse_subnet(subnet: &str) -> ExpressionResult<u32> {
-    let subnet = RE
-        .captures(subnet)
-        .ok_or_else(|| format!("{subnet} is not a valid subnet"))?;
-
-    let subnet = subnet["subnet"].parse().expect("digits ensured by regex");
-
+    let subnet = subnet[1..]
+        .parse()
+        .map_err(|_| format!("{subnet} is not a valid subnet"))?;
     Ok(subnet)
 }
 


### PR DESCRIPTION
## Summary

It is no needed to use regex to parse simple string. This change reduces code complexity and also speed ups `ip_subnet`.

### Bencharmk

vrl_stdlib/functions/ip_subnet/ipv4_prefix
* before:  303.15 ns
* after:  175.73 ns

vrl_stdlib/functions/ip_subnet/ipv6_prefix
* before: 322.57 ns
* after: 200.04 ns

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard tests.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
