### PR TITLE
chore(deps): Upgrade rand from 0.8 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "exitcode",
  "fancy-regex",
  "flate2",
+ "getrandom 0.3.4",
  "grok",
  "hex",
  "hmac",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,7 +2614,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2748,7 +2748,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2814,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3092,7 +3092,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3540,7 +3540,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4271,7 +4271,7 @@ dependencies = [
  "publicsuffix",
  "quickcheck",
  "quoted_printable",
- "rand 0.8.5",
+ "rand 0.9.4",
  "regex",
  "relative-path",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,7 @@ jsonschema = { version = "0.38.1", default-features = false }
 
 # Dependencies used for WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 uuid = { version = "1", features = ["v4", "v7", "js"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ quoted_printable = { version = "0.5", optional = true }
 psl = { version = "2", optional = true }
 psl-types = { version = "2", optional = true }
 publicsuffix = { version = "2", optional = true }
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9.3", optional = true }
 regex = { version = "1", default-features = false, optional = true, features = ["std", "perf", "unicode"] }
 relative-path = { version = "2.0.1", optional = true }
 roxmltree = { version = "0.21", optional = true }

--- a/src/stdlib/random_bytes.rs
+++ b/src/stdlib/random_bytes.rs
@@ -1,5 +1,5 @@
 use crate::compiler::prelude::*;
-use rand::{RngCore, thread_rng};
+use rand::RngCore;
 
 const MAX_LENGTH: i64 = 1024 * 64;
 const LENGTH_TOO_LARGE_ERR: &str = "Length is too large. Maximum is 64k";
@@ -9,7 +9,7 @@ fn random_bytes(length: Value) -> Resolved {
     let mut output = vec![0_u8; get_length(length)?];
 
     // ThreadRng is a cryptographically secure generator
-    thread_rng().fill_bytes(&mut output);
+    rand::rng().fill_bytes(&mut output);
 
     Ok(Value::Bytes(Bytes::from(output)))
 }

--- a/src/stdlib/random_float.rs
+++ b/src/stdlib/random_float.rs
@@ -1,5 +1,5 @@
 use crate::compiler::prelude::*;
-use rand::{Rng, thread_rng};
+use rand::Rng;
 use std::ops::Range;
 
 const INVALID_RANGE_ERR: &str = "max must be greater than min";
@@ -12,7 +12,7 @@ fn random_float(min: Value, max: Value) -> Resolved {
         return Err("max must be greater than min".into());
     }
 
-    let f: f64 = thread_rng().gen_range(min..max);
+    let f: f64 = rand::rng().random_range(min..max);
 
     Ok(Value::Float(NotNan::new(f).expect("always a number")))
 }

--- a/src/stdlib/random_int.rs
+++ b/src/stdlib/random_int.rs
@@ -1,5 +1,5 @@
 use crate::compiler::prelude::*;
-use rand::{Rng, thread_rng};
+use rand::Rng;
 use std::ops::Range;
 
 const INVALID_RANGE_ERR: &str = "max must be greater than min";
@@ -7,7 +7,7 @@ const INVALID_RANGE_ERR: &str = "max must be greater than min";
 fn random_int(min: Value, max: Value) -> Resolved {
     let range = get_range(min, max)?;
 
-    let i: i64 = thread_rng().gen_range(range);
+    let i: i64 = rand::rng().random_range(range);
 
     Ok(Value::Integer(i))
 }


### PR DESCRIPTION
## Summary

Upgrade the `rand` crate from 0.8 to 0.9.3, adapting to API changes (`thread_rng()` -> `rand::rng()`, `gen_range` -> `random_range`).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

`cargo check --features stdlib` and `cargo test --features stdlib random_` both pass.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA