### PR TITLE
fix(stdlib): fix panic due to overflow in parse_duration

### DIFF
--- a/changelog.d/1618.fix.md
+++ b/changelog.d/1618.fix.md
@@ -1,0 +1,4 @@
+Fixed a bug where `parse_duration` panicked when large values overflowed during multiplication.
+The function now returns an error instead.
+
+authors: thomasqueirozb

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,21 @@
 cognitive-complexity-threshold = 75
 
+# Disallow for non-std types (for now)
+arithmetic-side-effects-allowed = [
+  "std::string::String",
+  "str",
+  "isize",
+  "i64",
+  "i32",
+  "i16",
+  "i8",
+  "usize",
+  "u64",
+  "u32",
+  "u16",
+  "u8",
+]
+
 # for `disallowed_method`:
 # https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_method
 disallowed-methods = [

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,6 @@
 cognitive-complexity-threshold = 75
 
+# https://github.com/vectordotdev/vrl/issues/1620
 # Disallow for non-std types (for now)
 arithmetic-side-effects-allowed = [
   "std::string::String",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 #![warn(clippy::all)]
+#![warn(clippy::arithmetic_side_effects)]
 
 #[cfg(feature = "compiler")]
 pub mod compiler;

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -26,7 +26,9 @@ fn parse_bytes(bytes: &Value, unit: Value, base: &Bytes) -> Resolved {
         .parse_size(value)
         .map_err(|e| format!("unable to parse bytes: '{e}'"))?;
     let value = Decimal::from_u64(value).ok_or(format!("unable to parse number: {value}"))?;
-    let number = value / conversion_factor;
+    let number = value
+        .checked_div(*conversion_factor)
+        .expect("division by >1 divisor overflowed"); // This should never ever happen
     let number = number
         .to_f64()
         .ok_or(format!("unable to parse number: '{number}'"))?;

--- a/src/stdlib/parse_bytes.rs
+++ b/src/stdlib/parse_bytes.rs
@@ -28,7 +28,7 @@ fn parse_bytes(bytes: &Value, unit: Value, base: &Bytes) -> Resolved {
     let value = Decimal::from_u64(value).ok_or(format!("unable to parse number: {value}"))?;
     let number = value
         .checked_div(*conversion_factor)
-        .expect("division by >1 divisor overflowed"); // This should never ever happen
+        .ok_or("division by >1 divisor overflowed")?; // This should never ever happen
     let number = number
         .to_f64()
         .ok_or(format!("unable to parse number: '{number}'"))?;


### PR DESCRIPTION
## Summary

Enable clippy::arithmetic_side_effects lint to prevent unchecked arithmetic operations that can overflow or panic on rust_decimal::Decimal types and use checked_* in `parse_duration`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Verified clippy catches arithmetic operations on Decimal types and existing code uses checked_mul/checked_div methods. Also added tests

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [x] For new VRL functions, please also create a sibling PR in Vector to document the new function.

## References

Fixes #1615