### PR TITLE
fix(dev): make convert_value_raw private again

### DIFF
--- a/src/protobuf/encode.rs
+++ b/src/protobuf/encode.rs
@@ -13,7 +13,7 @@ pub struct Options {
 /// Convert a single raw `Value` into a protobuf `Value`.
 ///
 /// Unlike `convert_value`, this ignores any field metadata such as cardinality.
-pub fn convert_value_raw(
+fn convert_value_raw(
     value: Value,
     kind: &Kind,
     options: &Options,


### PR DESCRIPTION
## Summary

This function was accidentally made public in #1605.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

NA

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## References

- Related: #1605