### PR TITLE
fix(dev): fix broken src/stdlib/http_request.rs tests

### DIFF
--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -429,9 +429,9 @@ mod tests {
     async fn test_basic_get_request() {
         let func: HttpRequestFn = HttpRequestFn {
             url: expr!("https://httpbin.org/get"),
-            method: expr!("get"),
-            headers: expr!({}),
-            body: expr!(""),
+            method: Some(expr!("get")),
+            headers: Some(expr!({})),
+            body: Some(expr!("")),
             client_or_proxies: ClientOrProxies::no_proxies(),
         };
 
@@ -451,9 +451,9 @@ mod tests {
     async fn test_malformed_url() {
         let func = HttpRequestFn {
             url: expr!("not-a-valid-url"),
-            method: expr!("get"),
-            headers: expr!({}),
-            body: expr!(""),
+            method: Some(expr!("get")),
+            headers: Some(expr!({})),
+            body: Some(expr!("")),
             client_or_proxies: ClientOrProxies::no_proxies(),
         };
 
@@ -467,9 +467,9 @@ mod tests {
     async fn test_invalid_header() {
         let func = HttpRequestFn {
             url: expr!("https://httpbin.org/get"),
-            method: expr!("get"),
-            headers: expr!({"Invalid Header With Spaces": "value"}),
-            body: expr!(""),
+            method: Some(expr!("get")),
+            headers: Some(expr!({"Invalid Header With Spaces": "value"})),
+            body: Some(expr!("")),
             client_or_proxies: ClientOrProxies::no_proxies(),
         };
 
@@ -483,9 +483,9 @@ mod tests {
     async fn test_invalid_proxy() {
         let func = HttpRequestFn {
             url: expr!("https://httpbin.org/get"),
-            method: expr!("get"),
-            headers: expr!({}),
-            body: expr!(""),
+            method: Some(expr!("get")),
+            headers: Some(expr!({})),
+            body: Some(expr!("")),
             client_or_proxies: ClientOrProxies::new_proxies_no_const_resolve(
                 None,
                 Some(expr!("not^a&valid*url")),


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Unblocks code coverage support. Running the following:
```
cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
```
gives:
```
error[E0308]: mismatched types
   --> src/compiler/value/convert.rs:20:9
    |
 20 |         $crate::compiler::value::VrlValueConvert::into_expression(value)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<Box<dyn Expression>>`, found `Box<dyn Expression>`
    |
   ::: src/stdlib/http_request.rs:432:21
    |
432 |             method: expr!("get"),
    |                     ------------ in this macro invocation
```

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

Actually ran the tests (they are featured gate and do not run by default).
## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).
- [ ] For new VRL functions, please also create a sibling PR in Vector to document the new function.

<!-- Examples for the above:
  PR adding new VRL function: https://github.com/vectordotdev/vrl/pull/993
  PR adding documentation: https://github.com/vectordotdev/vector/pull/21142
  
  We are working towards improving this workflow.
-->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
