### PR TITLE
fix(tests): Always print diagnostics on test failure

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -159,10 +159,8 @@ pub fn run_tests<T>(
                     process_result(result, &mut test, cfg, timings)
                 } else {
                     println!("{} (diagnostics)", Colour::Red.bold().paint("FAILED"));
-                    if cfg.verbose {
-                        let formatter = Formatter::new(&test.source, warnings);
-                        println!("{formatter}");
-                    }
+                    let formatter = Formatter::new(&test.source, warnings);
+                    println!("{formatter}");
                     // mark as failure, did not expect any warnings
                     true
                 }
@@ -331,10 +329,15 @@ fn process_compilation_diagnostics(
             println!("{diff}");
         }
 
+        // Always print diagnostics when test fails
+        formatter.enable_colors(true);
+        println!("{formatter:#}");
+
         failed = true;
     }
 
-    if cfg.verbose {
+    if cfg.verbose && !failed {
+        // In verbose mode, print diagnostics even for passing tests
         formatter.enable_colors(true);
         println!("{formatter:#}");
     }


### PR DESCRIPTION
## Summary

When `./scripts/vrl_tests.sh` fails, diagnostics are now printed regardless of the verbose flag, making it easier to debug test failures without re-running with `--verbose`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Verified that the code compiles with `cargo check --package vrl-tests`.

Changed `basename!` to `basename` in tests and ran `./scripts/vrl_tests.sh`:

```
functions/basename
  Extract basename from file path.............................FAILED (compilation)
 "vrl"
 error[E100]: unhandled error
 ┌─ :1:1
 │
 1 │ basename("/usr/local/bin/vrl")
 │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 │ │
 │ expression can result in runtime error
 │ handle the error case to ensure runtime success
 │
 = see documentation about error handling at https://errors.vrl.dev/#handling
 = learn more about error code 100 at https://errors.vrl.dev/100
 = see language documentation at https://vrl.dev
 = try your code in the VRL REPL, learn more at https://vrl.dev/examples

error[E100]: unhandled error
  ┌─ :1:1
  │
1 │ basename("/usr/local/bin/vrl")
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  │ │
  │ expression can result in runtime error
  │ handle the error case to ensure runtime success
  │
  = see documentation about error handling at https://errors.vrl.dev/#handling
  = learn more about error code 100 at https://errors.vrl.dev/100
  = see language documentation at https://vrl.dev
  = try your code in the VRL REPL, learn more at https://vrl.dev/examples
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

N/A