### PR TITLE
chore: bump cargo-deny to 0.18.9

### DIFF
--- a/scripts/check_deny.sh
+++ b/scripts/check_deny.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if ! cargo install --list | grep -q "cargo-deny v0.18.3"; then
+if ! cargo install --list | grep -q "cargo-deny v0.18.9"; then
     echo "Install cargo-deny"
-    cargo install cargo-deny --version 0.18.3 --force --locked
+    cargo install cargo-deny --version 0.18.9 --force --locked
 fi
 
 echo "Check deny"


### PR DESCRIPTION
## Summary

Bumps cargo-deny version to resolve CVSS v4 issues with current deny version.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

NA

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

- Related: #1564