### PR TITLE
fix(stdlib): Fix `http_request` ability to run from CLI

### DIFF
--- a/changelog.d/1510.fix.md
+++ b/changelog.d/1510.fix.md
@@ -1,0 +1,3 @@
+Fixed the `http_request` function's ability to run from the VRL CLI, no longer panics.
+
+authors: sbalmos

--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -94,11 +94,10 @@ mod non_wasm {
             // block_in_place runs the HTTP request synchronously
             // without blocking Tokio's async worker threads.
             // This temporarily moves execution to a blocking-compatible thread.
-            task::block_in_place(|| match Handle::try_current() {
-                Ok(handle) => {
+            task::block_in_place(|| {
+                if let Ok(handle) = Handle::try_current() {
                     handle.block_on(async { http_request(&url, &method, headers, &body).await })
-                }
-                Err(_) => {
+                } else {
                     let runtime = runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
The current implementation of the new `http_request` function causes the VRL CLI to panic, as it relies on an active Tokio runtime. This PR adapts similar code used in the `dns_lookup` function to build a tiny runtime and run the request task within it when no active Tokio runtime / `Handle` is found.

## Change Type

- [X] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [X] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->
Running VRL CLI - `http_request!("https://httpbin.org/post", method: "post", body: encode_json!({"hello":"there"}))`
Does the CLI still panic, or is the function executed?

This mod is also how I was able to test other changes in other related PRs

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
- #1499
- #1502
