### PR TITLE
fix(stdlib): fix glog parser to accept padded thread_id

### DIFF
--- a/changelog.d/1515.fix.md
+++ b/changelog.d/1515.fix.md
@@ -1,0 +1,1 @@
+fix `parse_glog` to accept space-padded thread-id

--- a/src/stdlib/parse_glog.rs
+++ b/src/stdlib/parse_glog.rs
@@ -58,7 +58,7 @@ static REGEX_GLOG: LazyLock<Regex> = LazyLock::new(|| {
         ^\s*                                                        # Start with any number of whitespaces.
         (?P<level>\w)                                               # Match one word character (expecting `I`,`W`,`E` or `F`).
         (?P<timestamp>\d{4}\d{2}\d{2}\s\d{2}:\d{2}:\d{2}\.\d{6})    # Match YYYYMMDD hh:mm:ss.ffffff.
-        \s                                                          # Match one whitespace.
+        \s+                                                         # Match one or more whitespace.
         (?P<id>\d+)                                                 # Match at least one digit.
         \s                                                          # Match one whitespace.
         (?P<file>.+):(?P<line>\d+)                                  # Match any character (greedily), ended by `:` and at least one digit.
@@ -168,6 +168,19 @@ mod tests {
                 "level" => "info",
                 "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-01-31T14:48:54.411655Z").unwrap().into()),
                 "id" => 15520,
+                "file" => "main.c++",
+                "line" => 9,
+                "message" => "Hello world!",
+            }),
+            tdef: TypeDef::object(inner_kind()).fallible(),
+        }
+
+        log_line_padded_threadid {
+            args: func_args![value: "I20210131 14:48:54.411655    20 main.c++:9] Hello world!"],
+            want: Ok(btreemap! {
+                "level" => "info",
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-01-31T14:48:54.411655Z").unwrap().into()),
+                "id" => 20,
                 "file" => "main.c++",
                 "line" => 9,
                 "message" => "Hello world!",


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

According to docs[1] of glog, the thread_id is space-padded. Parser should accept shorter thread_id as well.

Similar regex is used in parse_klog as well.

[1]: https://google.github.io/glog/0.7.1/logging/#log-line-prefix-format

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

Added new test-case to the code

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
