### PR TITLE
chore(ci): pin npm tools with lockfile to prevent supply chain compromise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,22 @@ updates:
         patterns:
         - "prost"
         - "prost-*"
+  - package-ecosystem: "npm"
+    directory: "/scripts/npm-tools"
+    schedule:
+      interval: "monthly"
+      time: "04:00" # UTC
+    labels:
+      - "domain: deps"
+      - "no-changelog"
+    commit-message:
+      prefix: "chore(deps)"
+    # Disable version updates; security updates bypass this limit
+    open-pull-requests-limit: 0
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,8 +35,17 @@ jobs:
       - name: "Generate code coverage"
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
+      - name: Cache npm tools
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: scripts/npm-tools/node_modules
+          key: ${{ runner.os }}-npm-tools-${{ hashFiles('scripts/npm-tools/*') }}
+
       - name: "Install datadog-ci"
-        run: npm install -g @datadog/datadog-ci
+        run: npm ci --prefix scripts/npm-tools
+
+      - name: "Add npm tools to PATH"
+        run: echo "${{ github.workspace }}/scripts/npm-tools/node_modules/.bin" >> $GITHUB_PATH
 
       - uses: ./.github/actions/dd-token
 

--- a/scripts/npm-tools/.gitignore
+++ b/scripts/npm-tools/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/scripts/npm-tools/package-lock.json
+++ b/scripts/npm-tools/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "npm-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@datadog/datadog-ci": "5.13.0"
+      }
+    },
+    "node_modules/@datadog/datadog-ci": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-ci/-/datadog-ci-5.13.0.tgz",
+      "integrity": "sha512-QEooWT2OE6J//OV4gka3F8Ca8QkmVGEyKR8zpJVZ6EufJVsNSnBX2V2VE3tzkvndcKRe2/Q9ZCiL9GUiZ4wTLA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "datadog-ci": "dist/bundle.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/scripts/npm-tools/package.json
+++ b/scripts/npm-tools/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "description": "Pinned npm tools for CI. Run 'npm ci' to install with exact versions from package-lock.json.",
+  "dependencies": {
+    "@datadog/datadog-ci": "5.13.0"
+  }
+}


### PR DESCRIPTION
## Summary

Note that this is a preventative measure.

Replaces `npm install -g @datadog/datadog-ci` in the coverage workflow with a lockfile-based install from a committed `scripts/npm-tools/` directory. This ensures every install uses an exact, integrity-verified version rather than resolving against the live registry.

- `scripts/npm-tools/package.json` pins `@datadog/datadog-ci` at `5.13.0`
- `scripts/npm-tools/package-lock.json` (generated by npm) locks the tarball with a `sha512` integrity hash; `npm ci` enforces exact match and refuses to install anything not in the lockfile
- `node_modules` is cached in CI keyed off the lockfile hash
- Dependabot watches the directory for security advisories only (`open-pull-requests-limit: 0`)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Verified locally that `npm ci --prefix scripts/npm-tools` installs correctly and `datadog-ci --version` works after adding the bin directory to PATH.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA