### PR TITLE
enhancement!(lz4): Improve handling of various lz4 implementations

### DIFF
--- a/changelog.d/1447.breaking.md
+++ b/changelog.d/1447.breaking.md
@@ -1,3 +1,5 @@
-`encode_lz4`  no longer prepends the uncompressed size by default, improving compatibility with standard LZ4 tools. A new `prepend_size` flag restores the old behavior if needed. Also, `decode_lz4 now also accepts `prepend_size` and a `buf_size` option (default: 1MB).
+`encode_lz4`  no longer prepends the uncompressed size by default, improving compatibility with standard LZ4 tools. A new `prepend_size` flag restores the old behavior if needed. Also, `decode_lz4` now also accepts `prepend_size` and a `buf_size` option (default: 1MB). 
+
+Existing users of `encode_lz4` and `decode_lz4` will need to update their functions to include the argument `prepend_size: true` to maintain existing compatibility.
 
 authors: jlambatl

--- a/changelog.d/1447.breaking.md
+++ b/changelog.d/1447.breaking.md
@@ -1,0 +1,3 @@
+`encode_lz4` used the common method of prepending the uncompressed size to the first four bytes of the compressed payload. This allowed the consumer to decompress the payload, knowing the final size of the uncompressed data, and is fairly performant. Unfortunately, it's a pattern that is not universal and has resulted in payloads that couldn't be decompressed by a number of common libraries. An argument prepend_size has been introduced to turn this behaviour on or off, defaulting to false. decode_lz4 has the same argument, allowing for decoding of lz4 payloads that don't have the uncompressed size prepended. Decode also allows users to specify the buf_size (defaults to 1MB).
+
+authors: jlambatl

--- a/changelog.d/1447.breaking.md
+++ b/changelog.d/1447.breaking.md
@@ -1,3 +1,3 @@
-`encode_lz4` used the common method of prepending the uncompressed size to the first four bytes of the compressed payload. This allowed the consumer to decompress the payload, knowing the final size of the uncompressed data, and is fairly performant. Unfortunately, it's a pattern that is not universal and has resulted in payloads that couldn't be decompressed by a number of common libraries. An argument prepend_size has been introduced to turn this behaviour on or off, defaulting to false. decode_lz4 has the same argument, allowing for decoding of lz4 payloads that don't have the uncompressed size prepended. Decode also allows users to specify the buf_size (defaults to 1MB).
+`encode_lz4`  no longer prepends the uncompressed size by default, improving compatibility with standard LZ4 tools. A new `prepend_size` flag restores the old behavior if needed. Also, `decode_lz4 now also accepts `prepend_size` and a `buf_size` option (default: 1MB).
 
 authors: jlambatl

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -4,6 +4,7 @@ use lz4_flex::frame::FrameDecoder;
 use std::io;
 
 const LZ4_FRAME_MAGIC: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
+const LZ4_DEFAULT_BUFFER_SIZE: usize = 1_000_000; // Default buffer size for decompression 1MB
 
 #[derive(Clone, Copy, Debug)]
 pub struct DecodeLz4;
@@ -35,7 +36,7 @@ impl Function for DecodeLz4 {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let buf_size = arguments.optional("buf_size").unwrap_or_else(|| expr!(0));
+        let buf_size = arguments.optional("buf_size").unwrap_or_else(|| expr!(LZ4_DEFAULT_BUFFER_SIZE));
         let prepended_size = arguments
             .optional("use_prepended_size")
             .unwrap_or_else(|| expr!(false));

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -36,7 +36,9 @@ impl Function for DecodeLz4 {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let buf_size = arguments.optional("buf_size").unwrap_or_else(|| expr!(LZ4_DEFAULT_BUFFER_SIZE));
+        let buf_size = arguments
+            .optional("buf_size")
+            .unwrap_or_else(|| expr!(LZ4_DEFAULT_BUFFER_SIZE));
         let prepended_size = arguments
             .optional("use_prepended_size")
             .unwrap_or_else(|| expr!(false));

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -1,44 +1,9 @@
 use crate::compiler::prelude::*;
-use lz4_flex::block::{decompress, decompress_size_prepended, DecompressError};
+use lz4_flex::block::{decompress, decompress_size_prepended};
 use lz4_flex::frame::FrameDecoder;
-use nom::AsBytes;
+use std::io;
 
-fn decode_lz4(value: Value, buf_size: usize, prepended_size: bool) -> Resolved {
-    const FRAME_MAGIC_LE: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
-
-    let value = value.try_bytes()?;
-
-    // evaluate if value is lz4 frame encoded by checking the magic number.
-    if value.starts_with(&FRAME_MAGIC_LE) {
-        let mut buf = Vec::with_capacity(buf_size);
-        // FrameDecoder doesn't require or have a value for prepending the uncompressed size to the compressed data.
-        let mut decoder = FrameDecoder::new(std::io::Cursor::new(value));
-        let result = std::io::copy(&mut decoder, &mut buf);
-        match result {
-            Ok(_) => Ok(Value::Bytes(buf.into())),
-            Err(_) => Err("unable to decode value with lz4 decoder".into()),
-        }
-    } else {
-        // value is not lz4 frame encoded, use block decompressor.
-        let result: Result<Vec<u8>, DecompressError>;
-        // some lz4 block compressors prepend the size of the original data to the compressed data.
-        // this is often to improve performance when decompressing as the size of the buffer can be known in advance.
-        // if prepended_size is true, we will use decompress_size_prepended, otherwise
-        // we will use decompress which requires a buffer size.
-        if prepended_size {
-            result = decompress_size_prepended(value.as_bytes());
-        } else {
-            result = decompress(value.as_bytes(), buf_size);
-        }
-        match result {
-            Ok(buf) => Ok(Value::Bytes(buf.into())),
-            Err(e) => {
-                let msg = format!("unable to decode value with lz4 decoder {e}");
-                Err(msg.into())
-            }
-        }
-    }
-}
+const LZ4_FRAME_MAGIC: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
 
 #[derive(Clone, Copy, Debug)]
 pub struct DecodeLz4;
@@ -49,11 +14,18 @@ impl Function for DecodeLz4 {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "demo string",
-            source: r#"decode_lz4!(decode_base64!("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4="))"#,
-            result: Ok("The quick brown fox jumps over 13 lazy dogs."),
-        }]
+        &[
+            Example {
+                title: "LZ4 block with prepended size",
+                source: r#"decode_lz4!(decode_base64!("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4="), use_prepended_size: true)"#,
+                result: Ok("The quick brown fox jumps over 13 lazy dogs."),
+            },
+            Example {
+                title: "LZ4 frame format",
+                source: r#"decode_lz4!(decode_base64!("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA="))"#,
+                result: Ok("The quick brown fox jumps over 13 lazy dogs."),
+            },
+        ]
     }
 
     fn compile(
@@ -110,8 +82,13 @@ impl FunctionExpression for DecodeLz4Fn {
         let buf_size = self.buf_size.resolve(ctx)?.try_integer()?;
         let prepended_size = self.prepended_size.resolve(ctx)?.try_boolean()?;
 
-        let buffer_size = buf_size as usize;
-
+        let buffer_size: usize;
+        if let Ok(sz) = u32::try_from(buf_size) {
+            buffer_size = sz as usize;
+        } else {
+            // If the buffer size is too large, we default to a maximum size
+            buffer_size = usize::MAX;
+        }
         decode_lz4(value, buffer_size, prepended_size)
     }
 
@@ -121,12 +98,54 @@ impl FunctionExpression for DecodeLz4Fn {
     }
 }
 
+fn decode_lz4(value: Value, buf_size: usize, prepended_size: bool) -> Resolved {
+    let compressed_data = value.try_bytes()?;
+
+    if is_lz4_frame(&compressed_data) {
+        decode_lz4_frame(&compressed_data, buf_size)
+    } else {
+        decode_lz4_block(&compressed_data, buf_size, prepended_size)
+    }
+}
+
+fn is_lz4_frame(data: &[u8]) -> bool {
+    data.starts_with(&LZ4_FRAME_MAGIC)
+}
+
+fn decode_lz4_frame(compressed_data: &[u8], initial_capacity: usize) -> Resolved {
+    let mut output_buffer = Vec::with_capacity(initial_capacity);
+    let mut decoder = FrameDecoder::new(std::io::Cursor::new(compressed_data));
+
+    match io::copy(&mut decoder, &mut output_buffer) {
+        Ok(_) => Ok(Value::Bytes(output_buffer.into())),
+        Err(e) => Err(format!("unable to decode value with lz4 frame decoder: {e}").into()),
+    }
+}
+
+fn decode_lz4_block(compressed_data: &[u8], buf_size: usize, prepended_size: bool) -> Resolved {
+    let decompression_result = if prepended_size {
+        // The compressed data includes the original size as a prefix
+        decompress_size_prepended(compressed_data)
+    } else {
+        // We need to provide the buffer size for decompression
+        decompress(compressed_data, buf_size)
+    };
+
+    match decompression_result {
+        Ok(decompressed_data) => Ok(Value::Bytes(decompressed_data.into())),
+        Err(e) => Err(format!("unable to decode value with lz4 block decoder: {e}").into()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::value;
 
     use nom::AsBytes;
+
+    // Define a constant for 256 KB, used in tests
+    const KB_256: usize = 262_144;
 
     fn decode_base64(text: &str) -> Vec<u8> {
         base64_simd::STANDARD
@@ -150,7 +169,7 @@ mod tests {
     }
 
     right_lz4_block_no_prepend_size_with_buffer_size {
-        args: func_args![value: value!(decode_base64("8B1UaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLg==").as_bytes()), buf_size: value!(262144), use_prepended_size: value!(false)],
+        args: func_args![value: value!(decode_base64("8B1UaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLg==").as_bytes()), buf_size: value!(KB_256), use_prepended_size: value!(false)],
         want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
         tdef: TypeDef::bytes().fallible(),
     }
@@ -163,19 +182,19 @@ mod tests {
 
     wrong_lz4_block_grow_buffer_size_from_zero_no_prepended_size {
         args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), buf_size: value!(0), use_prepended_size: value!(false)],
-        want: Err("unable to decode value with lz4 decoder provided output is too small for the decompressed data, actual 0, expected 2"),
+        want: Err("unable to decode value with lz4 block decoder: provided output is too small for the decompressed data, actual 0, expected 2"),
         tdef: TypeDef::bytes().fallible(),
     }
 
     wrong_lz4 {
         args: func_args![value: value!("xxxxxxxxx"), buf_size: value!(10), use_prepended_size: value!(false)],
-        want: Err("unable to decode value with lz4 decoder expected another byte, found none"),
+        want: Err("unable to decode value with lz4 block decoder: expected another byte, found none"),
         tdef: TypeDef::bytes().fallible(),
     }
 
     wrong_lz4_block_false_prepended_size {
         args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), use_prepended_size: value!(false)],
-        want: Err("unable to decode value with lz4 decoder provided output is too small for the decompressed data, actual 0, expected 2"),
+        want: Err("unable to decode value with lz4 block decoder: provided output is too small for the decompressed data, actual 0, expected 2"),
         tdef: TypeDef::bytes().fallible(),
     }];
 }

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -40,7 +40,7 @@ impl Function for DecodeLz4 {
             .optional("buf_size")
             .unwrap_or_else(|| expr!(LZ4_DEFAULT_BUFFER_SIZE));
         let prepended_size = arguments
-            .optional("use_prepended_size")
+            .optional("prepended_size")
             .unwrap_or_else(|| expr!(false));
 
         Ok(DecodeLz4Fn {
@@ -65,7 +65,7 @@ impl Function for DecodeLz4 {
             },
             Parameter {
                 keyword: "prepended_size",
-                kind: kind::INTEGER,
+                kind: kind::BOOLEAN,
                 required: false,
             },
         ]
@@ -160,8 +160,8 @@ mod tests {
     decode_lz4 => DecodeLz4;
 
     right_lz4_block {
-        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), use_prepended_size: value!(true)],
-        want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
+        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDk5IGxhenkgZG9ncy4=").as_bytes()), prepended_size: value!(true)],
+        want: Ok(value!(b"The quick brown fox jumps over 99 lazy dogs.")),
         tdef: TypeDef::bytes().fallible(),
     }
 
@@ -172,31 +172,31 @@ mod tests {
     }
 
     right_lz4_block_no_prepend_size_with_buffer_size {
-        args: func_args![value: value!(decode_base64("8B1UaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLg==").as_bytes()), buf_size: value!(KB_256), use_prepended_size: value!(false)],
+        args: func_args![value: value!(decode_base64("8B1UaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLg==").as_bytes()), buf_size: value!(KB_256), prepended_size: value!(false)],
         want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
         tdef: TypeDef::bytes().fallible(),
     }
 
     right_lz4_frame_grow_buffer_size_from_zero {
-        args: func_args![value: value!(decode_base64("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA=").as_bytes()), buf_size: value!(0), use_prepended_size: value!(false)],
+        args: func_args![value: value!(decode_base64("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA=").as_bytes()), buf_size: value!(0), prepended_size: value!(false)],
         want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
         tdef: TypeDef::bytes().fallible(),
     }
 
     wrong_lz4_block_grow_buffer_size_from_zero_no_prepended_size {
-        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), buf_size: value!(0), use_prepended_size: value!(false)],
+        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), buf_size: value!(0), prepended_size: value!(false)],
         want: Err("unable to decode value with lz4 block decoder: provided output is too small for the decompressed data, actual 0, expected 2"),
         tdef: TypeDef::bytes().fallible(),
     }
 
     wrong_lz4 {
-        args: func_args![value: value!("xxxxxxxxx"), buf_size: value!(10), use_prepended_size: value!(false)],
+        args: func_args![value: value!("xxxxxxxxx"), buf_size: value!(10), prepended_size: value!(false)],
         want: Err("unable to decode value with lz4 block decoder: expected another byte, found none"),
         tdef: TypeDef::bytes().fallible(),
     }
 
     wrong_lz4_block_false_prepended_size {
-        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), use_prepended_size: value!(false)],
+        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), prepended_size: value!(false)],
         want: Err("unable to decode value with lz4 block decoder: the offset to copy is not contained in the decompressed buffer"),
         tdef: TypeDef::bytes().fallible(),
     }];

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -18,7 +18,7 @@ impl Function for DecodeLz4 {
         &[
             Example {
                 title: "LZ4 block with prepended size",
-                source: r#"decode_lz4!(decode_base64!("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4="), use_prepended_size: true)"#,
+                source: r#"decode_lz4!(decode_base64!("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4="), prepended_size: true)"#,
                 result: Ok("The quick brown fox jumps over 13 lazy dogs."),
             },
             Example {
@@ -197,7 +197,7 @@ mod tests {
 
     wrong_lz4_block_false_prepended_size {
         args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), use_prepended_size: value!(false)],
-        want: Err("unable to decode value with lz4 block decoder: provided output is too small for the decompressed data, actual 0, expected 2"),
+        want: Err("unable to decode value with lz4 block decoder: the offset to copy is not contained in the decompressed buffer"),
         tdef: TypeDef::bytes().fallible(),
     }];
 }

--- a/src/stdlib/decode_lz4.rs
+++ b/src/stdlib/decode_lz4.rs
@@ -1,16 +1,17 @@
 use crate::compiler::prelude::*;
-use lz4_flex::block::decompress_size_prepended;
+use lz4_flex::block::{decompress, decompress_size_prepended, DecompressError};
 use lz4_flex::frame::FrameDecoder;
 use nom::AsBytes;
 
-fn decode_lz4(value: Value) -> Resolved {
+fn decode_lz4(value: Value, buf_size: usize, prepended_size: bool) -> Resolved {
     const FRAME_MAGIC_LE: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
 
     let value = value.try_bytes()?;
 
     // evaluate if value is lz4 frame encoded by checking the magic number.
     if value.starts_with(&FRAME_MAGIC_LE) {
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(buf_size);
+        // FrameDecoder doesn't require or have a value for prepending the uncompressed size to the compressed data.
         let mut decoder = FrameDecoder::new(std::io::Cursor::new(value));
         let result = std::io::copy(&mut decoder, &mut buf);
         match result {
@@ -19,10 +20,22 @@ fn decode_lz4(value: Value) -> Resolved {
         }
     } else {
         // value is not lz4 frame encoded, use block decompressor.
-        let result = decompress_size_prepended(value.as_bytes());
+        let result: Result<Vec<u8>, DecompressError>;
+        // some lz4 block compressors prepend the size of the original data to the compressed data.
+        // this is often to improve performance when decompressing as the size of the buffer can be known in advance.
+        // if prepended_size is true, we will use decompress_size_prepended, otherwise
+        // we will use decompress which requires a buffer size.
+        if prepended_size {
+            result = decompress_size_prepended(value.as_bytes());
+        } else {
+            result = decompress(value.as_bytes(), buf_size);
+        }
         match result {
             Ok(buf) => Ok(Value::Bytes(buf.into())),
-            Err(_) => Err("unable to decode value with lz4 decoder".into()),
+            Err(e) => {
+                let msg = format!("unable to decode value with lz4 decoder {e}");
+                Err(msg.into())
+            }
         }
     }
 }
@@ -50,29 +63,56 @@ impl Function for DecodeLz4 {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
+        let buf_size = arguments.optional("buf_size").unwrap_or_else(|| expr!(0));
+        let prepended_size = arguments
+            .optional("use_prepended_size")
+            .unwrap_or_else(|| expr!(false));
 
-        Ok(DecodeLz4Fn { value }.as_expr())
+        Ok(DecodeLz4Fn {
+            value,
+            buf_size,
+            prepended_size,
+        }
+        .as_expr())
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "value",
-            kind: kind::BYTES,
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "buf_size",
+                kind: kind::INTEGER,
+                required: false,
+            },
+            Parameter {
+                keyword: "prepended_size",
+                kind: kind::INTEGER,
+                required: false,
+            },
+        ]
     }
 }
 
 #[derive(Clone, Debug)]
 struct DecodeLz4Fn {
     value: Box<dyn Expression>,
+    buf_size: Box<dyn Expression>,
+    prepended_size: Box<dyn Expression>,
 }
 
 impl FunctionExpression for DecodeLz4Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
+        let buf_size = self.buf_size.resolve(ctx)?.try_integer()?;
+        let prepended_size = self.prepended_size.resolve(ctx)?.try_boolean()?;
 
-        decode_lz4(value)
+        let buffer_size = buf_size as usize;
+
+        decode_lz4(value, buffer_size, prepended_size)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
@@ -95,24 +135,47 @@ mod tests {
     }
 
     test_function![
-        decode_lz4 => DecodeLz4;
+    decode_lz4 => DecodeLz4;
 
-        right_lz4_block {
-            args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes())],
-            want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
-            tdef: TypeDef::bytes().fallible(),
-        }
+    right_lz4_block {
+        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), use_prepended_size: value!(true)],
+        want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
+        tdef: TypeDef::bytes().fallible(),
+    }
 
-        right_lz4_frame {
-            args: func_args![value: value!(decode_base64("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA=").as_bytes())],
-            want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
-            tdef: TypeDef::bytes().fallible(),
-        }
+    right_lz4_frame {
+        args: func_args![value: value!(decode_base64("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA=").as_bytes())],
+        want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
+        tdef: TypeDef::bytes().fallible(),
+    }
 
-        wrong_lz4 {
-            args: func_args![value: value!("xxxxxxxxx")],
-            want: Err("unable to decode value with lz4 decoder"),
-            tdef: TypeDef::bytes().fallible(),
-        }
-    ];
+    right_lz4_block_no_prepend_size_with_buffer_size {
+        args: func_args![value: value!(decode_base64("8B1UaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLg==").as_bytes()), buf_size: value!(262144), use_prepended_size: value!(false)],
+        want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
+        tdef: TypeDef::bytes().fallible(),
+    }
+
+    right_lz4_frame_grow_buffer_size_from_zero {
+        args: func_args![value: value!(decode_base64("BCJNGGBAgiwAAIBUaGUgcXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgMTMgbGF6eSBkb2dzLgAAAAA=").as_bytes()), buf_size: value!(0), use_prepended_size: value!(false)],
+        want: Ok(value!(b"The quick brown fox jumps over 13 lazy dogs.")),
+        tdef: TypeDef::bytes().fallible(),
+    }
+
+    wrong_lz4_block_grow_buffer_size_from_zero_no_prepended_size {
+        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), buf_size: value!(0), use_prepended_size: value!(false)],
+        want: Err("unable to decode value with lz4 decoder provided output is too small for the decompressed data, actual 0, expected 2"),
+        tdef: TypeDef::bytes().fallible(),
+    }
+
+    wrong_lz4 {
+        args: func_args![value: value!("xxxxxxxxx"), buf_size: value!(10), use_prepended_size: value!(false)],
+        want: Err("unable to decode value with lz4 decoder expected another byte, found none"),
+        tdef: TypeDef::bytes().fallible(),
+    }
+
+    wrong_lz4_block_false_prepended_size {
+        args: func_args![value: value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes()), use_prepended_size: value!(false)],
+        want: Err("unable to decode value with lz4 decoder provided output is too small for the decompressed data, actual 0, expected 2"),
+        tdef: TypeDef::bytes().fallible(),
+    }];
 }

--- a/src/stdlib/encode_lz4.rs
+++ b/src/stdlib/encode_lz4.rs
@@ -6,7 +6,7 @@ fn encode_lz4(value: Value, prepend_size: bool) -> Resolved {
     let value = value.try_bytes()?;
     if prepend_size {
         let encoded = compress_prepend_size(value.as_bytes());
-        return Ok(Value::Bytes(encoded.into()))
+        return Ok(Value::Bytes(encoded.into()));
     }
     let encoded = compress(value.as_bytes());
     Ok(Value::Bytes(encoded.into()))
@@ -39,7 +39,11 @@ impl Function for EncodeLz4 {
             .optional("prepend_size")
             .unwrap_or_else(|| expr!(true));
 
-        Ok(EncodeLz4Fn { value, prepend_size }.as_expr())
+        Ok(EncodeLz4Fn {
+            value,
+            prepend_size,
+        }
+        .as_expr())
     }
 
     fn parameters(&self) -> &'static [Parameter] {

--- a/src/stdlib/encode_lz4.rs
+++ b/src/stdlib/encode_lz4.rs
@@ -1,10 +1,14 @@
 use crate::compiler::prelude::*;
-use lz4_flex::block::compress_prepend_size;
+use lz4_flex::block::{compress, compress_prepend_size};
 use nom::AsBytes;
 
-fn encode_lz4(value: Value) -> Resolved {
+fn encode_lz4(value: Value, prepend_size: bool) -> Resolved {
     let value = value.try_bytes()?;
-    let encoded = compress_prepend_size(value.as_bytes());
+    if prepend_size {
+        let encoded = compress_prepend_size(value.as_bytes());
+        return Ok(Value::Bytes(encoded.into()))
+    }
+    let encoded = compress(value.as_bytes());
     Ok(Value::Bytes(encoded.into()))
 }
 
@@ -19,7 +23,7 @@ impl Function for EncodeLz4 {
     fn examples(&self) -> &'static [Example] {
         &[Example {
             title: "demo string",
-            source: r#"encode_base64(encode_lz4!("The quick brown fox jumps over 13 lazy dogs."))"#,
+            source: r#"encode_base64(encode_lz4!("The quick brown fox jumps over 13 lazy dogs.", true))"#,
             result: Ok("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4="),
         }]
     }
@@ -31,29 +35,41 @@ impl Function for EncodeLz4 {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
+        let prepend_size = arguments
+            .optional("prepend_size")
+            .unwrap_or_else(|| expr!(true));
 
-        Ok(EncodeLz4Fn { value }.as_expr())
+        Ok(EncodeLz4Fn { value, prepend_size }.as_expr())
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "value",
-            kind: kind::BYTES,
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "prepend_size",
+                kind: kind::BOOLEAN,
+                required: false,
+            },
+        ]
     }
 }
 
 #[derive(Clone, Debug)]
 struct EncodeLz4Fn {
     value: Box<dyn Expression>,
+    prepend_size: Box<dyn Expression>,
 }
 
 impl FunctionExpression for EncodeLz4Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
+        let prepend_size = self.prepend_size.resolve(ctx)?.try_boolean()?;
 
-        encode_lz4(value)
+        encode_lz4(value, prepend_size)
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
@@ -78,7 +94,7 @@ mod test {
         encode_lz4 => EncodeLz4;
 
         success {
-            args: func_args![value: value!("The quick brown fox jumps over 13 lazy dogs.")],
+            args: func_args![value: value!("The quick brown fox jumps over 13 lazy dogs."), prepend_size: value!(true)],
             want: Ok(value!(decode_base64("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=").as_bytes())),
             tdef: TypeDef::bytes().fallible(),
         }


### PR DESCRIPTION
## Summary

This pull request improves encode_lz4() and decode_lz4() support to handle a variety of different implementations that we have found in production. The original implementation that I contributed prepended the uncompressed data size in bytes to the first four bytes of the compressed payload. This worked for most of the LZ4-encoded payloads that we received; however, it turned out that this pattern is not a standard.

This change introduces a `prepend_size` boolean argument that allows the user to turn on/off expecting the size to be prepended. Because it's non-standard, this defaults to `false`. This means that the change is **breaking**; however, it should increase compatibility.

I have also introduced a `buf_size` argument that sets the buffer size to which the uncompressed data is written. If the user has not set it, then the default is 1MB. 1MB has been chosen because it's larger than many of the common payload sizes (256kb) seen across cloud pub/sub products. If users are familiar with their pipeline, they can adjust it up or down, which may also improve performance on busy systems.

Note, I've used `buf_size` and `prepend_size` as the argument names, I'm unsure how obvious their use case is from the argument names, maybe they need to change? 

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

## How did you test this PR?

I have introduced a number of new tests to cover the various differences.

## Does this PR include user-facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.


## References


