### PR TITLE
fix(parser): allow `else` on a newline after the closing brace

### DIFF
--- a/changelog.d/1756.fix.md
+++ b/changelog.d/1756.fix.md
@@ -1,0 +1,3 @@
+Allowed the `else` keyword (and `else if`) to appear on a new line after the closing `}` of an `if`-block. Previously the trailing newline terminated the if-expression at the parser level, forcing `else` to share a line with `}`.
+
+authors: prontidis

--- a/lib/tests/tests/expressions/if_statement/else_on_newline.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_on_newline.vrl
@@ -1,0 +1,40 @@
+# result: ["a", "b", "c", "d", "e", "f", "k8s-plain"]
+
+# `else` on a new line directly after the closing brace.
+v1 = if true { "a" }
+else { "z" }
+
+# `else` on the next line for the false branch.
+v2 = if false { "y" }
+else { "b" }
+
+# Blank line(s) between the closing brace and `else`.
+v3 = if true { "c" }
+
+
+else { "z" }
+
+# `else if` on a new line.
+v4 = if false { "y" }
+else if true { "d" }
+else { "z" }
+
+# Multiple `else if`s split across lines.
+v5 = if false { "y" }
+else if false { "y2" }
+else if true { "e" }
+else { "z" }
+
+# Comment between the closing brace and `else`.
+v6 = if true { "f" }
+# trailing comment on its own line
+else { "z" }
+
+# Original example from issue #129: a multi-line predicate together with
+# `else` on the next line.
+image = "k8s.gcr.io/kube-apiserver"
+v7 = if (starts_with(image, "k8s.gcr.io/kube-apiserver") ||
+         starts_with(image, "k8s.gcr.io/kube-scheduler")) {"k8s-plain"}
+     else {"unknown"}
+
+[v1, v2, v3, v4, v5, v6, v7]

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -769,6 +769,19 @@ impl<'input> Lexer<'input> {
     /// Used to allow `else` (and `else if`) on a line following the closing
     /// `}` of an `if`-block — without this, the trailing newline terminates
     /// the `if`-expression at the parser level. See issue #129.
+    ///
+    /// "The next significant token is `else`" means: after `"else"` the input
+    /// has either ended, or has a character that is not [`is_ident_continue`].
+    /// That is the same boundary [`Lexer::identifier_or_function_call`] uses
+    /// to terminate an identifier, so this check agrees with how the keyword
+    /// would otherwise be tokenized.
+    ///
+    /// This intentionally returns true for inputs the parser will later reject
+    /// (e.g. `else %x`, `else #comment` with no block). The lexer's job is
+    /// only to disambiguate the `else` keyword from an identifier — well-
+    /// formedness of the if-statement is the parser's problem, and the
+    /// downstream error is the same one that occurs without a preceding
+    /// newline.
     fn next_significant_is_else(&self) -> bool {
         let mut chars = self.chars.clone();
         loop {
@@ -1322,10 +1335,19 @@ impl<'input> Lexer<'input> {
 // generic helpers
 // -----------------------------------------------------------------------------
 
+/// Characters allowed at the start of an identifier.
 fn is_ident_start(ch: char) -> bool {
     matches!(ch, '@' | '_' | 'a'..='z' | 'A'..='Z')
 }
 
+/// Characters allowed inside an identifier after the first character.
+///
+/// This is the canonical "is the identifier still going" predicate — it's
+/// what [`Lexer::identifier_or_function_call`] uses (via `take_while`) to
+/// decide where an identifier ends. Any other lexer logic that needs to
+/// distinguish a keyword (e.g. `else`) from a longer identifier prefixed
+/// with that keyword (e.g. `elsewhere`) should use this same predicate so
+/// the boundary stays consistent with tokenization.
 fn is_ident_continue(ch: char) -> bool {
     match ch {
         '0'..='9' => true,

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -313,6 +313,7 @@ impl<'input> Lexer<'input> {
                     '"' => Some(self.string_literal(start)),
 
                     ';' => Some(Ok(self.token(start, SemiColon))),
+                    '\n' if self.next_significant_is_else() => continue,
                     '\n' => Some(Ok(self.token(start, Newline))),
                     '\\' => Some(Ok(self.token(start, Escape))),
 
@@ -760,6 +761,38 @@ impl<'input> Lexer<'input> {
 
     fn token(&mut self, start: usize, token: Token<&'input str>) -> Spanned<'input, usize> {
         (start, token, self.next_index())
+    }
+
+    /// Peek past whitespace, comments, and additional newlines to see whether
+    /// the next significant token is the `else` keyword.
+    ///
+    /// Used to allow `else` (and `else if`) on a line following the closing
+    /// `}` of an `if`-block — without this, the trailing newline terminates
+    /// the `if`-expression at the parser level. See issue #129.
+    fn next_significant_is_else(&self) -> bool {
+        let mut chars = self.chars.clone();
+        loop {
+            match chars.peek().copied() {
+                None => return false,
+                Some((_, ch)) if ch.is_whitespace() => {
+                    chars.next();
+                }
+                Some((_, '#')) => {
+                    chars.next();
+                    for (_, ch) in chars.by_ref() {
+                        if ch == '\n' {
+                            break;
+                        }
+                    }
+                }
+                Some((start, _)) => {
+                    let rest = &self.input[start..];
+                    return rest.strip_prefix("else").is_some_and(|after| {
+                        after.chars().next().is_none_or(|c| !is_ident_continue(c))
+                    });
+                }
+            }
+        }
     }
 
     fn query_end(&mut self, start: usize) -> Option<usize> {
@@ -2251,6 +2284,93 @@ mod test {
                 ("                  ~  ", Identifier("v")),
                 ("                    ~", RBrace),
             ],
+        );
+    }
+
+    fn token_kinds(input: &str) -> Vec<Tok<'_>> {
+        Lexer::new(input)
+            .map(|res| res.expect("lex error").1)
+            .collect()
+    }
+
+    #[test]
+    fn newline_before_else_is_elided() {
+        assert_eq!(
+            token_kinds("if x { 1 }\nelse { 2 }"),
+            vec![
+                If,
+                Identifier("x"),
+                LBrace,
+                IntegerLiteral(1),
+                RBrace,
+                Else,
+                LBrace,
+                IntegerLiteral(2),
+                RBrace,
+            ],
+        );
+    }
+
+    #[test]
+    fn blank_lines_before_else_are_elided() {
+        assert_eq!(
+            token_kinds("if x { 1 }\n\n\nelse { 2 }"),
+            vec![
+                If,
+                Identifier("x"),
+                LBrace,
+                IntegerLiteral(1),
+                RBrace,
+                Else,
+                LBrace,
+                IntegerLiteral(2),
+                RBrace,
+            ],
+        );
+    }
+
+    #[test]
+    fn comment_between_brace_and_else_is_handled() {
+        assert_eq!(
+            token_kinds("if x { 1 }\n# comment\nelse { 2 }"),
+            vec![
+                If,
+                Identifier("x"),
+                LBrace,
+                IntegerLiteral(1),
+                RBrace,
+                Else,
+                LBrace,
+                IntegerLiteral(2),
+                RBrace,
+            ],
+        );
+    }
+
+    #[test]
+    fn newline_kept_when_else_does_not_follow() {
+        // No `else` after the if-block; the newline must terminate the statement.
+        assert_eq!(
+            token_kinds("if x { 1 }\nfoo"),
+            vec![
+                If,
+                Identifier("x"),
+                LBrace,
+                IntegerLiteral(1),
+                RBrace,
+                Newline,
+                Identifier("foo"),
+            ],
+        );
+    }
+
+    #[test]
+    fn newline_kept_when_followed_by_else_prefixed_identifier() {
+        // `elsewhere` is an identifier, not the `else` keyword — newline stays.
+        let kinds = token_kinds("if x { 1 }\nelsewhere");
+        assert!(
+            kinds.contains(&Newline),
+            "expected a Newline token, got {kinds:?}",
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #129. VRL has long required `else` to share a line with the closing `}` of an `if`-block. That has been a recurring papercut for users — the issue points to multiple Discord reports, and the original example shows the natural way to format a long if-expression with a multi-line predicate:

```
if (starts_with(image, "k8s.gcr.io/kube-apiserver") ||
    starts_with(image, "k8s.gcr.io/kube-scheduler")) {"k8s-plain"}
else {"unknown"}
```

People reasonably expect this to work, and at least one reported that they assumed VRL didn't support `else if` at all because of the rejection. The restriction is a parsing artefact, not a language design choice — it has no upside for users.

This PR lifts the restriction. `else` and `else if` may now appear on the line after the closing `}`, with any number of blank lines or comments between them.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

Purely additive — every program that parsed before still parses, and the new programs all have the obvious meaning.

## How did you test this PR?

The full `vrl-tests` integration suite (936 tests) and `cargo test -p vrl --lib` (1832 tests) pass, so we have confidence existing behavior isn't broken. New coverage for the change itself:

- An integration test (`lib/tests/tests/expressions/if_statement/else_on_newline.vrl`) covering `else` on the next line, `else if` on the next line, multiple `else if` clauses split across lines, blank lines between `}` and `else`, comments between them, and the original multi-line predicate example from the issue.
- Five lexer unit tests asserting the newline is dropped when `else` follows (including across blank lines and comments) and preserved otherwise (e.g. when followed by an identifier like `elsewhere`).

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. (No dependency changes.)

## References

- Closes: https://github.com/vectordotdev/vrl/issues/129