### PR TITLE
fix(stdlib): correct format_int return type to bytes

### DIFF
--- a/changelog.d/1586.fix.md
+++ b/changelog.d/1586.fix.md
@@ -1,0 +1,3 @@
+Corrected the type definition for `format_int` function to return bytes instead of integer.
+
+authors: thomasqueirozb

--- a/src/stdlib/format_int.rs
+++ b/src/stdlib/format_int.rs
@@ -144,19 +144,19 @@ mod tests {
         decimal {
             args: func_args![value: 42],
             want: Ok(value!("42")),
-            tdef: TypeDef::integer().fallible(),
+            tdef: TypeDef::bytes().fallible(),
         }
 
         hexidecimal {
             args: func_args![value: 42, base: 16],
             want: Ok(value!("2a")),
-            tdef: TypeDef::integer().fallible(),
+            tdef: TypeDef::bytes().fallible(),
         }
 
         negative_hexidecimal {
             args: func_args![value: -42, base: 16],
             want: Ok(value!("-2a")),
-            tdef: TypeDef::integer().fallible(),
+            tdef: TypeDef::bytes().fallible(),
         }
     ];
 }

--- a/src/stdlib/format_int.rs
+++ b/src/stdlib/format_int.rs
@@ -100,7 +100,7 @@ impl FunctionExpression for FormatIntFn {
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::integer().fallible()
+        TypeDef::bytes().fallible()
     }
 }
 


### PR DESCRIPTION
## Summary

Corrects the type definition for format_int function to return bytes instead of integer.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing tests verify the correct behavior.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our guidelines.
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our CONTRIBUTING.md is a good starting place.
- [x] If this PR introduces changes to LICENSE-3rdparty.csv, please run `dd-rust-license-tool write` and commit the changes. More details here.
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

NA