### PR TITLE
docs: add network notice to reverse_dns and standardize notice

### DIFF
--- a/docs/generated/dns_lookup.json
+++ b/docs/generated/dns_lookup.json
@@ -46,7 +46,7 @@
     ]
   },
   "notices": [
-    "This function performs network calls and blocks on each request until a response is\nreceived. It is not recommended for frequent or performance-critical workflows."
+    "This function performs synchronous blocking operations and is not recommended for\nfrequent or performance-critical workflows due to potential network-related delays."
   ],
   "pure": true
 }

--- a/docs/generated/reverse_dns.json
+++ b/docs/generated/reverse_dns.json
@@ -25,5 +25,8 @@
       "return": "localhost"
     }
   ],
+  "notices": [
+    "This function performs synchronous blocking operations and is not recommended for\nfrequent or performance-critical workflows due to potential network-related delays."
+  ],
   "pure": true
 }

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -357,10 +357,7 @@ impl Function for DnsLookup {
     }
 
     fn notices(&self) -> &'static [&'static str] {
-        &[indoc! {"
-            This function performs network calls and blocks on each request until a response is
-            received. It is not recommended for frequent or performance-critical workflows.
-        "}]
+        &[super::util::NETWORK_CALL_NOTICE]
     }
 
     fn category(&self) -> &'static str {

--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -379,10 +379,7 @@ impl Function for HttpRequest {
     }
 
     fn notices(&self) -> &'static [&'static str] {
-        &[indoc! {"
-            This function performs synchronous blocking operations and is not recommended for
-            frequent or performance-critical workflows due to potential network-related delays.
-        "}]
+        &[super::util::NETWORK_CALL_NOTICE]
     }
 
     fn category(&self) -> &'static str {

--- a/src/stdlib/reverse_dns.rs
+++ b/src/stdlib/reverse_dns.rs
@@ -50,6 +50,10 @@ impl Function for ReverseDns {
         "Performs a reverse DNS lookup on the provided IP address to retrieve the associated hostname."
     }
 
+    fn notices(&self) -> &'static [&'static str] {
+        &[super::util::NETWORK_CALL_NOTICE]
+    }
+
     fn category(&self) -> &'static str {
         Category::System.as_ref()
     }

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -8,10 +8,8 @@ cfg_if::cfg_if! {
 use crate::compiler::{Context, Expression, Resolved, TypeState};
 use crate::value::{KeyString, ObjectMap, Value};
 
-use indoc::indoc;
-
 #[cfg(feature = "enable_network_functions")]
-pub(crate) const NETWORK_CALL_NOTICE: &str = indoc! {"
+pub(crate) const NETWORK_CALL_NOTICE: &str = indoc::indoc! {"
     This function performs synchronous blocking operations and is not recommended for
     frequent or performance-critical workflows due to potential network-related delays.
 "};

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -8,6 +8,13 @@ cfg_if::cfg_if! {
 use crate::compiler::{Context, Expression, Resolved, TypeState};
 use crate::value::{KeyString, ObjectMap, Value};
 
+use indoc::indoc;
+
+pub(crate) const NETWORK_CALL_NOTICE: &str = indoc! {"
+    This function performs synchronous blocking operations and is not recommended for
+    frequent or performance-critical workflows due to potential network-related delays.
+"};
+
 /// Rounds the given number to the given precision.
 /// Takes a function parameter so the exact rounding function (ceil, floor or round)
 /// can be specified.

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -10,6 +10,7 @@ use crate::value::{KeyString, ObjectMap, Value};
 
 use indoc::indoc;
 
+#[cfg(feature = "enable_network_functions")]
 pub(crate) const NETWORK_CALL_NOTICE: &str = indoc! {"
     This function performs synchronous blocking operations and is not recommended for
     frequent or performance-critical workflows due to potential network-related delays.


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
As title states

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
