### PR TITLE
enhancement(conversion): Improve timestamp conversion error message

### DIFF
--- a/src/compiler/conversion/mod.rs
+++ b/src/compiler/conversion/mod.rs
@@ -121,18 +121,22 @@ impl Conversion {
             (Some("float"), None) => Ok(Self::Float),
             (Some("bool" | "boolean"), None) => Ok(Self::Boolean),
             (Some("timestamp"), None) => Ok(Self::Timestamp(tz)),
-            (Some("timestamp"), Some(fmt)) => {
-                // DateTime<Utc> can only convert timestamps without
-                // time zones, and DateTime<FixedOffset> can only
-                // convert with tone zones, so this has to distinguish
-                // between the two types of formats.
-                if format_has_zone(fmt) {
-                    Ok(Self::TimestampTzFmt(fmt.into()))
-                } else {
-                    Ok(Self::TimestampFmt(fmt.into(), tz))
-                }
-            }
+            (Some("timestamp"), Some(fmt)) => Ok(Self::timestamp(fmt, tz)),
             _ => Err(ConversionError::UnknownConversion { name: s.into() }),
+        }
+    }
+
+    /// Convert the string into timestamp
+    #[must_use]
+    pub fn timestamp(fmt: &str, tz: TimeZone) -> Self {
+        // DateTime<Utc> can only convert timestamps without
+        // time zones, and DateTime<FixedOffset> can only
+        // convert with tone zones, so this has to distinguish
+        // between the two types of formats.
+        if format_has_zone(fmt) {
+            Self::TimestampTzFmt(fmt.into())
+        } else {
+            Self::TimestampFmt(fmt.into(), tz)
         }
     }
 

--- a/src/stdlib/parse_timestamp.rs
+++ b/src/stdlib/parse_timestamp.rs
@@ -22,8 +22,7 @@ fn parse_timestamp(
                 .transpose()?
                 .unwrap_or(*ctx.timezone());
 
-            Conversion::parse(format!("timestamp|{format}"), timezone)
-                .map_err(|e| e.to_string())?
+            Conversion::timestamp(&format, timezone)
                 .convert(v)
                 .map_err(|e| e.to_string().into())
         }
@@ -212,7 +211,7 @@ mod tests {
             tdef: TypeDef::timestamp().fallible(),
             tz: TimeZone::default(),
         }
-        
+
         err_value_null {
             args: func_args![
                 value: value!(null),

--- a/src/stdlib/parse_timestamp.rs
+++ b/src/stdlib/parse_timestamp.rs
@@ -28,7 +28,7 @@ fn parse_timestamp(
                 .map_err(|e| e.to_string().into())
         }
         Value::Timestamp(_) => Ok(value),
-        _ => Err("unable to convert value to timestamp".into()),
+        _ => Err(format!("unable to convert {} value to timestamp", value.kind_str()).into()),
     }
 }
 
@@ -160,7 +160,7 @@ mod tests {
         parse_text_with_tz {
             args: func_args![
                 value: "16/10/2019:12:00:00",
-                format:"%d/%m/%Y:%H:%M:%S"
+                format: "%d/%m/%Y:%H:%M:%S"
             ],
             want: Ok(value!(
                 DateTime::parse_from_rfc2822("Wed, 16 Oct 2019 10:00:00 +0000")
@@ -175,7 +175,7 @@ mod tests {
         parse_text_with_timezone_args_no_dst {
             args: func_args![
                 value: "31/12/2019:12:00:00",
-                format:"%d/%m/%Y:%H:%M:%S",
+                format: "%d/%m/%Y:%H:%M:%S",
                 timezone: "Europe/Paris"
             ],
             want: Ok(value!(
@@ -190,7 +190,7 @@ mod tests {
         parse_text_with_favor_timezone_args_than_tz_no_dst {
             args: func_args![
                 value: "31/12/2019:12:00:00",
-                format:"%d/%m/%Y:%H:%M:%S",
+                format: "%d/%m/%Y:%H:%M:%S",
                 timezone: "Europe/Paris"
             ],
             want: Ok(value!(
@@ -205,10 +205,20 @@ mod tests {
         err_timezone_args {
             args: func_args![
                 value: "16/10/2019:12:00:00",
-                format:"%d/%m/%Y:%H:%M:%S",
+                format: "%d/%m/%Y:%H:%M:%S",
                 timezone: "Europe/Pariss"
             ],
             want: Err("unable to parse timezone: Europe/Pariss"),
+            tdef: TypeDef::timestamp().fallible(),
+            tz: TimeZone::default(),
+        }
+        
+        err_value_null {
+            args: func_args![
+                value: value!(null),
+                format: "%d/%m/%Y:%H:%M:%S",
+            ],
+            want: Err("unable to convert null value to timestamp"),
             tdef: TypeDef::timestamp().fallible(),
             tz: TimeZone::default(),
         }


### PR DESCRIPTION
## Summary

More specific error message when trying invalid value to timestamp.

* Before: `unable to convert value to timestamp`
* After:  `unable to convert null value to timestamp`

It also removes one unnecessary string allocation, so parsing should be little bit faster.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Standard tests.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.
