### PR TITLE
fix(stdlib): properly export haversine function in `all`

### DIFF
--- a/src/stdlib/haversine.rs
+++ b/src/stdlib/haversine.rs
@@ -119,7 +119,7 @@ impl Function for Haversine {
         let longitude2 = arguments.required("longitude2");
 
         let measurement_unit = match arguments
-            .optional_enum("measurement", &measurement_systems(), state)?
+            .optional_enum("measurement_unit", &measurement_systems(), state)?
             .unwrap_or_else(|| value!("kilometers"))
             .try_bytes()
             .ok()
@@ -144,7 +144,7 @@ impl Function for Haversine {
         &[
             Example {
                 title: "haversine",
-                source: "haversine(0, 0, 10, 10)",
+                source: "haversine(0.0, 0.0, 10.0, 10.0)",
                 result: Ok(indoc!(
                     r#"{
                         "distance": 1568.5227233,
@@ -154,10 +154,10 @@ impl Function for Haversine {
             },
             Example {
                 title: "haversine in miles",
-                source: r#"haversine(0, 0, 10, 10, "miles")"#,
+                source: r#"haversine(0.0, 0.0, 10.0, 10.0, measurement_unit: "miles")"#,
                 result: Ok(indoc!(
                     r#"{
-                        "distance": 974.6348468
+                        "distance": 974.6348468,
                         "bearing": 44.561
                     }"#
                 )),
@@ -218,7 +218,7 @@ mod tests {
         }
 
         basic_miles {
-            args: func_args![latitude1: value!(0.0), longitude1: value!(0.0), latitude2: value!(10.0), longitude2: value!(10.0), measurement: value!("miles")],
+            args: func_args![latitude1: value!(0.0), longitude1: value!(0.0), latitude2: value!(10.0), longitude2: value!(10.0), measurement_unit: value!("miles")],
             want: Ok(value!({ "distance": 974.634_846_8, "bearing": 44.561 })),
             tdef: TypeDef::object(inner_kind()).infallible(),
         }

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -458,6 +458,7 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(GetEnvVar),
         Box::new(GetHostname),
         Box::new(GetTimezoneName),
+        Box::new(Haversine),
         Box::new(Hmac),
         Box::new(Includes),
         Box::new(Integer),


### PR DESCRIPTION
## Summary

Haversine function was not properly exported in #1442, making it unusable in VRL.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

- Related: #1442
- Related: https://github.com/vectordotdev/vector/pull/23336 (this was causing it to fail)

---
>Sponsored by [Quad9](https://quad9.net/)