### PR TITLE
enhancement(stdlib): Add optional `http_proxy` and `https_proxy` params to `http_request`

### DIFF
--- a/changelog.d/1534.enhancement.md
+++ b/changelog.d/1534.enhancement.md
@@ -1,0 +1,1 @@
+Added optional `http_proxy` and `https_proxy` parameters to `http_request` for setting the proxies used for a request.

--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -14,13 +14,13 @@ mod non_wasm {
         Value, VrlValueConvert,
     };
     use reqwest_middleware::{
+        ClientBuilder, ClientWithMiddleware,
         reqwest::{
-            header::{HeaderMap, HeaderName, HeaderValue}, Client, Method,
-            Proxy,
-        }, ClientBuilder,
-        ClientWithMiddleware,
+            Client, Method, Proxy,
+            header::{HeaderMap, HeaderName, HeaderValue},
+        },
     };
-    use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+    use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
     use std::sync::LazyLock;
     use tokio::runtime::Handle;
     use tokio::time::Duration;
@@ -120,7 +120,6 @@ mod non_wasm {
             Ok(Some(proxies))
         }
     }
-
 
     #[derive(Debug, Clone)]
     pub(super) enum ClientOrProxies {

--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -369,11 +369,8 @@ impl Function for HttpRequest {
         let http_proxy = arguments.optional("http_proxy");
         let https_proxy = arguments.optional("https_proxy");
 
-        // Result::map_err wouldn't properly convert the error for ? sugar
-        let client_or_proxies = match ClientOrProxies::new(state, http_proxy, https_proxy) {
-            Ok(ok) => ok,
-            Err(err) => return Err(Box::new(err)),
-        };
+        let client_or_proxies = ClientOrProxies::new(state, http_proxy, https_proxy)
+            .map_err(|err| Box::new(err) as Box<dyn DiagnosticMessage>)?;
 
         Ok(HttpRequestFn {
             url,


### PR DESCRIPTION
## Summary

Adds optional parameters for setting a proxy for http and https requests to `http_request`.

A future enhancement should use the [global proxy](https://github.com/vectordotdev/vector/blob/cd2471ab3ed81cc55b13eb4f094af735a210b61e/lib/vector-core/src/config/global_options.rs#L103) by default if set. Is there any easy way to pass that information from vector to vrl?

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Locally testing since I didn't want to add standing up a whole proxy server as party of the test suite.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

None