### PR TITLE
fix(vrl): fix typo in enum variant

### DIFF
--- a/changelog.d/1770.fix.md
+++ b/changelog.d/1770.fix.md
@@ -1,0 +1,1 @@
+Fixed a typo in enum variant that made it impossible to compile a function like pascalcase("hello", original_case: "SCREAMING_SNAKE").

--- a/changelog.d/1770.fix.md
+++ b/changelog.d/1770.fix.md
@@ -1,1 +1,3 @@
-Fixed a typo in enum variant that made it impossible to compile a function like pascalcase("hello", original_case: "SCREAMING_SNAKE").
+Fixed a typo in enum variant that made it impossible to use `SCREAMING_SNAKE` in casing functions such as `pascalcase`, `camelcase` and others.
+
+`pascalcase("hello", original_case: "SCREAMING_SNAKE")` now compiles properly.

--- a/src/stdlib/casing/mod.rs
+++ b/src/stdlib/casing/mod.rs
@@ -84,7 +84,7 @@ pub(crate) fn into_case(s: &str) -> Result<Case, Box<dyn DiagnosticMessage>> {
     match s {
         "camelCase" => Ok(Case::Camel),
         "PascalCase" => Ok(Case::Pascal),
-        "SREAMING_SNAKE" => Ok(Case::Constant),
+        "SCREAMING_SNAKE" => Ok(Case::Constant),
         "snake_case" => Ok(Case::Snake),
         "kebab-case" => Ok(Case::Kebab),
         _ => Err(Box::new(ExpressionError::from(format!(


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

There was a typo that made it impossible to compile a function like `pascalcase("hello", original_case: "SCREAMING_SNAKE")`.

Is this a breaking change? If someone used a workaround (incorrectly spelling it like "SREAMING_SNAKE" so that it compiles), it will no longer compile for them.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

```
.out = pascalcase("hello", original_case: "SCREAMING_SNAKE")
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
