### PR TITLE
feat(stdlib): Add new xxhash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,6 +3676,7 @@ dependencies = [
  "uuid",
  "webbrowser",
  "woothee",
+ "xxhash-rust",
  "zstd",
 ]
 
@@ -4250,6 +4251,12 @@ name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ stdlib = [
   "dep:utf8-width",
   "dep:uuid",
   "dep:woothee",
+  "dep:xxhash-rust",
   "dep:zstd",
   "dep:encoding_rs"
 ]
@@ -197,6 +198,7 @@ url = { version = "2", optional = true }
 snafu = { version = "0.8", optional = true }
 webbrowser = { version = "1.0", default-features = false, optional = true }
 woothee = { version = "0.13", optional = true }
+xxhash-rust = { version = "0.8", optional = true }
 community-id = { version = "0.2", optional = true }
 
 zstd = { version = "0.13", default-features = false, features = ["wasm"], optional = true }

--- a/src/stdlib/xxhash.rs
+++ b/src/stdlib/xxhash.rs
@@ -1,0 +1,327 @@
+use xxhash_rust::{xxh3, xxh32, xxh64};
+
+use crate::compiler::prelude::*;
+
+#[allow(clippy::cast_possible_wrap)]
+fn xxhash(value: Value, ctx: &mut Context) -> Resolved {
+    let bytes = value.try_bytes()?;
+    let result = xxh32::xxh32(&bytes, 0);
+    Ok(Value::from(result as i64))
+}
+
+#[allow(clippy::cast_possible_wrap)]
+fn xxhash_with_options(value: Value, algorithm: Option<Value>, ctx: &mut Context) -> Resolved {
+    let bytes = value.try_bytes()?;
+
+    let algorithm_str = algorithm
+        .map(|v| v.try_bytes())
+        .transpose()?
+        .map(|b| String::from_utf8_lossy(&b).to_string())
+        .unwrap_or_else(|| "xxh32".to_string());
+
+    match algorithm_str.as_str() {
+        "xxh32" => {
+            let result = xxh32::xxh32(&bytes, 0);
+            Ok(Value::from(result as i64))
+        }
+        "xxh64" => {
+            let result = xxh64::xxh64(&bytes, 0);
+            Ok(Value::from(result as i64))
+        }
+        "xxh3_64" => {
+            let result = xxh3::xxh3_64(&bytes);
+            Ok(Value::from(result as i64))
+        }
+        "xxh3_128" => {
+            let result = xxh3::xxh3_128(&bytes);
+            // Convert u128 to string representation since VRL doesn't have native u128 support
+            Ok(Value::from(result.to_string()))
+        }
+        _ => Err("algorithm must be either 'xxh32', 'xxh64', 'xxh3_64', or 'xxh3_128'".into()),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Xxhash;
+
+impl Function for Xxhash {
+    fn identifier(&self) -> &'static str {
+        "xxhash"
+    }
+
+    fn summary(&self) -> &'static str {
+        "calculate xxhash hash"
+    }
+
+    fn usage(&self) -> &'static str {
+        "xxhash"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "algorithm",
+                kind: kind::BYTES,
+                required: false,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "calculate xxhash hash (xxh32 default)",
+                source: r#"xxhash("foobar")"#,
+                result: Ok("2654435761"),
+            },
+            Example {
+                title: "calculate xxhash hash (xxh64)",
+                source: r#"xxhash("foobar", algorithm: "xxh64")"#,
+                result: Ok("-7444071767201028348"),
+            },
+            Example {
+                title: "calculate xxhash3_64 hash",
+                source: r#"xxhash("foobar", algorithm: "xxh3_64")"#,
+                result: Ok("-8166901779493161352"),
+            },
+            Example {
+                title: "calculate xxhash3_128 hash",
+                source: r#"xxhash("foobar", algorithm: "xxh3_128")"#,
+                result: Ok("303003700981207993820949119788962816296"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        state: &state::TypeState,
+        ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        let algorithm = arguments.optional("algorithm");
+
+        match algorithm {
+            Some(algorithm_expr) => Ok(xxhash_with_options_fn::new(value, algorithm_expr).into()),
+            None => Ok(xxhash_fn::new(value).into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct xxhash_fn {
+    value: Box<dyn Expression>,
+}
+
+impl xxhash_fn {
+    fn new(value: Box<dyn Expression>) -> Self {
+        Self { value }
+    }
+}
+
+impl FunctionExpression for xxhash_fn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        xxhash(value, ctx)
+    }
+
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        TypeDef::integer()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct xxhash_with_options_fn {
+    value: Box<dyn Expression>,
+    algorithm: Box<dyn Expression>,
+}
+
+impl xxhash_with_options_fn {
+    fn new(value: Box<dyn Expression>, algorithm: Box<dyn Expression>) -> Self {
+        Self { value, algorithm }
+    }
+}
+
+impl FunctionExpression for xxhash_with_options_fn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let algorithm = Some(self.algorithm.resolve(ctx)?);
+        xxhash_with_options(value, algorithm, ctx)
+    }
+
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        // Return union of integer (32/64-bit variants) and string (128-bit)
+        TypeDef::integer().or_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value;
+
+    test_function![
+        xxhash => Xxhash;
+
+        hash_xxh32_default {
+            args: func_args![value: "foo"],
+            want: Ok(value!(4138058784)),
+            tdef: TypeDef::integer(),
+        }
+
+        hash_xxh32_explicit {
+            args: func_args![value: "foo", algorithm: "xxh32"],
+            want: Ok(value!(4138058784)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        hash_xxh64 {
+            args: func_args![value: "foo", algorithm: "xxh64"],
+            want: Ok(value!(-3728692692368066520)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        hash_xxh3_64 {
+            args: func_args![value: "foo", algorithm: "xxh3_64"],
+            want: Ok(value!(-4636154005964105165)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        hash_xxh3_128 {
+            args: func_args![value: "foo", algorithm: "xxh3_128"],
+            want: Ok(value!("84696207739838802046286913206618428373")),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        invalid_algorithm {
+            args: func_args![value: "foo", algorithm: "xxh16"],
+            want: Err("algorithm must be either 'xxh32', 'xxh64', 'xxh3_64', or 'xxh3_128'"),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        empty_string_xxh32 {
+            args: func_args![value: ""],
+            want: Ok(value!(46947589)),
+            tdef: TypeDef::integer(),
+        }
+
+        empty_string_xxh64 {
+            args: func_args![value: "", algorithm: "xxh64"],
+            want: Ok(value!(-1205034819632174695)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        empty_string_xxh3_64 {
+            args: func_args![value: "", algorithm: "xxh3_64"],
+            want: Ok(value!(-4963153986929159138)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        empty_string_xxh3_128 {
+            args: func_args![value: "", algorithm: "xxh3_128"],
+            want: Ok(value!("99394879406065805935928060743628289650")),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        unicode_string_xxh32 {
+            args: func_args![value: "ñoño"],
+            want: Ok(value!(1159352444)),
+            tdef: TypeDef::integer(),
+        }
+
+        unicode_string_xxh64 {
+            args: func_args![value: "ñoño", algorithm: "xxh64"],
+            want: Ok(value!(3293578300618893924)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        unicode_string_xxh3_64 {
+            args: func_args![value: "ñoño", algorithm: "xxh3_64"],
+            want: Ok(value!(7265014866508651963)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        unicode_string_xxh3_128 {
+            args: func_args![value: "ñoño", algorithm: "xxh3_128"],
+            want: Ok(value!("232859983847772695459159509959473584851")),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        binary_data_xxh32 {
+            args: func_args![value: value!([0, 1, 2, 3, 255])],
+            want: Ok(value!(1161967623)),
+            tdef: TypeDef::integer(),
+        }
+
+        binary_data_xxh64 {
+            args: func_args![value: value!([0, 1, 2, 3, 255]), algorithm: "xxh64"],
+            want: Ok(value!(-6875981080804642536)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        binary_data_xxh3_64 {
+            args: func_args![value: value!([0, 1, 2, 3, 255]), algorithm: "xxh3_64"],
+            want: Ok(value!(-7905757983058936925)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        binary_data_xxh3_128 {
+            args: func_args![value: value!([0, 1, 2, 3, 255]), algorithm: "xxh3_128"],
+            want: Ok(value!("107988036830263503854644659829616537907")),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        long_string_xxh32 {
+            args: func_args![value: "vrl xxhash hash function"],
+            want: Ok(value!(1951877985)),
+            tdef: TypeDef::integer(),
+        }
+
+        long_string_xxh64 {
+            args: func_args![value: "vrl xxhash hash function", algorithm: "xxh64"],
+            want: Ok(value!(5103503319754928801)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        long_string_xxh3_64 {
+            args: func_args![value: "vrl xxhash hash function", algorithm: "xxh3_64"],
+            want: Ok(value!(-1476804297949976525)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        long_string_xxh3_128 {
+            args: func_args![value: "vrl xxhash hash function", algorithm: "xxh3_128"],
+            want: Ok(value!("229055459936831226905346831779542577667")),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        large_input_xxh32 {
+            args: func_args![value: "a".repeat(1024)],
+            want: Ok(value!(1766643583)),
+            tdef: TypeDef::integer(),
+        }
+
+        large_input_xxh64 {
+            args: func_args![value: "a".repeat(1024), algorithm: "xxh64"],
+            want: Ok(value!(5934086765239761821)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        large_input_xxh3_64 {
+            args: func_args![value: "a".repeat(1024), algorithm: "xxh3_64"],
+            want: Ok(value!(-4329874863901799357)),
+            tdef: TypeDef::integer().or_string(),
+        }
+
+        large_input_xxh3_128 {
+            args: func_args![value: "a".repeat(1024), algorithm: "xxh3_128"],
+            want: Ok(value!("181467889456669024226987041395653829229")),
+            tdef: TypeDef::integer().or_string(),
+        }
+    ];
+}


### PR DESCRIPTION
## Summary

Adds a new xxhash function implementing xxh32/xxh64/xxh3_64/xxh3_128 hashing algorithms

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Added function tests, and test examples in the function definition

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.


## References

- Closes: #72
