### PR TITLE
chore(ci): support branches from forks

### DIFF
--- a/.github/workflows/vector_integration_check.yaml
+++ b/.github/workflows/vector_integration_check.yaml
@@ -35,8 +35,15 @@ jobs:
           git clone https://github.com/vectordotdev/vector.git
           cd vector
           git switch master
-          VRL_BRANCH=$(cd ../vrl && git rev-parse --abbrev-ref HEAD)
-          sed -i.bak "s|\(vrl = {[^}]*branch = \)\"[^\"]*\"|\1\"${{ github.head_ref }}\"|" Cargo.toml
+
+          VRL_GITHUB_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          VRL_GITHUB_BRANCH="${{ github.head_ref }}"
+
+          REPLACEMENT_LINE="vrl = { git = \"https://github.com/${VRL_GITHUB_REPO}.git\", branch = \"${VRL_GITHUB_BRANCH}\" }"
+          sed -i.bak -e "/^vrl = {/c\\
+          $REPLACEMENT_LINE
+          " Cargo.toml
+
           cargo update -p vrl
 
       - name: Cargo Check Vector

--- a/.github/workflows/vector_integration_check.yaml
+++ b/.github/workflows/vector_integration_check.yaml
@@ -36,13 +36,24 @@ jobs:
           cd vector
           git switch master
 
+          # Set new git repo and branch
           VRL_GITHUB_REPO="${{ github.event.pull_request.head.repo.full_name }}"
           VRL_GITHUB_BRANCH="${{ github.head_ref }}"
+          NEW_REPO="https://github.com/${VRL_GITHUB_REPO}.git"
+          NEW_BRANCH="${VRL_GITHUB_BRANCH}"
 
-          REPLACEMENT_LINE="vrl = { git = \"https://github.com/${VRL_GITHUB_REPO}.git\", branch = \"${VRL_GITHUB_BRANCH}\" }"
-          sed -i.bak -e "/^vrl = {/c\\
-          $REPLACEMENT_LINE
-          " Cargo.toml
+          # Extract existing features (if any)
+          FEATURES=$(sed -nE 's/.*vrl = \{[^}]*features = (\[[^]]*\]).*/\1/p' Cargo.toml)
+
+          # Compose the new dependency line
+          if [[ -n "$FEATURES" ]]; then
+            NEW_VRL_DEP_LINE="vrl = { git = \"$NEW_REPO\", branch = \"$NEW_BRANCH\", features = $FEATURES }"
+          else
+            NEW_VRL_DEP_LINE="vrl = { git = \"$NEW_REPO\", branch = \"$NEW_BRANCH\" }"
+          fi
+
+          # Replace the old vrl line
+          sed -i.bak -E "s|vrl = \{[^}]*\}|$NEW_VRL_DEP_LINE|" Cargo.toml
 
           cargo update -p vrl
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Follow up to https://github.com/vectordotdev/vrl/pull/1398.

Extracted commits from https://github.com/vectordotdev/vrl/pull/1399/files#diff-4f5c849c205cf3224b7c13fdcfc7f684e272f85f2a7a8aae17d5ce4a0d9a7036.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

```
#!/bin/bash
set -euo pipefail

# Simulated PR info
VRL_GITHUB_REPO="Zettroke/vrl"
VRL_GITHUB_BRANCH="apply-function-closure-type-info"

# Create a temporary Cargo.toml
cat > Cargo.toml <<EOF
[dependencies]
vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "main", features = ["cli", "foo", sss] }
tokio = "1.0"
EOF

echo "🔧 Before:"
cat Cargo.toml

# Path to the Cargo.toml file
CARGO_TOML="Cargo.toml"

# Set new git repo and branch
VRL_GITHUB_REPO="some_fork"
VRL_GITHUB_BRANCH="some_branch"
NEW_GIT="https://github.com/${VRL_GITHUB_REPO}.git"
NEW_BRANCH="${VRL_GITHUB_BRANCH}"

# Extract existing features (if any)
EXISTING_FEATURES=$(sed -nE 's/.*vrl = \{[^}]*features = (\[[^]]*\]).*/\1/p' "$CARGO_TOML")

# Compose the new dependency line
if [[ -n "$EXISTING_FEATURES" ]]; then
  NEW_LINE="vrl = { git = \"$NEW_GIT\", branch = \"$NEW_BRANCH\", features = $EXISTING_FEATURES }"
else
  NEW_LINE="vrl = { git = \"$NEW_GIT\", branch = \"$NEW_BRANCH\" }"
fi

# Replace the old vrl line
sed -i.bak -E "s|vrl = \{[^}]*\}|$NEW_LINE|" "$CARGO_TOML"



echo -e "\n✅ After:"
cat Cargo.toml

```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
