### PR TITLE
fix(dev): anchor docs/ CODEOWNERS pattern to repo root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @vectordotdev/vector
-docs/ @vectordotdev/vector @vectordotdev/documentation
+/docs/ @vectordotdev/vector @vectordotdev/documentation

--- a/src/docs/cmd.rs
+++ b/src/docs/cmd.rs
@@ -1,5 +1,4 @@
 use crate::compiler::Function;
-// Hi
 use clap::Parser;
 use std::io;
 use std::path::PathBuf;

--- a/src/docs/cmd.rs
+++ b/src/docs/cmd.rs
@@ -1,4 +1,5 @@
 use crate::compiler::Function;
+// Hi
 use clap::Parser;
 use std::io;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

Prefix the `docs/` pattern with a leading slash so it matches only the top-level `docs/` directory instead of any `docs/` directory anywhere in the repo.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Verified CODEOWNERS pattern behaviour via GitHub docs on path matching rules.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA