### PR TITLE
feat(vrl): return null instead of -1 when not find in `find` function

### DIFF
--- a/changelog.d/1514.breaking.md
+++ b/changelog.d/1514.breaking.md
@@ -1,1 +1,3 @@
-The return value of the `find` stdlib VRL function has been changed to `null` instead of `-1` if the search string is not found.
+The return value of the `find` function has been changed to `null` instead of `-1` if there is no match.
+
+authors: titaneric

--- a/changelog.d/1514.breaking.md
+++ b/changelog.d/1514.breaking.md
@@ -1,2 +1,1 @@
-The following changes are breaking:
-- The return value of the `find` function has been changed to `null` instead of `-1`.
+The return value of the `find` stdlib VRL function has been changed to `null` instead of `-1` if the search string is not found.

--- a/changelog.d/1514.breaking.md
+++ b/changelog.d/1514.breaking.md
@@ -1,0 +1,2 @@
+The following changes are breaking:
+- The return value of the `find` function has been changed to `null` instead of `-1`.

--- a/src/stdlib/find.rs
+++ b/src/stdlib/find.rs
@@ -10,7 +10,7 @@ fn find(value: Value, pattern: Value, from: Option<Value>) -> Resolved {
     } as usize;
 
     Ok(FindFn::find(value, pattern, from)?
-        .map_or(Value::Integer(-1), |value| Value::Integer(value as i64)))
+        .map_or(Value::Null, |value| Value::Integer(value as i64)))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -163,7 +163,7 @@ mod tests {
 
         str_too_long {
             args: func_args![value: "foo", pattern: "foobar"],
-            want: Ok(value!(-1)),
+            want: Ok(value!(null)),
             tdef: TypeDef::integer().infallible(),
         }
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This change intends to fix the return value of `find` function to `null` instead of `-1`

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

```bash
./scripts/checks.sh

./scripts/check_changelog_fragments.sh
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

Closes: #1383 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
