### PR TITLE
chore(admin): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vectordotdev/vector

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 VRL is a scripting language for processing observability data (logs, metrics, traces). Although VRL was originally
 created for use in [Vector], it was designed to be generic and re-usable in many contexts.
 
+VRL is maintained by
+Datadog's [Community Open Source Engineering team](https://opensource.datadoghq.com/about/#the-community-open-source-engineering-team).
 
 ## Features
 


### PR DESCRIPTION
The following tool reminded me that this file was not present: 

```
github-security-settings-scanner run-checks -r vectordotdev/vrl  
```