### PR TITLE
chore(performance): Use simd for base64 encoding/decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,12 +787,6 @@ checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dbl"
@@ -1946,6 +1950,12 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -3379,7 +3389,7 @@ dependencies = [
  "arbitrary",
  "base16",
  "base62",
- "base64 0.22.1",
+ "base64-simd",
  "bytes",
  "cbc",
  "cfb-mode",
@@ -3399,7 +3409,6 @@ dependencies = [
  "crypto_secretbox",
  "csv",
  "ctr",
- "data-encoding",
  "digest",
  "dns-lookup",
  "domain",
@@ -3503,6 +3512,12 @@ dependencies = [
  "tracing-subscriber",
  "vrl",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ stdlib = [
   "dep:aes-siv",
   "dep:base16",
   "dep:base62",
-  "dep:base64",
+  "dep:base64-simd",
   "dep:cbc",
   "dep:cfb-mode",
   "dep:chacha20poly1305",
@@ -77,7 +77,6 @@ stdlib = [
   "dep:crypto_secretbox",
   "dep:csv",
   "dep:ctr",
-  "dep:data-encoding",
   "dep:digest",
   "dep:domain",
   "dep:dns-lookup",
@@ -129,7 +128,7 @@ ansi_term = { version = "0.12", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 base16 = { version = "0.2", optional = true }
 base62 = { version = "2.2.1", optional = true }
-base64 = { version = "0.22", optional = true }
+base64-simd = { version = "0.8", optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 charset = { version = "0.1", optional = true }
 encoding_rs = { version = "0.8.35", optional = true }
@@ -142,7 +141,6 @@ clap.workspace = true
 codespan-reporting = { version = "0.12", optional = true }
 convert_case = { version = "0.7.1", optional = true }
 crc = { version = "3.2.1", optional = true }
-data-encoding = { version = "2", optional = true }
 digest = { version = "0.10", optional = true }
 dyn-clone = { version = "1", default-features = false, optional = true }
 exitcode = { version = "1", optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -21,6 +21,7 @@ base16,https://github.com/thomcc/rust-base16,CC0-1.0,Thom Chiovoloni <tchiovolon
 base62,https://github.com/fbernier/base62,MIT,"François Bernier <frankbernier@gmail.com>, Chai T. Rex <ChaiTRex@users.noreply.github.com>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
+base64-simd,https://github.com/Nugine/simd,MIT,The base64-simd Authors
 bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bit-vec,https://github.com/contain-rs/bit-vec,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
@@ -65,7 +66,6 @@ crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto 
 crypto_secretbox,https://github.com/RustCrypto/nacl-compat/tree/master/crypto_secretbox,Apache-2.0 OR MIT,RustCrypto Developers
 csv,https://github.com/BurntSushi/rust-csv,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 ctr,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Developers
-data-encoding,https://github.com/ia0/data-encoding,MIT,Julien Cretin <git@ia0.eu>
 dbl,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
@@ -162,6 +162,7 @@ once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov 
 onig,http://github.com/iwillspeak/rust-onig,MIT,"Will Speak <will@willspeak.me>, Ivan Ivashchenko <defuz@me.com>"
 opaque-debug,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 ordered-float,https://github.com/reem/rust-ordered-float,MIT,"Jonathan Reem <jonathan.reem@gmail.com>, Matt Brubeck <mbrubeck@limpet.net>"
+outref,https://github.com/Nugine/outref,MIT,The outref Authors
 overload,https://github.com/danaugrs/overload,MIT,Daniel Salvadori <danaugrs@gmail.com>
 owo-colors,https://github.com/owo-colors/owo-colors,MIT,jam1garner <8260240+jam1garner@users.noreply.github.com>
 pad,https://github.com/ogham/rust-pad,MIT,Ben S <ogham@bsago.me>
@@ -259,6 +260,7 @@ utf8-width,https://github.com/magiclen/utf8-width,MIT,Magic Len <len@magiclen.or
 utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 uuid,https://github.com/uuid-rs/uuid,Apache-2.0 OR MIT,"Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>"
 valuable,https://github.com/tokio-rs/valuable,MIT,The valuable Authors
+vsimd,https://github.com/Nugine/simd,MIT,The vsimd Authors
 vte,https://github.com/alacritty/vte,Apache-2.0 OR MIT,"Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>"
 wasi,https://github.com/bytecodealliance/wasi,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The Cranelift Project Developers
 wasm-bindgen,https://github.com/rustwasm/wasm-bindgen,MIT OR Apache-2.0,The wasm-bindgen Developers

--- a/changelog.d/1379.enhancement.md
+++ b/changelog.d/1379.enhancement.md
@@ -1,0 +1,4 @@
+The `decode_base64` and `encode_base64` and `decode_mime_q` methods now uses the SIMD backend
+which is faster than the previous backend.
+
+authors: JakubOnderka

--- a/changelog.d/1379.enhancement.md
+++ b/changelog.d/1379.enhancement.md
@@ -1,4 +1,4 @@
-The `decode_base64` and `encode_base64` and `decode_mime_q` methods now uses the SIMD backend
+The `decode_base64`, `encode_base64` and `decode_mime_q` functions now use the SIMD backend
 which is faster than the previous backend.
 
 authors: JakubOnderka

--- a/src/stdlib/decode_base64.rs
+++ b/src/stdlib/decode_base64.rs
@@ -1,29 +1,26 @@
 use crate::compiler::prelude::*;
-use base64::Engine as _;
-use std::str::FromStr;
-
-use super::util::Base64Charset;
+use crate::stdlib::util::Base64Charset;
 
 fn decode_base64(charset: Option<Value>, value: Value) -> Resolved {
+    let value = value.try_bytes()?;
     let charset = charset
         .map(Value::try_bytes)
         .transpose()?
-        .map(|c| Base64Charset::from_str(&String::from_utf8_lossy(&c)))
+        .as_deref()
+        .map(Base64Charset::from_slice)
         .transpose()?
         .unwrap_or_default();
-    let alphabet = match charset {
-        Base64Charset::Standard => base64::alphabet::STANDARD,
-        Base64Charset::UrlSafe => base64::alphabet::URL_SAFE,
-    };
-    let value = value.try_bytes()?;
-    let config = base64::engine::general_purpose::GeneralPurposeConfig::new()
-        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent);
-    let engine = base64::engine::GeneralPurpose::new(&alphabet, config);
 
-    match engine.decode(value) {
-        Ok(s) => Ok(Value::from(Bytes::from(s))),
-        Err(_) => Err("unable to decode value to base64".into()),
-    }
+    let decoder = match charset {
+        Base64Charset::Standard => base64_simd::STANDARD_NO_PAD,
+        Base64Charset::UrlSafe => base64_simd::URL_SAFE_NO_PAD,
+    };
+
+    let decoded_vec = decoder
+        .decode_to_vec(value)
+        .map_err(|_| "unable to decode value to base64")?;
+
+    Ok(Value::Bytes(Bytes::from(decoded_vec)))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -114,6 +111,12 @@ mod test {
         with_urlsafe_charset {
             args: func_args![value: value!("c29tZSs9c3RyaW5nL3ZhbHVl"), charset: value!("url_safe")],
             want: Ok(value!("some+=string/value")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
+        with_invalid_charset {
+            args: func_args![value: value!("c29tZSs9c3RyaW5nL3ZhbHVl"), charset: value!("invalid")],
+            want: Err("unknown charset"),
             tdef: TypeDef::bytes().fallible(),
         }
 

--- a/src/stdlib/decode_base64.rs
+++ b/src/stdlib/decode_base64.rs
@@ -120,6 +120,12 @@ mod test {
             tdef: TypeDef::bytes().fallible(),
         }
 
+        with_defaults_invalid_value {
+            args: func_args![value: value!("helloworld")],
+            want: Err("unable to decode value to base64"),
+            tdef: TypeDef::bytes().fallible(),
+        }
+
         empty_string_standard_charset {
             args: func_args![value: value!(""), charset: value!("standard")],
             want: Ok(value!("")),

--- a/src/stdlib/decode_base64.rs
+++ b/src/stdlib/decode_base64.rs
@@ -21,8 +21,7 @@ fn decode_base64(charset: Option<Value>, value: Value) -> Resolved {
         .iter()
         .rev()
         .position(|c| *c != b'=')
-        .map(|p| value.len() - p)
-        .unwrap_or(value.len());
+        .map_or(value.len(), |p| value.len() - p);
 
     let decoded_vec = decoder
         .decode_to_vec(&value[0..pos])

--- a/src/stdlib/decode_base64.rs
+++ b/src/stdlib/decode_base64.rs
@@ -16,8 +16,13 @@ fn decode_base64(charset: Option<Value>, value: Value) -> Resolved {
         Base64Charset::UrlSafe => base64_simd::URL_SAFE_NO_PAD,
     };
 
-    // Find the start of padding char '='
-    let pos = value.iter().position(|c| *c == b'=').unwrap_or(value.len());
+    // Find the position of padding char '='
+    let pos = value
+        .iter()
+        .rev()
+        .position(|c| *c != b'=')
+        .map(|p| value.len() - p)
+        .unwrap_or(value.len());
 
     let decoded_vec = decoder
         .decode_to_vec(&value[0..pos])

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -71,16 +71,12 @@ mod tests {
     use super::*;
     use crate::value;
 
-    use base64::Engine;
     use nom::AsBytes;
 
     fn decode_base64(text: &str) -> Vec<u8> {
-        let engine = base64::engine::GeneralPurpose::new(
-            &base64::alphabet::STANDARD,
-            base64::engine::general_purpose::GeneralPurposeConfig::new(),
-        );
-
-        engine.decode(text).expect("Cannot decode from Base64")
+        base64_simd::STANDARD
+            .decode_to_vec(text)
+            .expect("Cannot decode from Base64")
     }
 
     test_function![

--- a/src/stdlib/decode_mime_q.rs
+++ b/src/stdlib/decode_mime_q.rs
@@ -1,5 +1,4 @@
 use charset::Charset;
-use data_encoding::BASE64_MIME;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_until, take_until1},
@@ -160,8 +159,8 @@ impl EncodedWord<'_> {
 
         // Decode
         let decoded = match self.encoding {
-            "B" | "b" => BASE64_MIME
-                .decode(self.input.as_bytes())
+            "B" | "b" => base64_simd::STANDARD_NO_PAD
+                .decode_to_vec(self.input.as_bytes())
                 .map_err(|_| "Unable to decode base64 value")?,
             "Q" | "q" => {
                 // The quoted_printable module does a trim_end on the input, so if

--- a/src/stdlib/decode_mime_q.rs
+++ b/src/stdlib/decode_mime_q.rs
@@ -159,7 +159,7 @@ impl EncodedWord<'_> {
 
         // Decode
         let decoded = match self.encoding {
-            "B" | "b" => base64_simd::STANDARD_NO_PAD
+            "B" | "b" => base64_simd::STANDARD
                 .decode_to_vec(self.input.as_bytes())
                 .map_err(|_| "Unable to decode base64 value")?,
             "Q" | "q" => {

--- a/src/stdlib/decode_snappy.rs
+++ b/src/stdlib/decode_snappy.rs
@@ -70,16 +70,12 @@ impl FunctionExpression for DecodeSnappyFn {
 mod tests {
     use super::*;
     use crate::value;
-    use base64::Engine;
     use nom::AsBytes;
 
     fn decode_base64(text: &str) -> Vec<u8> {
-        let engine = base64::engine::GeneralPurpose::new(
-            &base64::alphabet::STANDARD,
-            base64::engine::general_purpose::GeneralPurposeConfig::new(),
-        );
-
-        engine.decode(text).expect("Cannot decode from Base64")
+        base64_simd::STANDARD
+            .decode_to_vec(text)
+            .expect("Cannot decode from Base64")
     }
 
     test_function![

--- a/src/stdlib/encode_base64.rs
+++ b/src/stdlib/encode_base64.rs
@@ -140,6 +140,30 @@ mod test {
             tdef: TypeDef::bytes().infallible(),
         }
 
+        with_padding_standard_charset_unicode {
+            args: func_args![value: value!("some=string/řčža"), padding: value!(true), charset: value!("standard")],
+            want: Ok(value!("c29tZT1zdHJpbmcvxZnEjcW+YQ==")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        no_padding_standard_charset_unicode {
+            args: func_args![value: value!("some=string/řčža"), padding: value!(false), charset: value!("standard")],
+            want: Ok(value!("c29tZT1zdHJpbmcvxZnEjcW+YQ")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        with_padding_urlsafe_charset_unicode {
+            args: func_args![value: value!("some=string/řčža"), padding: value!(true), charset: value!("url_safe")],
+            want: Ok(value!("c29tZT1zdHJpbmcvxZnEjcW-YQ==")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        no_padding_urlsafe_charset_unicode {
+            args: func_args![value: value!("some=string/řčža"), padding: value!(false), charset: value!("url_safe")],
+            want: Ok(value!("c29tZT1zdHJpbmcvxZnEjcW-YQ")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
         empty_string_standard_charset {
             args: func_args![value: value!(""), charset: value!("standard")],
             want: Ok(value!("")),

--- a/src/stdlib/encode_base64.rs
+++ b/src/stdlib/encode_base64.rs
@@ -1,8 +1,5 @@
 use crate::compiler::prelude::*;
-use base64::Engine as _;
-use std::str::FromStr;
-
-use super::util::Base64Charset;
+use crate::stdlib::util::Base64Charset;
 
 fn encode_base64(value: Value, padding: Option<Value>, charset: Option<Value>) -> Resolved {
     let value = value.try_bytes()?;
@@ -10,20 +7,23 @@ fn encode_base64(value: Value, padding: Option<Value>, charset: Option<Value>) -
         .map(VrlValueConvert::try_boolean)
         .transpose()?
         .unwrap_or(true);
+
     let charset = charset
         .map(VrlValueConvert::try_bytes)
         .transpose()?
-        .map(|c| Base64Charset::from_str(&String::from_utf8_lossy(&c)))
+        .as_deref()
+        .map(Base64Charset::from_slice)
         .transpose()?
         .unwrap_or_default();
 
-    let engine = base64::engine::GeneralPurpose::new(
-        &base64::alphabet::Alphabet::from(charset),
-        base64::engine::general_purpose::GeneralPurposeConfig::default()
-            .with_encode_padding(padding),
-    );
+    let encoder = match (padding, charset) {
+        (true, Base64Charset::Standard) => base64_simd::STANDARD,
+        (false, Base64Charset::Standard) => base64_simd::STANDARD_NO_PAD,
+        (true, Base64Charset::UrlSafe) => base64_simd::URL_SAFE,
+        (false, Base64Charset::UrlSafe) => base64_simd::URL_SAFE_NO_PAD,
+    };
 
-    Ok(engine.encode(value).into())
+    Ok(encoder.encode_to_string(value).into())
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/stdlib/encode_lz4.rs
+++ b/src/stdlib/encode_lz4.rs
@@ -66,16 +66,12 @@ impl FunctionExpression for EncodeLz4Fn {
 mod test {
     use super::*;
     use crate::value;
-    use base64::Engine;
     use nom::AsBytes;
 
     fn decode_base64(text: &str) -> Vec<u8> {
-        let engine = base64::engine::GeneralPurpose::new(
-            &base64::alphabet::STANDARD,
-            base64::engine::general_purpose::GeneralPurposeConfig::new(),
-        );
-
-        engine.decode(text).expect("Cannot decode from Base64")
+        base64_simd::STANDARD
+            .decode_to_vec(text)
+            .expect("Cannot decode from Base64")
     }
 
     test_function![

--- a/src/stdlib/encode_snappy.rs
+++ b/src/stdlib/encode_snappy.rs
@@ -70,16 +70,12 @@ impl FunctionExpression for EncodeSnappyFn {
 mod test {
     use super::*;
     use crate::value;
-    use base64::Engine;
     use nom::AsBytes;
 
     fn decode_base64(text: &str) -> Vec<u8> {
-        let engine = base64::engine::GeneralPurpose::new(
-            &base64::alphabet::STANDARD,
-            base64::engine::general_purpose::GeneralPurposeConfig::new(),
-        );
-
-        engine.decode(text).expect("Cannot decode from Base64")
+        base64_simd::STANDARD
+            .decode_to_vec(text)
+            .expect("Cannot decode from Base64")
     }
 
     test_function![

--- a/src/stdlib/redact.rs
+++ b/src/stdlib/redact.rs
@@ -1,5 +1,4 @@
 use crate::compiler::prelude::*;
-use base64::engine::Engine;
 use std::{
     borrow::Cow,
     convert::{TryFrom, TryInto},
@@ -460,7 +459,7 @@ impl Encoder {
     fn encode(self, data: &[u8]) -> String {
         use Encoder::{Base16, Base64};
         match self {
-            Base64 => base64::engine::general_purpose::STANDARD.encode(data),
+            Base64 => base64_simd::STANDARD.encode_to_string(data),
             Base16 => base16::encode_lower(data),
         }
     }

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -81,38 +81,18 @@ pub(crate) fn is_nullish(value: &Value) -> bool {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Base64Charset {
+    #[default]
     Standard,
     UrlSafe,
 }
 
-impl Default for Base64Charset {
-    fn default() -> Self {
-        Self::Standard
-    }
-}
-
-impl From<Base64Charset> for base64::alphabet::Alphabet {
-    fn from(charset: Base64Charset) -> base64::alphabet::Alphabet {
-        use Base64Charset::{Standard, UrlSafe};
-
-        match charset {
-            Standard => base64::alphabet::STANDARD,
-            UrlSafe => base64::alphabet::URL_SAFE,
-        }
-    }
-}
-
-impl std::str::FromStr for Base64Charset {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        use Base64Charset::{Standard, UrlSafe};
-
-        match s {
-            "standard" => Ok(Standard),
-            "url_safe" => Ok(UrlSafe),
+impl Base64Charset {
+    pub(super) fn from_slice(bytes: &[u8]) -> Result<Self, &'static str> {
+        match bytes {
+            b"standard" => Ok(Self::Standard),
+            b"url_safe" => Ok(Self::UrlSafe),
             _ => Err("unknown charset"),
         }
     }


### PR DESCRIPTION
## Summary

Use SIMD instructions when doing base64 encoding/decoding. base64 encoding/decoding is common when processing logs, so it would be nice to use SIMD powered algo. `base64-simd` crate is already used by vector.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard tests.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
