### PR TITLE
fix(dev): use dynamic year in examples

### DIFF
--- a/src/stdlib/parse_klog.rs
+++ b/src/stdlib/parse_klog.rs
@@ -71,6 +71,28 @@ static REGEX_KLOG: LazyLock<Regex> = LazyLock::new(|| {
     ").expect("failed compiling regex for klog")
 });
 
+static EXAMPLES: LazyLock<Vec<Example>> = LazyLock::new(|| {
+    let result = Box::leak(
+        format!(
+            indoc! { r#"{{
+                "file": "klog.go",
+                "id": 28133,
+                "level": "info",
+                "line": 70,
+                "message": "hello from klog",
+                "timestamp": "{year}-05-05T17:59:40.692994Z"
+            }}"#},
+            year = Utc::now().year()
+        )
+        .into_boxed_str(),
+    );
+    vec![example! {
+        title: "Parse using klog",
+        source: r#"parse_klog!("I0505 17:59:40.692994   28133 klog.go:70] hello from klog")"#,
+        result: Ok(result),
+    }]
+});
+
 #[derive(Clone, Copy, Debug)]
 pub struct ParseKlog;
 
@@ -80,18 +102,7 @@ impl Function for ParseKlog {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[example! {
-            title: "Parse using klog",
-            source: r#"parse_klog!("I0505 17:59:40.692994   28133 klog.go:70] hello from klog")"#,
-            result: Ok(indoc! { r#"{
-                    "file": "klog.go",
-                    "id": 28133,
-                    "level": "info",
-                    "line": 70,
-                    "message": "hello from klog",
-                    "timestamp": "2025-05-05T17:59:40.692994Z"
-                }"#}),
-        }]
+        EXAMPLES.as_slice()
     }
 
     fn compile(

--- a/src/stdlib/parse_linux_authorization.rs
+++ b/src/stdlib/parse_linux_authorization.rs
@@ -1,5 +1,32 @@
 use super::parse_syslog::ParseSyslogFn;
 use crate::compiler::prelude::*;
+use chrono::{Datelike, Utc};
+use std::sync::LazyLock;
+
+static EXAMPLES: LazyLock<Vec<Example>> = LazyLock::new(|| {
+    let result = Box::leak(
+        format!(
+            indoc! {r#"{{
+                "appname": "sshd",
+                "hostname": "localhost",
+                "message": "Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar",
+                "procid": 1111,
+                "timestamp": "{year}-03-23T01:49:58Z"
+            }}"#},
+            year = Utc::now().year()
+        )
+        .into_boxed_str(),
+    );
+    vec![example! {
+        title: "Parse Linux authorization event",
+        source: indoc! {"
+            parse_linux_authorization!(
+                s'Mar 23 01:49:58 localhost sshd[1111]: Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar'
+            )
+        "},
+        result: Ok(result),
+    }]
+});
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseLinuxAuthorization;
@@ -18,21 +45,7 @@ impl Function for ParseLinuxAuthorization {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[example! {
-            title: "Parse Linux authorization event",
-            source: indoc! {"
-                parse_linux_authorization!(
-                    s'Mar 23 01:49:58 localhost sshd[1111]: Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar'
-                )
-            "},
-            result: Ok(indoc! {r#"{
-                "appname": "sshd",
-                "hostname": "localhost",
-                "message": "Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar",
-                "procid": 1111,
-                "timestamp": "2025-03-23T01:49:58Z"
-            }"#}),
-        }]
+        EXAMPLES.as_slice()
     }
 
     fn compile(


### PR DESCRIPTION
## Summary

Fixed `parse_klog` and `parse_linux_authorization` examples to dynamically fetch the current year instead of using hardcoded values. This prevents test failures when the year changes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Ran `./scripts/vrl_tests.sh` - all 907 tests pass.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our guidelines.
- [x] No. A maintainer will apply the "no-changelog" label to this PR.
## References

- Related: https://github.com/vectordotdev/vrl/actions/runs/20639860982/job/59270021389?pr=1595
<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
