### PR TITLE
enhancement(lz4_decode) add lz4_decode compression type detection

### DIFF
--- a/changelog.d/1367.enhancement.md
+++ b/changelog.d/1367.enhancement.md
@@ -1,0 +1,3 @@
+Add support for decompressing lz4 frame compressed data.
+
+authors: jimmystewpot

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -1,14 +1,29 @@
 use crate::compiler::prelude::*;
 use lz4_flex::block::decompress_size_prepended;
+use lz4_flex::frame::FrameDecoder;
 use nom::AsBytes;
 
 fn decode_lz4(value: Value) -> Resolved {
-    let value = value.try_bytes()?;
-    let result = decompress_size_prepended(value.as_bytes());
+    const FRAME_MAGIC_LE: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
 
-    match result {
-        Ok(buf) => Ok(Value::Bytes(buf.into())),
-        Err(_) => Err("unable to decode value with lz4 decoder".into()),
+    let value = value.try_bytes()?;
+
+    // evaluate if value is lz4 frame encoded by checking the magic number.
+    if value.starts_with(&FRAME_MAGIC_LE) {
+        let mut buf = Vec::new();
+        let mut decoder = FrameDecoder::new(std::io::Cursor::new(value));
+        let result = std::io::copy(&mut decoder, &mut buf);
+        match result {
+            Ok(_) => Ok(Value::Bytes(buf.into())),
+            Err(_) => Err("unable to decode value with lz4 decoder".into()),
+        }
+    } else {
+        // value is not lz4 frame encoded, use block decompressor.
+        let result = decompress_size_prepended(value.as_bytes());
+        match result {
+            Ok(buf) => Ok(Value::Bytes(buf.into())),
+            Err(_) => Err("unable to decode value with lz4 decoder".into()),
+        }
     }
 }
 
@@ -86,8 +101,14 @@ mod tests {
     test_function![
         decode_lz4 => DecodeLz4;
 
-        right_lz4 {
+        right_lz4_block {
             args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes())],
+            want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        right_lz4_frame {
+            args: func_args![value: value!(decode_base64("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA=").as_bytes())],
             want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
             tdef: TypeDef::bytes().fallible(),
         }


### PR DESCRIPTION
## Summary

In a previous PR #1339, LZ4 block compression was added. That change focused on adding LZ4 block compression and decompression support. With Lz4, there are two types of compression: [frame](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md) and [block](https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md). This change supports detecting if the value being decoded is compressed using LZ4 frame compression and attempts to handle it gracefully.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

I have run through the various scripts in `scripts` and added an additional test to decompress an LZ4 frame payload.

## Does this PR include user-facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

