### PR TITLE
(fix stdlib): Fix `validate_json_schema` to prevent compile-time panics

### DIFF
--- a/changelog.d/1476.fix.md
+++ b/changelog.d/1476.fix.md
@@ -1,0 +1,1 @@
+This fixes the `validate_json_schema` function behavior to not panic if the JSON schema file cannot be accessed or is invalid. It also collects and returns in a function call error message any JSON schema validation errors of the given JSON value.

--- a/changelog.d/1476.fix.md
+++ b/changelog.d/1476.fix.md
@@ -1,1 +1,1 @@
-This fixes the `validate_json_schema` function behavior to not panic if the JSON schema file cannot be accessed or is invalid. It also collects and returns in a function call error message any JSON schema validation errors of the given JSON value.
+This fixes the `validate_json_schema` function behavior to not panic if the JSON schema file cannot be accessed or is invalid.

--- a/changelog.d/1476.fix.md
+++ b/changelog.d/1476.fix.md
@@ -1,1 +1,1 @@
-This fixes the `validate_json_schema` function behavior to not panic if the JSON schema file cannot be accessed or is invalid.
+The `validate_json_schema` function no longer panics if the JSON schema file cannot be accessed or is invalid.

--- a/src/stdlib/validate_json_schema.rs
+++ b/src/stdlib/validate_json_schema.rs
@@ -101,7 +101,9 @@ impl Function for ValidateJsonSchema {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod non_wasm {
-    use super::{Context, Expression, FunctionExpression, Resolved, TypeDef, VrlValueConvert, state};
+    use super::{
+        Context, Expression, FunctionExpression, Resolved, TypeDef, VrlValueConvert, state,
+    };
     use crate::stdlib::json_utils::bom::StripBomFromUTF8;
     use crate::value;
     use jsonschema;
@@ -142,10 +144,8 @@ mod non_wasm {
                 serde_json::from_slice(stripped_bytes).map_err(|e| format!("Invalid JSON: {e}"))?
             };
 
-            let schema_validator = get_or_compile_schema(
-                &self.schema_path,
-                ignore_unknown_formats,
-            )?;
+            let schema_validator =
+                get_or_compile_schema(&self.schema_path, ignore_unknown_formats)?;
 
             Ok(value!(schema_validator.is_valid(&json_value)))
         }
@@ -196,8 +196,8 @@ mod non_wasm {
             return Ok(schema.clone());
         }
 
-        let schema_definition =
-            get_json_schema_definition(schema_path).map_err(|e| format!("JSON schema not found: {e}"))?;
+        let schema_definition = get_json_schema_definition(schema_path)
+            .map_err(|e| format!("JSON schema not found: {e}"))?;
 
         // Compile schema
         let compiled_schema = jsonschema::options()


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR fixes the issue noted in #1474, where VRL (and thus Vector) panics if the referenced JSON schema file path is not accessible at function compile-time. This PR moves the loading of the schema file to the first runtime evaluation of the function. This better aligns the expectation that VRL and Vector won't fully crash, but will merely throw a standard VRL function call error, if the JSON schema file cannot be accessed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [X] Yes
- [ ] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #1474
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
