### PR TITLE
chore(deps): Ignore rand unsoundness advisory RUSTSEC-2026-0097

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,5 @@ license-files = [
 
 [advisories]
 ignore = [
-  # `derivative` is unmaintained
-  "RUSTSEC-2024-0388",
+  { id = "RUSTSEC-2026-0097", reason = "Rand is unsound with a custom logger using rand::rng() - unpatched crate (https://github.com/NLnetLabs/domain/pull/628)" },
 ]


### PR DESCRIPTION
## Summary

Update `deny.toml` to ignore RUSTSEC-2026-0097 (rand unsoundness with custom logger) and remove the stale `derivative` unmaintained advisory entry.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

`cargo deny check` passes locally.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA