### PR TITLE
feat(rfc): automatic documentation generation

### DIFF
--- a/rfcs/2025-10-27-vrl-function-documentation-auto-generation.md
+++ b/rfcs/2025-10-27-vrl-function-documentation-auto-generation.md
@@ -2,7 +2,9 @@
 
 ## Context
 
-The purpose of this RFC is to propose significant improvements to VRL function documentation.
+VRL function documentation lives in two repos today, must be updated by hand, and easily goes stale.
+This RFC proposes moving all VRL function documentation into function definition source code, so
+Vector can generate documentation automatically and all examples are validated in CI.
 
 Today contributing a new VRL function requires creating PRs in two separate repositories:
 1. VRL repository - Function implementation.
@@ -10,21 +12,20 @@ Today contributing a new VRL function requires creating PRs in two separate repo
 
 This split workflow creates several problems:
 - Documentation becomes outdated or incorrect.
-- Examples in the manually-maintained CUE files are not tested, leading to broken examples.
-- Functions can ship without documentation if the Vector PR is never created/merged.
-- Contributors/maintainer burden of dealing with multiple PRs.
+- Examples in CUE files are not tested, leading to broken examples.
+- Functions can ship without documentation if the Vector PR is missed.
+- Contributors must open two PRs for one change.
 
 Once this RFC is implemented, the workflow of adding and documenting a new VRL function should look like this:
 1. PR is opened in the VRL repository.
   * Function documentation lives alongside/within it's definition.
   * All examples are tested and validated before merging.
-2. VRL function documentation is automatically updated in the Vector repo once VRL is
-   bumped.
+2. VRL function documentation is automatically updated in the Vector repo once VRL is bumped.
 
 ## Goals
 
-1. All 200+ VRL functions should maintain documentation quality at parity with or exceeding current manually-maintained CUE files
-2. 100% of VRL functions have the necessary attributes to automatically generate documentation
+1. All 200+ VRL functions should maintain documentation quality at parity with or exceeding current manually-maintained CUE files.
+2. All functions provide the fields needed for automatic documentation.
 3. Vector automatically generates documentation for all VRL functions without relying on **any**
    non-Rust source code files.
 4. Validate 100% of examples through CI-enforced testing
@@ -38,6 +39,9 @@ Once this RFC is implemented, the workflow of adding and documenting a new VRL f
    documentation and not (code generation for) automatic function discovery
 
 ## Proposal
+
+We will move all VRL function docs into the `Function` trait, port existing docs into VRL,
+and add a `vdev` command that generates website-ready docs from VRL functions alone.
 
 ### Proposed brief architecture overview
 
@@ -58,7 +62,7 @@ Once this RFC is implemented, the workflow of adding and documenting a new VRL f
    missing `internal_failure_reasons`, `description`, `return` and `category`. Note that `usage` and
    `description` should be equivalent.
 
-2. Once the `Function` trait is updated, port all documentation currently present in Vector cue functions
+2. Once the `Function` trait is updated, port all documentation currently present in Vector CUE functions
    [here](https://github.com/vectordotdev/vector/blob/master/website/cue/reference/remap/functions/)
    into VRL's source code. Once the PR is merged, update VRL inside of Vector and do the same for
    Vector-specific VRL functions.
@@ -71,33 +75,30 @@ Once this RFC is implemented, the workflow of adding and documenting a new VRL f
 4. Provide documentation to the website. There are a couple of options here:
   * [Rejected] Directly convert documentation into json and insert it into `data/docs.json`
     - Cons
-      * No documentation present in any cue files in the Vector repo, making it harder to
+      * No documentation present in any CUE files in the Vector repo, making it harder to
       notice if the website needs to be updated.
       * Docs team and maintainers will probably not see any VRL documentation changes (during
         releases).
       * (minor) Less visibility into VRL documentation when checking out old source code
     - Pros
-      * VRL source code is the sole source of truth and updating docs is simply running website
+      * VRL source code is the single source of documentation and updating docs is simply running website
       deploy commands and one additional `vdev` command.
       * No binary documentation files or duplicated information in repos anywhere.
-  * [Rejected] Convert documentation into cue files and keep the regular flow.
+  * [Rejected] Convert documentation into CUE files and keep the regular flow.
     - Cons
-      * VRL source code is not the sole source of truth.
+      * VRL source code is not the single source of documentation.
       * VRL documentation has to be updated in two repos.
-      * Need to generate cue files when updating VRL.
-      * We'd be generating cue in a very hacky manner and we want to move away from cue wherever
-        possible
+      * Need to generate CUE files when updating VRL.
+      * We'd be generating CUE in a very hacky manner and we want to reduce our use of CUE.
     - Pros:
       * More visibility into documentation changes. This makes it easier to notice if the website needs
       to be updated since CI checks will catch differences in generated files.
-  * Convert documentation into pretty printed JSON file.
+  * **[Chosen]** Convert documentation into pretty printed JSON file.
     - Cons
-      * VRL source code is not the sole source of truth.
+      * VRL source code is not the single source of documentation.
       * VRL documentation has to be updated in two repos.
       * Need to generate json files when updating VRL.
     - Pros:
-      * While VRL source code is not the sole source of truth, the docs can and will be generated
-        from VRL directly.
       * More visibility into documentation changes. This makes it easier to notice if the website needs
       to be updated since CI checks will catch differences in generated files.
 
@@ -108,8 +109,8 @@ Once this RFC is implemented, the workflow of adding and documenting a new VRL f
 ## Future work
 
 - Make it so Vector-specific functions also have their examples tested with the same rigor as VRL
-  examples. This could turn out to be a hard problem since some of them need Vector to be running
-  and configured properly.
+  examples. Vector-only functions usually require a running Vector instance, so testing their
+  examples will require a new test harness.
 
 ## References
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

RFC skeleton was created by @pront and handed over to @thomasqueirozb.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

- Related: #280
<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
---
# Rendered RFC

# RFC 2025-10-27 - VRL Function Documentation Auto-Generation

## Context

VRL function documentation lives in two repos today, must be updated by hand, and easily goes stale.
This RFC proposes moving all VRL function documentation into function definition source code, so
Vector can generate documentation automatically and all examples are validated in CI.

Today contributing a new VRL function requires creating PRs in two separate repositories:
1. VRL repository - Function implementation.
2. Vector repository - Adds documentation in a _manually_ created/maintained CUE file.

This split workflow creates several problems:
- Documentation becomes outdated or incorrect.
- Examples in CUE files are not tested, leading to broken examples.
- Functions can ship without documentation if the Vector PR is missed.
- Contributors must open two PRs for one change.

Once this RFC is implemented, the workflow of adding and documenting a new VRL function should look like this:
1. PR is opened in the VRL repository.
  * Function documentation lives alongside/within it's definition.
  * All examples are tested and validated before merging.
2. VRL function documentation is automatically updated in the Vector repo once VRL is bumped.

## Goals

1. All 200+ VRL functions should maintain documentation quality at parity with or exceeding current manually-maintained CUE files.
2. All functions provide the fields needed for automatic documentation.
3. Vector automatically generates documentation for all VRL functions without relying on **any**
   non-Rust source code files.
4. Validate 100% of examples through CI-enforced testing
5. Require only a single PR to add new VRL functions

## Out of scope

1. **Website rendering changes** - This RFC focuses on documentation generation; website rendering should remain mostly unchanged
2. **Automatic VRL function discovery and/or AST parsing** - This is a nice project but currently
   all VRL functions are present in the `vrl::stdlib::all()` vector. This RFC focuses on
   documentation and not (code generation for) automatic function discovery

## Proposal

We will move all VRL function docs into the `Function` trait, port existing docs into VRL,
and add a `vdev` command that generates website-ready docs from VRL functions alone.

### Proposed brief architecture overview

1. VRL functions source code (src/stdlib in the VRL repository)
- Functions implement the `Function` trait.
- Functions are documented using required methods in the `Function` trait.
- All functions' examples are tested.

2. Vector Repo (consumes VRL)
- Aggregates VRL functions and internal VRL functions.
- Grabs all function information using the `Function` trait.
- Does necessary transforms/validations and generates output.
- Output is visible on the website.

### Technical approach

1. Expand the `Function` trait. Currently it contains `identifier`, `summary`, `usage`, `examples`. It is
   missing `internal_failure_reasons`, `description`, `return` and `category`. Note that `usage` and
   `description` should be equivalent.

2. Once the `Function` trait is updated, port all documentation currently present in Vector CUE functions
   [here](https://github.com/vectordotdev/vector/blob/master/website/cue/reference/remap/functions/)
   into VRL's source code. Once the PR is merged, update VRL inside of Vector and do the same for
   Vector-specific VRL functions.
  * Note that after the `Function` trait is updated VRL will not be able to be updated in the Vector
    repo until all functions are documented.

3. Create a `vdev` command (in Vector's repo) to generate documentation based solely on the methods
   provided by the `Function` trait.

4. Provide documentation to the website. There are a couple of options here:
  * [Rejected] Directly convert documentation into json and insert it into `data/docs.json`
    - Cons
      * No documentation present in any CUE files in the Vector repo, making it harder to
      notice if the website needs to be updated.
      * Docs team and maintainers will probably not see any VRL documentation changes (during
        releases).
      * (minor) Less visibility into VRL documentation when checking out old source code
    - Pros
      * VRL source code is the single source of documentation and updating docs is simply running website
      deploy commands and one additional `vdev` command.
      * No binary documentation files or duplicated information in repos anywhere.
  * [Rejected] Convert documentation into CUE files and keep the regular flow.
    - Cons
      * VRL source code is not the single source of documentation.
      * VRL documentation has to be updated in two repos.
      * Need to generate CUE files when updating VRL.
      * We'd be generating CUE in a very hacky manner and we want to reduce our use of CUE.
    - Pros:
      * More visibility into documentation changes. This makes it easier to notice if the website needs
      to be updated since CI checks will catch differences in generated files.
  * **[Chosen]** Convert documentation into pretty printed JSON file.
    - Cons
      * VRL source code is not the single source of documentation.
      * VRL documentation has to be updated in two repos.
      * Need to generate json files when updating VRL.
    - Pros:
      * More visibility into documentation changes. This makes it easier to notice if the website needs
      to be updated since CI checks will catch differences in generated files.

5. Add an extra step to `make generate-component-docs` to also automatically generate VRL function
   documentation and have CI fail if there are any unexpected changes to VRL generated documentation,
   making it so no PRs go in without properly updating the function documentation.

## Future work

- Make it so Vector-specific functions also have their examples tested with the same rigor as VRL
  examples. Vector-only functions usually require a running Vector instance, so testing their
  examples will require a new test harness.

## References

- [VRL Issue #280: Function documentation auto-generation](https://github.com/vectordotdev/vrl/issues/280)
- [Vector VRL Functions](https://github.com/vectordotdev/vector/tree/master/lib/vector-vrl/functions)
- [Vector Website CUE Documentation](https://github.com/vectordotdev/vector/tree/master/website/cue/reference/remap/functions)
- [VRL Repository](https://github.com/vectordotdev/vrl)
- [VRL stdlib](https://github.com/vectordotdev/vrl/tree/main/src/stdlib)

