### PR TITLE
chore(deps): revert bump `ordered-float` to 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,9 +1925,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ordered-float"
-version = "5.0.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ itertools = { version = "0.14", default-features = false, features = ["use_std"]
 lalrpop-util = { version = "0.22", optional = true }
 mlua = { version = "0.10", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
 nom = { version = "7", default-features = false, features = ["std"], optional = true }
-ordered-float = { version = "5", default-features = false, optional = true }
+ordered-float = { version = "4", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 parse-size = { version = "1.1.0",  optional = true }
 peeking_take_while = { version = "1", default-features = false, optional = true }

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -3,14 +3,14 @@
 
 use std::ops::{Add, Mul, Rem};
 
-use super::ValueError;
 use crate::compiler::{
     value::{Kind, VrlValueConvert},
     ExpressionError,
 };
 use crate::value::{ObjectMap, Value};
 use bytes::{BufMut, Bytes, BytesMut};
-use ordered_float::NotNan;
+
+use super::ValueError;
 
 #[allow(clippy::missing_errors_doc)]
 pub trait VrlValueArithmetic: Sized {
@@ -92,11 +92,8 @@ impl VrlValueArithmetic for Value {
                 i64::wrapping_mul(lhv, rhv_i64).into()
             }
             Value::Float(lhv) => {
-                let rhs_f64 = rhs.try_into_f64().map_err(|_| err())?;
-                match NotNan::new(lhv.mul(rhs_f64)) {
-                    Ok(value) => value.into(),
-                    Err(_) => return Err(ValueError::Mul(self.kind(), rhs.kind())),
-                }
+                let rhs = rhs.try_into_f64().map_err(|_| err())?;
+                lhv.mul(rhs).into()
             }
             Value::Bytes(lhv) if rhs.is_integer() => {
                 Bytes::from(lhv.repeat(as_usize(rhs.try_integer()?))).into()
@@ -137,14 +134,10 @@ impl VrlValueArithmetic for Value {
                 i64::wrapping_add(lhs, rhv_i64).into()
             }
             (Value::Float(lhs), rhs) => {
-                let rhs_f64 = rhs
+                let rhs = rhs
                     .try_into_f64()
                     .map_err(|_| ValueError::Add(Kind::float(), rhs.kind()))?;
-
-                match NotNan::new(lhs.add(rhs_f64)) {
-                    Ok(value) => value.into(),
-                    Err(_) => return Err(ValueError::Add(Kind::float(), rhs.kind())),
-                }
+                lhs.add(rhs).into()
             }
             (lhs @ Value::Bytes(_), Value::Null) => lhs,
             (Value::Bytes(lhs), Value::Bytes(rhs)) => {
@@ -239,10 +232,7 @@ impl VrlValueArithmetic for Value {
             }
             Value::Float(left) => {
                 let right = rhs.try_into_f64().map_err(|_| err())?;
-                match NotNan::new(left.rem(right)) {
-                    Ok(value) => value.into(),
-                    Err(_) => return Err(ValueError::Rem(self.kind(), rhs.kind())),
-                }
+                left.rem(right).into()
             }
             _ => return Err(err()),
         };


### PR DESCRIPTION
Reverts vectordotdev/vrl#1291 to unblock VRL updates for Vector.

We can proceed with this once we crypto crates upgrade to a newer `rand_core` version.

Explanation: https://github.com/vectordotdev/vector/pull/22558#issuecomment-2722275121

