### PR TITLE
fix(compiler): avoid false unused-variable warning after shadowed reassignment

### DIFF
--- a/changelog.d/1743.fix.md
+++ b/changelog.d/1743.fix.md
@@ -1,0 +1,1 @@
+Fixed a false positive in the unused-variable diagnostic (`E900`) where a variable used before being reassigned (shadowed) was incorrectly flagged as unused at its original assignment.

--- a/src/compiler/unused_expression_checker.rs
+++ b/src/compiler/unused_expression_checker.rs
@@ -106,14 +106,12 @@ impl VisitorState {
             return;
         }
 
+        // Shadowing is not supported (see module docs). Only the first assignment
+        // of an identifier is tracked; subsequent re-assignments are ignored so
+        // a variable used before being shadowed is not incorrectly flagged as
+        // unused (https://github.com/vectordotdev/vrl/issues/1742).
         self.ident_to_state
             .entry(ident.clone())
-            .and_modify(|state| {
-                state.pending_usage = true;
-                if self.visiting_closure {
-                    state.used_in_closure = true;
-                }
-            })
             .or_insert(IdentState {
                 span: *span,
                 pending_usage: true,
@@ -691,6 +689,20 @@ mod test {
             x = {}
             x |= { "a" : 1}
             .
+        "#};
+        unused_test(source, &[]);
+    }
+
+    #[test]
+    fn reassignment_after_use_is_not_flagged() {
+        // Regression test for https://github.com/vectordotdev/vrl/issues/1742
+        // Previously, reassigning a variable after it was used would incorrectly
+        // report the original (used) variable as unused at its original span.
+        let source = indoc! {r#"
+            p, err = to_float(.message)
+            .p = p
+            .e = err
+            err = ""
         "#};
         unused_test(source, &[]);
     }

--- a/src/compiler/unused_expression_checker.rs
+++ b/src/compiler/unused_expression_checker.rs
@@ -106,9 +106,9 @@ impl VisitorState {
             return;
         }
 
-        // Shadowing is not supported (see module docs). Only the first assignment
-        // of an identifier is tracked; subsequent re-assignments are ignored so
-        // a variable used before being shadowed is not incorrectly flagged as
+        // Shadowing is not supported yet (https://github.com/vectordotdev/vrl/issues/1216).
+        // Only the first assignment of an identifier is tracked; subsequent re-assignments
+        // are ignored so a variable used before being shadowed is not incorrectly flagged as
         // unused (https://github.com/vectordotdev/vrl/issues/1742).
         self.ident_to_state
             .entry(ident.clone())
@@ -696,8 +696,6 @@ mod test {
     #[test]
     fn reassignment_after_use_is_not_flagged() {
         // Regression test for https://github.com/vectordotdev/vrl/issues/1742
-        // Previously, reassigning a variable after it was used would incorrectly
-        // report the original (used) variable as unused at its original span.
         let source = indoc! {r#"
             p, err = to_float(.message)
             .p = p


### PR DESCRIPTION
## Summary

Fixes a false positive in the E900 unused-variable diagnostic: when a variable is used and then later reassigned (shadowed), the checker incorrectly flags the *original* assignment as unused.

Example from #1742:
```vrl
p, err = to_float(.message)
.p = p
.e = err       # err is used here
err = ""       # later reassigned
```
The old behavior reports `unused variable \`err\`` pointing at line 1, even though `err` is clearly used on line 3.

### Approach & tradeoff

The module already documents that variable shadowing is unsupported (\"Unused variables will not be detected in this case\"). This PR aligns the code with that documented behavior: only the *first* assignment of an ident is tracked, subsequent re-assignments are ignored.

- Fixes the false positive in #1742.
- Proper shadow support would require per-scope state tracking (already noted as a TODO in the existing `unused_shadow_variable_not_detected` test).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- Added regression test `reassignment_after_use_is_not_flagged` using the exact snippet from the issue.
- Ran `cargo test --lib --package vrl -- compiler::` — all 122 tests pass.
- Ran the `vrl-tests` binary — 935 pass (no regressions).
- Ran `cargo fmt --check` and `./scripts/clippy.sh` — clean.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the \"no-changelog\" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run \`dd-rust-license-tool write\` and commit the changes. (N/A)

## References

- Closes: #1742