### PR TITLE
chore(ci): use dd-sts instead of DD_API_KEY

### DIFF
--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -1,0 +1,28 @@
+name: "Datadog Short-Lived Token"
+description: "Federate a short-lived Datadog token via dd-sts-action and export DD_API_KEY (and DD_APP_KEY when available) to the job environment."
+
+inputs:
+  policy:
+    required: false
+    default: public-vectordotdev-vrl
+    description: "dd-sts policy to federate against."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Federate Datadog token
+      id: dd-sts
+      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
+      with:
+        policy: ${{ inputs.policy }}
+
+    - name: Export Datadog credentials to environment
+      shell: bash
+      env:
+        DD_STS_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+        DD_STS_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
+      run: |
+        echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"
+        if [ -n "${DD_STS_APP_KEY}" ]; then
+          echo "DD_APP_KEY=${DD_STS_APP_KEY}" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,9 @@ env:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -35,9 +38,10 @@ jobs:
       - name: "Install datadog-ci"
         run: npm install -g @datadog/datadog-ci
 
+      - uses: ./.github/actions/dd-token
+
       - name: "Upload coverage to Datadog"
         env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_SITE: datadoghq.com
           DD_ENV: ci
         run: datadog-ci coverage upload lcov.info

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,14 +13,21 @@ permissions:
 jobs:
   static-analysis:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - id: dd-token
+        uses: ./.github/actions/dd-token
+        with:
+          policy: public-vectordotdev-vrl-static-analysis
+
       - name: Datadog Static Analyzer
-        if: ${{ secrets.DD_API_KEY != '' }}
         uses: DataDog/datadog-static-analyzer-github-action@8340f18875fcefca86844b5f947ce2431387e552 # v3.0.0
         with:
-          dd_api_key: ${{ secrets.DD_API_KEY }}
-          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_api_key: ${{ env.DD_API_KEY }}
+          dd_app_key: ${{ env.DD_APP_KEY }}
           dd_site: datadoghq.com
           secrets_enabled: true


### PR DESCRIPTION
## Summary

Replace the `DD_API_KEY` secret with `dd-octo-sts` short-lived tokens in the CI workflows that talk to Datadog.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Verified workflow syntax locally; runtime validation will happen via CI.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA