### PR TITLE
enhancement(match_datadog_query): add is_phrase flag to equals method

### DIFF
--- a/src/datadog/filter/filter.rs
+++ b/src/datadog/filter/filter.rs
@@ -22,7 +22,12 @@ pub trait Filter<V: Debug + Send + Sync + Clone + 'static>: DynClone {
     /// # Errors
     ///
     /// Will return `Err` if the query contains an invalid path.
-    fn equals(&self, field: Field, to_match: &str) -> Result<Box<dyn Matcher<V>>, PathParseError>;
+    fn equals(
+        &self,
+        field: Field,
+        to_match: &str,
+        is_phrase: bool,
+    ) -> Result<Box<dyn Matcher<V>>, PathParseError>;
 
     /// Determine whether a value starts with a prefix.
     ///

--- a/src/datadog/filter/filter.rs
+++ b/src/datadog/filter/filter.rs
@@ -22,12 +22,14 @@ pub trait Filter<V: Debug + Send + Sync + Clone + 'static>: DynClone {
     /// # Errors
     ///
     /// Will return `Err` if the query contains an invalid path.
-    fn equals(
-        &self,
-        field: Field,
-        to_match: &str,
-        is_phrase: bool,
-    ) -> Result<Box<dyn Matcher<V>>, PathParseError>;
+    fn equals(&self, field: Field, to_match: &str) -> Result<Box<dyn Matcher<V>>, PathParseError>;
+
+    /// Determine whether a field value equals `phrase`.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if the query contains an invalid path.
+    fn phrase(&self, field: Field, phrase: &str) -> Result<Box<dyn Matcher<V>>, PathParseError>;
 
     /// Determine whether a value starts with a prefix.
     ///

--- a/src/datadog/filter/matcher.rs
+++ b/src/datadog/filter/matcher.rs
@@ -133,7 +133,7 @@ where
             let matchers: Result<Vec<_>, _> = filter
                 .build_fields(attr)
                 .into_iter()
-                .map(|field| filter.equals(field, value, false))
+                .map(|field| filter.equals(field, value))
                 .collect();
 
             Ok(any(matchers?))
@@ -145,7 +145,7 @@ where
             let matchers: Result<Vec<_>, _> = filter
                 .build_fields(attr)
                 .into_iter()
-                .map(|field| filter.equals(field, value, true))
+                .map(|field| filter.phrase(field, value))
                 .collect();
 
             Ok(any(matchers?))

--- a/src/datadog/filter/matcher.rs
+++ b/src/datadog/filter/matcher.rs
@@ -129,15 +129,23 @@ where
 
             Ok(all(matchers?))
         }
-        QueryNode::AttributeTerm { attr, value }
-        | QueryNode::QuotedAttribute {
+        QueryNode::AttributeTerm { attr, value } => {
+            let matchers: Result<Vec<_>, _> = filter
+                .build_fields(attr)
+                .into_iter()
+                .map(|field| filter.equals(field, value, false))
+                .collect();
+
+            Ok(any(matchers?))
+        }
+        QueryNode::QuotedAttribute {
             attr,
             phrase: value,
         } => {
             let matchers: Result<Vec<_>, _> = filter
                 .build_fields(attr)
                 .into_iter()
-                .map(|field| filter.equals(field, value))
+                .map(|field| filter.equals(field, value, true))
                 .collect();
 
             Ok(any(matchers?))

--- a/src/stdlib/match_datadog_query.rs
+++ b/src/stdlib/match_datadog_query.rs
@@ -166,6 +166,7 @@ impl Filter<Value> for VrlFilter {
         &self,
         field: Field,
         to_match: &str,
+        _is_phrase: bool,
     ) -> Result<Box<dyn Matcher<Value>>, PathParseError> {
         let buf = lookup_field(&field)?;
 


### PR DESCRIPTION
## Summary

Update the Filter trait's equals signature to include an `is_phrase` boolean flag.

Without that information there is no way to distinguish between phrased and non-phrased queries. They behave differently in datadog on default fields

This is for matching on default fields (typically `message`) in datadog. The matching behavior for phrases is different than non-phrased. In a phrase the tokens need to be in the same order. E.g.
`Hello nice world` => `"Hello world"` no match
`Hello nice world` => `Hello world` matches

### Alternative Options

There is an alternative solution where the tokenizer would emit multiple tokens (only for default fields):
`Hello world` would expand to the equivalent of`_default_:Hello` AND `_default_:World`.
`"Hello world"` would expand to the equivalent of`_default_:"Hello World"`

## Change Type

- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [X] Yes
- [ ] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [X] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [X] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [X] For new VRL functions, please also create a sibling PR in Vector to document the new function.
