### PR TITLE
feat(stdlib): add array pop() function

### DIFF
--- a/changelog.d/1501.feature.md
+++ b/changelog.d/1501.feature.md
@@ -1,0 +1,3 @@
+Added a new array function `pop` that removes the last item from an array.
+
+authors: jlambatl

--- a/lib/tests/tests/functions/pop.vrl
+++ b/lib/tests/tests/functions/pop.vrl
@@ -1,0 +1,5 @@
+# object: { "foo": [ "apples", "bananas" ] }
+# result: { "foo": [ "apples" ] }
+
+.foo = pop!(.foo)
+.

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -147,6 +147,7 @@ cfg_if::cfg_if! {
         mod parse_url;
         mod parse_user_agent;
         mod parse_xml;
+        mod pop;
         mod push;
         mod random_bool;
         mod random_bytes;
@@ -341,6 +342,7 @@ cfg_if::cfg_if! {
         pub use parse_url::ParseUrl;
         pub use parse_user_agent::ParseUserAgent;
         pub use parse_xml::ParseXml;
+        pub use pop::Pop;
         pub use push::Push;
         pub use r#match::Match;
         pub use random_bool::RandomBool;
@@ -543,6 +545,7 @@ pub fn all() -> Vec<Box<dyn Function>> {
         Box::new(ParseUserAgent),
         Box::new(ParseXml),
         Box::new(Pascalcase),
+        Box::new(Pop),
         Box::new(Push),
         Box::new(RandomBool),
         Box::new(RandomBytes),

--- a/src/stdlib/pop.rs
+++ b/src/stdlib/pop.rs
@@ -1,0 +1,110 @@
+use crate::compiler::prelude::*;
+
+fn pop(value: Value) -> Resolved {
+    let mut value = value.try_array()?;
+    value.pop();
+    Ok(value.into())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Pop;
+
+impl Function for Pop {
+    fn identifier(&self) -> &'static str {
+        "pop"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ARRAY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "pop array",
+            source: "pop(value: [0, 1])",
+            result: Ok("[0]"),
+        }]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(PopFn { value }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PopFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for PopFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+
+        pop(value)
+    }
+
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(Kind::array(Collection::any()))
+            .restrict_array()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{btreemap, value};
+
+    test_function![
+        pop => Pop;
+
+        empty_array {
+            args: func_args![value: value!([])],
+            want: Ok(value!([])),
+            tdef: TypeDef::array(Collection::empty()),
+        }
+
+        null_array {
+            args: func_args![value: value!(null)],
+            want: Err("expected array, got null"),
+            tdef: TypeDef::array(Collection::any()).fallible(),
+        }
+
+        mixed_array_types {
+            args: func_args![value: value!([1, 2, 3, true, 5.0, "bar"])],
+            want: Ok(value!([1, 2, 3, true, 5.0])),
+            tdef: TypeDef::array(btreemap! {
+                Index::from(0) => Kind::integer(),
+                Index::from(1) => Kind::integer(),
+                Index::from(2) => Kind::integer(),
+                Index::from(3) => Kind::boolean(),
+                Index::from(4) => Kind::float(),
+                Index::from(5) => Kind::bytes(),
+            }),
+        }
+
+        integer_array {
+            args: func_args![value: value!([0, 1, 2, 3])],
+            want: Ok(value!([0, 1, 2])),
+            tdef: TypeDef::array(btreemap! {
+                Index::from(0) => Kind::integer(),
+                Index::from(1) => Kind::integer(),
+                Index::from(2) => Kind::integer(),
+                Index::from(3) => Kind::integer(),
+            }),
+        }
+
+    ];
+}


### PR DESCRIPTION
## Summary

This PR adds a function `pop()` that removes the last entry from an array. This is the first of several array functions that we will contribute. This has been discussed here: https://github.com/vectordotdev/vrl/discussions/1481 

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Unit tests have been added to the function. I've run `scripts/checks.sh` and all pass without any issues. 

## Does this PR include user-facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [-] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

* https://github.com/vectordotdev/vrl/discussions/1481

