### PR TITLE
feat: re-add unicode string escapes

### DIFF
--- a/changelog.d/0000.feature.md
+++ b/changelog.d/0000.feature.md
@@ -1,0 +1,1 @@
+Add support for `\u{...}` Unicode escape sequences in VRL string literals.

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -1276,6 +1276,61 @@ impl<'input> Lexer<'input> {
     fn escape_code(&mut self, start: usize) -> Result<(), Error> {
         match self.bump() {
             Some((_, '\n' | '\'' | '"' | '\\' | 'n' | 'r' | 't' | '{' | '}' | '0')) => Ok(()),
+            Some((_, 'u')) => {
+                let Some((_, '{')) = self.bump() else {
+                    return Err(Error::EscapeChar {
+                        start,
+                        ch: Some('u'),
+                    });
+                };
+
+                let mut digits = String::new();
+                loop {
+                    match self.peek() {
+                        Some((_, '}')) => {
+                            self.bump();
+                            break;
+                        }
+                        Some((pos, ch)) if ch.is_ascii_hexdigit() => {
+                            if digits.len() >= 6 {
+                                return Err(Error::EscapeChar {
+                                    start: pos,
+                                    ch: Some(ch),
+                                });
+                            }
+                            digits.push(ch);
+                            self.bump();
+                        }
+                        Some((pos, ch)) => {
+                            return Err(Error::EscapeChar {
+                                start: pos,
+                                ch: Some(ch),
+                            });
+                        }
+                        None => {
+                            return Err(Error::EscapeChar { start, ch: None });
+                        }
+                    }
+                }
+
+                if digits.is_empty() {
+                    return Err(Error::EscapeChar {
+                        start,
+                        ch: Some('u'),
+                    });
+                }
+
+                match u32::from_str_radix(&digits, 16)
+                    .ok()
+                    .and_then(char::from_u32)
+                {
+                    Some(_) => Ok(()),
+                    None => Err(Error::EscapeChar {
+                        start,
+                        ch: Some('u'),
+                    }),
+                }
+            }
             Some((start, ch)) => Err(Error::EscapeChar {
                 start,
                 ch: Some(ch),
@@ -1321,6 +1376,11 @@ pub(crate) fn is_operator(ch: char) -> bool {
 fn unescape_string_literal(mut s: &str) -> String {
     let mut string = String::with_capacity(s.len());
     while let Some(i) = s.bytes().position(|b| b == b'\\') {
+        if i + 1 >= s.len() {
+            string.push_str(s);
+            return string;
+        }
+
         let next = s.as_bytes()[i + 1];
         if next == b'\n' {
             // Remove the \n and any ensuing spaces or tabs
@@ -1332,23 +1392,63 @@ fn unescape_string_literal(mut s: &str) -> String {
                 .map(char::len_utf8)
                 .sum();
             s = &s[i + whitespace + 2..];
-        } else {
-            let c = match next {
-                b'\'' => '\'',
-                b'"' => '"',
-                b'\\' => '\\',
-                b'n' => '\n',
-                b'r' => '\r',
-                b't' => '\t',
-                b'0' => '\0',
-                b'{' => '{',
-                _ => unimplemented!("invalid escape"),
-            };
-
-            string.push_str(&s[..i]);
-            string.push(c);
-            s = &s[i + 2..];
+            continue;
         }
+
+        if next == b'u' && s.as_bytes().get(i + 2) == Some(&b'{') {
+            let mut end = i + 3;
+            let mut digit_count = 0;
+            let mut valid = true;
+
+            while end < s.len() {
+                let b = s.as_bytes()[end];
+                if b == b'}' {
+                    break;
+                }
+                if !(b as char).is_ascii_hexdigit() {
+                    valid = false;
+                    break;
+                }
+                digit_count += 1;
+                if digit_count > 6 {
+                    valid = false;
+                    break;
+                }
+                end += 1;
+            }
+
+            if valid && digit_count > 0 && end < s.len() && s.as_bytes()[end] == b'}' {
+                if let Ok(value) = u32::from_str_radix(&s[i + 3..end], 16) {
+                    if let Some(value) = char::from_u32(value) {
+                        string.push_str(&s[..i]);
+                        string.push(value);
+                        s = &s[end + 1..];
+                        continue;
+                    }
+                }
+            }
+        }
+
+        let (handled, c) = match next {
+            b'\'' => (true, '\''),
+            b'"' => (true, '"'),
+            b'\\' => (true, '\\'),
+            b'n' => (true, '\n'),
+            b'r' => (true, '\r'),
+            b't' => (true, '\t'),
+            b'0' => (true, '\0'),
+            b'{' => (true, '{'),
+            _ => (false, '\0'),
+        };
+
+        string.push_str(&s[..i]);
+        if handled {
+            string.push(c);
+        } else {
+            string.push('\\');
+            string.push(next as char);
+        }
+        s = &s[i + 2..];
     }
 
     string.push_str(s);
@@ -1530,6 +1630,21 @@ mod test {
             ],
         );
         assert_eq!(TemplateString(vec![StringSegment::Literal(r#""""#.to_string(), Span::new(1, 5))]), StringLiteralToken(r#"\"\""#).template(Span::new(0, 6)));
+    }
+
+    #[test]
+    fn string_literal_unicode_escape() {
+        use StringLiteralToken as S;
+        use StringLiteral as L;
+
+        test(
+            data(r#""\u{7FFF}""#),
+            vec![
+                ("~~~~~~~~~~", L(S("\\u{7FFF}"))),
+            ],
+        );
+
+        assert_eq!(StringLiteralToken(r#"\u{7FFF}"#).unescape(), "\u{7FFF}");
     }
 
     #[test]


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e44a66d5-a370-4596-80ce-d923eda2a27a","source":"chat","resourceId":"46141cfc-0391-4478-80cd-1293879a6b54","workflowId":"8693ff4f-e814-4415-a178-e371090e3ab6","codeChangeId":"8693ff4f-e814-4415-a178-e371090e3ab6","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://vector.datadoghq.com/code/46141cfc-0391-4478-80cd-1293879a6b54)

---

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Add support for `\u{...}` Unicode escapes in VRL string literals, validate the escape sequences in the lexer, harden unescape handling to avoid panics, and add tests plus a changelog fragment.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

- Run tests

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->