### PR TITLE
feat(stdlib): add `haversine` function

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -56,6 +56,7 @@ criterion_group!(
               get_env_var,
               get_hostname,
               get_timezone_name,
+              haversine,
               includes,
               int,
               ip_aton,
@@ -681,6 +682,15 @@ bench_function! {
     get {
         args: func_args![],
         want: Ok(vrl::stdlib::get_name_for_timezone(&vrl::compiler::TimeZone::Named(chrono_tz::Tz::UTC))),
+    }
+}
+
+bench_function! {
+    haversine => vrl::stdlib::Haversine;
+
+    kilometers {
+        args: func_args![lat1: value!(0.0), lon1: value!(0.0), lat2: value!(10.0), lon2: value!(10.0)],
+        want: Ok(value!({ "distance": 1_568.522_723_3, "bearing": 44.561 })),
     }
 }
 

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -689,7 +689,7 @@ bench_function! {
     haversine => vrl::stdlib::Haversine;
 
     kilometers {
-        args: func_args![lat1: value!(0.0), lon1: value!(0.0), lat2: value!(10.0), lon2: value!(10.0)],
+        args: func_args![latitude1: value!(0.0), longitude1: value!(0.0), latitude2: value!(10.0), longitude2: value!(10.0)],
         want: Ok(value!({ "distance": 1_568.522_723_3, "bearing": 44.561 })),
     }
 }

--- a/changelog.d/1442.feature.md
+++ b/changelog.d/1442.feature.md
@@ -1,0 +1,3 @@
+Added `haversine` function for calculating [haversine](https://en.wikipedia.org/wiki/Haversine_formula) distance and bearing.
+
+authors: esensar Quad9DNS

--- a/src/stdlib/haversine.rs
+++ b/src/stdlib/haversine.rs
@@ -1,0 +1,199 @@
+use std::collections::BTreeMap;
+
+use crate::compiler::prelude::*;
+use crate::value;
+
+use super::util::round_to_precision;
+
+const EARTH_R_IN_M: f64 = 6_371_008.8;
+const EARTH_R_IN_KM: f64 = EARTH_R_IN_M / 1000.0;
+const EARTH_R_IN_MILES: f64 = EARTH_R_IN_KM * 0.621_371_2;
+
+fn haversine(lat1: Value, lon1: Value, lat2: Value, lon2: Value, measurement: &Bytes) -> Resolved {
+    let lat1 = lat1.try_float()?.to_radians();
+    let lon1 = lon1.try_float()?.to_radians();
+    let lat2 = lat2.try_float()?.to_radians();
+    let lon2 = lon2.try_float()?.to_radians();
+
+    let mut result = ObjectMap::new();
+
+    // Distance calculation
+    let dlon = lon2 - lon1;
+    let dlat = lat2 - lat1;
+    let a = (dlat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (dlon / 2.0).sin().powi(2);
+    let distance = 2.0 * a.sqrt().asin();
+
+    result.insert(
+        "distance".into(),
+        match measurement.as_ref() {
+            b"kilometers" => {
+                Value::from_f64_or_zero(round_to_precision(distance * EARTH_R_IN_KM, 7, f64::round))
+            }
+            b"miles" => Value::from_f64_or_zero(round_to_precision(
+                distance * EARTH_R_IN_MILES,
+                7,
+                f64::round,
+            )),
+            _ => unreachable!("enum invariant"),
+        },
+    );
+
+    // Bearing calculation
+    let y = dlon.sin() * lat2.cos();
+    let x = lat1.cos() * lat2.sin() - lat1.sin() * lat2.cos() * dlon.cos();
+    let bearing = (y.atan2(x).to_degrees() + 360.0) % 360.0;
+
+    result.insert(
+        "bearing".into(),
+        Value::from_f64_or_zero(round_to_precision(bearing, 3, f64::round)),
+    );
+
+    Ok(result.into())
+}
+
+fn measurement_systems() -> Vec<Value> {
+    vec![value!("kilometers"), value!("miles")]
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Haversine;
+
+impl Function for Haversine {
+    fn identifier(&self) -> &'static str {
+        "haversine"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "lat1",
+                kind: kind::FLOAT,
+                required: true,
+            },
+            Parameter {
+                keyword: "lon1",
+                kind: kind::FLOAT,
+                required: true,
+            },
+            Parameter {
+                keyword: "lat2",
+                kind: kind::FLOAT,
+                required: true,
+            },
+            Parameter {
+                keyword: "lon2",
+                kind: kind::FLOAT,
+                required: true,
+            },
+            Parameter {
+                keyword: "measurement",
+                kind: kind::BYTES,
+                required: false,
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let lat1 = arguments.required("lat1");
+        let lon1 = arguments.required("lon1");
+        let lat2 = arguments.required("lat2");
+        let lon2 = arguments.required("lon2");
+        let measurement = arguments
+            .optional_enum("measurement", &measurement_systems(), state)?
+            .unwrap_or_else(|| value!("kilometers"))
+            .try_bytes()
+            .expect("measurement not bytes");
+
+        Ok(HaversineFn {
+            lat1,
+            lon1,
+            lat2,
+            lon2,
+            measurement,
+        }
+        .as_expr())
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "haversine",
+                source: "haversine(0, 0, 10, 10)",
+                result: Ok(indoc!(
+                    r#"{
+                        "distance": 1568.5227233,
+                        "bearing": 44.561
+                    }"#
+                )),
+            },
+            Example {
+                title: "haversine in miles",
+                source: r#"haversine(0, 0, 10, 10, "miles")"#,
+                result: Ok(indoc!(
+                    r#"{
+                        "distance": 974.6348468
+                        "bearing": 44.561
+                    }"#
+                )),
+            },
+        ]
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HaversineFn {
+    lat1: Box<dyn Expression>,
+    lon1: Box<dyn Expression>,
+    lat2: Box<dyn Expression>,
+    lon2: Box<dyn Expression>,
+    measurement: Bytes,
+}
+
+impl FunctionExpression for HaversineFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let lat1 = self.lat1.resolve(ctx)?;
+        let lon1 = self.lon1.resolve(ctx)?;
+        let lat2 = self.lat2.resolve(ctx)?;
+        let lon2 = self.lon2.resolve(ctx)?;
+
+        haversine(lat1, lon1, lat2, lon2, &self.measurement)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+        TypeDef::object(inner_kind()).infallible()
+    }
+}
+
+fn inner_kind() -> BTreeMap<Field, Kind> {
+    BTreeMap::from([
+        (Field::from("distance"), Kind::float()),
+        (Field::from("bearing"), Kind::float()),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value;
+
+    test_function![
+        haversine => Haversine;
+
+        basic_kilometers {
+            args: func_args![lat1: value!(0.0), lon1: value!(0.0), lat2: value!(10.0), lon2: value!(10.0)],
+            want: Ok(value!({ "distance": 1_568.522_723_3, "bearing": 44.561 })),
+            tdef: TypeDef::object(inner_kind()).infallible(),
+        }
+
+        basic_miles {
+            args: func_args![lat1: value!(0.0), lon1: value!(0.0), lat2: value!(10.0), lon2: value!(10.0), measurement: value!("miles")],
+            want: Ok(value!({ "distance": 974.634_846_8, "bearing": 44.561 })),
+            tdef: TypeDef::object(inner_kind()).infallible(),
+        }
+    ];
+}

--- a/src/stdlib/haversine.rs
+++ b/src/stdlib/haversine.rs
@@ -9,7 +9,13 @@ const EARTH_R_IN_M: f64 = 6_371_008.8;
 const EARTH_R_IN_KM: f64 = EARTH_R_IN_M / 1000.0;
 const EARTH_R_IN_MILES: f64 = EARTH_R_IN_KM * 0.621_371_2;
 
-fn haversine(lat1: Value, lon1: Value, lat2: Value, lon2: Value, measurement: &Bytes) -> Resolved {
+fn haversine_distance(
+    latitude1: Value,
+    longitude1: Value,
+    latitude2: Value,
+    longitude2: Value,
+    measurement_unit: &Bytes,
+) -> Resolved {
     let lat1 = lat1.try_float()?.to_radians();
     let lon1 = lon1.try_float()?.to_radians();
     let lat2 = lat2.try_float()?.to_radians();

--- a/src/stdlib/haversine.rs
+++ b/src/stdlib/haversine.rs
@@ -108,6 +108,37 @@ impl Function for Haversine {
     }
 
     fn compile(
+    &self,
+    state: &state::TypeState,
+    _ctx: &mut FunctionCompileContext,
+    arguments: ArgumentList,
+) -> Compiled {
+    let latitude1 = arguments.required("latitude1");
+    let longitude1 = arguments.required("longitude1");
+    let latitude2 = arguments.required("latitude2");
+    let longitude2 = arguments.required("longitude2");
+
+    let measurement_unit = match arguments
+        .optional_enum("measurement", &measurement_systems(), state)?
+        .unwrap_or_else(|| value!("kilometers"))
+        .try_bytes()
+        .ok()
+        .as_deref()
+    {
+        Some(b"kilometers") => MeasurementUnit::Kilometers,
+        Some(b"miles") => MeasurementUnit::Miles,
+        _ => return Err("invalid measurement unit".into()),
+    };
+
+    Ok(HaversineFn {
+        latitude1,
+        longitude1,
+        latitude2,
+        longitude2,
+        measurement_unit,
+    }
+    .as_expr())
+}
         &self,
         state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -69,6 +69,7 @@ cfg_if::cfg_if! {
         mod get_env_var;
         mod get_hostname;
         mod get_timezone_name;
+        mod haversine;
         mod hmac;
         mod includes;
         mod integer;
@@ -263,6 +264,7 @@ cfg_if::cfg_if! {
         pub use get_hostname::GetHostname;
         pub use get_timezone_name::GetTimezoneName;
         pub use get_timezone_name::get_name_for_timezone;
+        pub use haversine::Haversine;
         pub use includes::Includes;
         pub use integer::Integer;
         pub use ip_aton::IpAton;


### PR DESCRIPTION
## Summary

Adds `haversine` function for calculating [haversine distance and bearing](https://en.wikipedia.org/wiki/Haversine_formula), in kilometers or miles.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Included tests and benchmarks.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

- Closes: #1441
- Documentation: https://github.com/vectordotdev/vector/pull/23336

---
>Sponsored by [Quad9](https://quad9.net/)