### PR TITLE
chore(stdlib): use basename in examples when files don't exist

### DIFF
--- a/src/stdlib/encode_proto.rs
+++ b/src/stdlib/encode_proto.rs
@@ -135,7 +135,7 @@ impl FunctionExpression for EncodeProtoFn {
 mod tests {
     use super::*;
     use crate::value;
-    use std::fs;
+    use std::{env, fs};
 
     fn test_data_dir() -> PathBuf {
         PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests/data/protobuf")

--- a/src/stdlib/encode_proto.rs
+++ b/src/stdlib/encode_proto.rs
@@ -14,8 +14,13 @@ pub struct EncodeProto;
 // This needs to be static because parse_proto needs to read a file
 // and the file path needs to be a literal.
 static EXAMPLE_ENCODE_PROTO_EXPR: LazyLock<&str> = LazyLock::new(|| {
-    let path = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .join("../../tests/data/protobuf/test_protobuf/v1/test_protobuf.desc")
+    let desc_path = "tests/data/protobuf/test_protobuf/v1/test_protobuf.desc";
+
+    let path = env::var_os("CARGO_MANIFEST_DIR")
+        .map_or_else(
+            || PathBuf::from(desc_path),
+            |dir| PathBuf::from(dir).join("../..").join(desc_path),
+        )
         .display()
         .to_string();
 

--- a/src/stdlib/encode_proto.rs
+++ b/src/stdlib/encode_proto.rs
@@ -3,7 +3,6 @@ use crate::compiler::prelude::*;
 use crate::protobuf::descriptor::get_message_descriptor;
 use crate::protobuf::encode::encode_proto;
 use prost_reflect::MessageDescriptor;
-use std::env;
 use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;

--- a/src/stdlib/encode_proto.rs
+++ b/src/stdlib/encode_proto.rs
@@ -1,3 +1,4 @@
+use super::util::example_path_or_basename;
 use crate::compiler::prelude::*;
 use crate::protobuf::descriptor::get_message_descriptor;
 use crate::protobuf::encode::encode_proto;
@@ -14,15 +15,7 @@ pub struct EncodeProto;
 // This needs to be static because parse_proto needs to read a file
 // and the file path needs to be a literal.
 static EXAMPLE_ENCODE_PROTO_EXPR: LazyLock<&str> = LazyLock::new(|| {
-    let desc_path = "tests/data/protobuf/test_protobuf/v1/test_protobuf.desc";
-
-    let path = env::var_os("CARGO_MANIFEST_DIR")
-        .map_or_else(
-            || PathBuf::from(desc_path),
-            |dir| PathBuf::from(dir).join("../..").join(desc_path),
-        )
-        .display()
-        .to_string();
+    let path = example_path_or_basename("protobuf/test_protobuf/v1/test_protobuf.desc");
 
     Box::leak(
         format!(

--- a/src/stdlib/parse_proto.rs
+++ b/src/stdlib/parse_proto.rs
@@ -141,7 +141,7 @@ impl FunctionExpression for ParseProtoFn {
 mod tests {
     use super::*;
     use crate::value;
-    use std::fs;
+    use std::{env, fs};
 
     fn test_data_dir() -> PathBuf {
         PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests/data/protobuf")

--- a/src/stdlib/parse_proto.rs
+++ b/src/stdlib/parse_proto.rs
@@ -1,9 +1,9 @@
+use super::util::example_path_or_basename;
 use crate::compiler::prelude::*;
 use crate::protobuf::descriptor::get_message_descriptor;
 use crate::protobuf::parse::parse_proto;
 use crate::stdlib::json_utils::json_type_def::json_type_def;
 use prost_reflect::MessageDescriptor;
-use std::env;
 use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
@@ -15,10 +15,7 @@ pub struct ParseProto;
 // This needs to be static because parse_proto needs to read a file
 // and the file path needs to be a literal.
 static EXAMPLE_PARSE_PROTO_EXPR: LazyLock<&str> = LazyLock::new(|| {
-    let path = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .join("../../tests/data/protobuf/test_protobuf/v1/test_protobuf.desc")
-        .display()
-        .to_string();
+    let path = example_path_or_basename("protobuf/test_protobuf/v1/test_protobuf.desc");
 
     Box::leak(
         format!(

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "enable_system_functions")]
 use std::{env, path::PathBuf};
 
 use crate::compiler::{Context, Expression, Resolved, TypeState};
@@ -133,6 +134,7 @@ impl ConstOrExpr {
 /// Get actual path as a string if exists or basename if not.
 ///
 /// `input` path is relative to `tests/data/`.
+#[cfg(feature = "enable_system_functions")]
 pub(crate) fn example_path_or_basename(input: &'static str) -> String {
     let path = env::var_os("CARGO_MANIFEST_DIR")
         .map(|dir| PathBuf::from(dir).join("../../tests/data").join(input));

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -1,3 +1,5 @@
+use std::{env, path::PathBuf};
+
 use crate::compiler::{Context, Expression, Resolved, TypeState};
 use crate::value::{KeyString, ObjectMap, Value};
 
@@ -121,5 +123,30 @@ impl ConstOrExpr {
             Self::Const(value) => Ok(value.clone()),
             Self::Expr(expr) => expr.resolve(ctx),
         }
+    }
+}
+
+/// Only to be used in examples since this can return an incorrect path.
+/// Useful for displaying a nicer path in the docs, since the path is going to be incorrect when
+/// docs are generated from outside this repo.
+///
+/// Get actual path as a string if exists or basename if not.
+///
+/// `input` path is relative to `tests/data/`.
+pub(crate) fn example_path_or_basename(input: &'static str) -> String {
+    let path = env::var_os("CARGO_MANIFEST_DIR")
+        .map(|dir| PathBuf::from(dir).join("../../tests/data").join(input));
+
+    if let Some(path) = path
+        && path.exists()
+    {
+        path.display().to_string()
+    } else {
+        // Extract basename
+        PathBuf::from(input)
+            .file_name()
+            .unwrap_or_default()
+            .display()
+            .to_string()
     }
 }

--- a/src/stdlib/validate_json_schema.rs
+++ b/src/stdlib/validate_json_schema.rs
@@ -1,30 +1,13 @@
+use super::util::example_path_or_basename;
 use crate::compiler::prelude::*;
-use std::env;
 use std::path::PathBuf;
 use std::sync::LazyLock;
-
-/// Get actual path if exists or basename if not.
-/// Useful for displaying a nicer path in the docs (since it's going to be incorrect either way).
-fn path_or_basename(basename: &'static str) -> String {
-    let path = env::var_os("CARGO_MANIFEST_DIR").map(|dir| {
-        PathBuf::from(dir)
-            .join("../../tests/data/jsonschema/validate_json_schema/")
-            .join(basename)
-    });
-
-    if let Some(path) = path
-        && path.exists()
-    {
-        path.display().to_string()
-    } else {
-        basename.to_string()
-    }
-}
 
 // This needs to be static because validate_json_schema needs to read a file
 // and the file path needs to be a literal.
 static EXAMPLE_JSON_SCHEMA_VALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
-    let path = path_or_basename("schema_with_email_format.json");
+    let path =
+        example_path_or_basename("jsonschema/validate_json_schema/schema_with_email_format.json");
 
     Box::leak(
         format!(
@@ -35,7 +18,8 @@ static EXAMPLE_JSON_SCHEMA_VALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
 });
 
 static EXAMPLE_JSON_SCHEMA_INVALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
-    let path = path_or_basename("schema_with_email_format.json");
+    let path =
+        example_path_or_basename("jsonschema/validate_json_schema/schema_with_email_format.json");
 
     Box::leak(
         format!(
@@ -46,7 +30,8 @@ static EXAMPLE_JSON_SCHEMA_INVALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
 });
 
 static EXAMPLE_JSON_SCHEMA_CUSTOM_FORMAT_FALSE: LazyLock<&str> = LazyLock::new(|| {
-    let path = path_or_basename("schema_with_custom_format.json");
+    let path =
+        example_path_or_basename("jsonschema/validate_json_schema/schema_with_custom_format.json");
 
     Box::leak(
         format!(r#"validate_json_schema!(s'{{ "productUser": "a-custom-formatted-string" }}', "{path}", false)"#)
@@ -55,7 +40,8 @@ static EXAMPLE_JSON_SCHEMA_CUSTOM_FORMAT_FALSE: LazyLock<&str> = LazyLock::new(|
 });
 
 static EXAMPLE_JSON_SCHEMA_CUSTOM_FORMAT_TRUE: LazyLock<&str> = LazyLock::new(|| {
-    let path = path_or_basename("schema_with_custom_format.json");
+    let path =
+        example_path_or_basename("jsonschema/validate_json_schema/schema_with_custom_format.json");
 
     Box::leak(
         format!(r#"validate_json_schema!(s'{{ "productUser": "a-custom-formatted-string" }}', "{path}", true)"#)

--- a/src/stdlib/validate_json_schema.rs
+++ b/src/stdlib/validate_json_schema.rs
@@ -3,13 +3,28 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+/// Get actual path if exists or basename if not.
+/// Useful for displaying a nicer path in the docs (since it's going to be incorrect either way).
+fn path_or_basename(basename: &'static str) -> String {
+    let path = env::var_os("CARGO_MANIFEST_DIR").map(|dir| {
+        PathBuf::from(dir)
+            .join("../../tests/data/jsonschema/validate_json_schema/")
+            .join(basename)
+    });
+
+    if let Some(path) = path
+        && path.exists()
+    {
+        path.display().to_string()
+    } else {
+        basename.to_string()
+    }
+}
+
 // This needs to be static because validate_json_schema needs to read a file
 // and the file path needs to be a literal.
 static EXAMPLE_JSON_SCHEMA_VALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
-    let path = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .join("../../tests/data/jsonschema/validate_json_schema/schema_with_email_format.json")
-        .display()
-        .to_string();
+    let path = path_or_basename("schema_with_email_format.json");
 
     Box::leak(
         format!(
@@ -20,10 +35,7 @@ static EXAMPLE_JSON_SCHEMA_VALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
 });
 
 static EXAMPLE_JSON_SCHEMA_INVALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
-    let path = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .join("../../tests/data/jsonschema/validate_json_schema/schema_with_email_format.json")
-        .display()
-        .to_string();
+    let path = path_or_basename("schema_with_email_format.json");
 
     Box::leak(
         format!(
@@ -34,10 +46,7 @@ static EXAMPLE_JSON_SCHEMA_INVALID_EMAIL: LazyLock<&str> = LazyLock::new(|| {
 });
 
 static EXAMPLE_JSON_SCHEMA_CUSTOM_FORMAT_FALSE: LazyLock<&str> = LazyLock::new(|| {
-    let path = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .join("../../tests/data/jsonschema/validate_json_schema/schema_with_custom_format.json")
-        .display()
-        .to_string();
+    let path = path_or_basename("schema_with_custom_format.json");
 
     Box::leak(
         format!(r#"validate_json_schema!(s'{{ "productUser": "a-custom-formatted-string" }}', "{path}", false)"#)
@@ -46,10 +55,7 @@ static EXAMPLE_JSON_SCHEMA_CUSTOM_FORMAT_FALSE: LazyLock<&str> = LazyLock::new(|
 });
 
 static EXAMPLE_JSON_SCHEMA_CUSTOM_FORMAT_TRUE: LazyLock<&str> = LazyLock::new(|| {
-    let path = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .join("../../tests/data/jsonschema/validate_json_schema/schema_with_custom_format.json")
-        .display()
-        .to_string();
+    let path = path_or_basename("schema_with_custom_format.json");
 
     Box::leak(
         format!(r#"validate_json_schema!(s'{{ "productUser": "a-custom-formatted-string" }}', "{path}", true)"#)

--- a/src/stdlib/validate_json_schema.rs
+++ b/src/stdlib/validate_json_schema.rs
@@ -337,6 +337,7 @@ mod non_wasm {
 mod tests {
     use super::*;
     use crate::value;
+    use std::env;
 
     fn test_data_dir() -> PathBuf {
         PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests/data/jsonschema/")


### PR DESCRIPTION
## Summary

When `CARGO_MANIFEST_DIR` is not set or the resolved path doesn't exist (e.g. when rendering docs outside this repo), example expressions now fall back to just the basename rather than a non-existent absolute path.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing tests cover the normal `CARGO_MANIFEST_DIR` path.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run `dd-rust-license-tool write` and commit the changes.
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.