### PR TITLE
perf(parse_regex, parse_regex_all): pre-compute capture names

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2095,6 +2095,20 @@ bench_function! {
         }))
     }
 
+    // ~1 KB input with large unmatched body — only 3 short fields captured (~39 bytes),
+    // well below half the input length, so captures are copied out
+    large_input_small_captures {
+        args: func_args![
+            value: "5.86.210.12 - [19/06/2019:17:20:49 -0400] 200 {\"trace_id\":\"abc123def456789\",\"spans\":[{\"service\":\"auth-service\",\"operation\":\"validate_token\",\"duration_ms\":12,\"tags\":{\"env\":\"prod\",\"version\":\"2.14.1\",\"cluster\":\"us-east-1a\",\"host\":\"i-0abc123def\",\"error\":false,\"http.method\":\"POST\",\"http.url\":\"/api/v2/auth/validate\",\"http.status\":200,\"user.id\":\"usr_abc123def456\",\"org.id\":\"org_xyz789pqr\"}},{\"service\":\"db-service\",\"operation\":\"query_user\",\"duration_ms\":5,\"tags\":{\"db.type\":\"postgresql\",\"db.statement\":\"SELECT id, email, created_at FROM users WHERE id=$1 LIMIT 1\",\"db.rows\":1,\"db.host\":\"pg-primary.internal\"}}],\"baggage\":{\"region\":\"us-east-1\",\"env\":\"prod\",\"version\":\"2.14.1\"}}",
+            pattern: Regex::new(r#"^(?P<host>[\w\.]+) - \[(?P<timestamp>[^\]]+)\] (?P<status>\d+)"#).unwrap()
+        ],
+        want: Ok(value!({
+            "host": "5.86.210.12",
+            "timestamp": "19/06/2019:17:20:49 -0400",
+            "status": "200",
+        }))
+    }
+
     // ~1 KB input — captures are small but the source buffer is large
     large_input {
         args: func_args![

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2094,6 +2094,24 @@ bench_function! {
             "number": "first",
         }))
     }
+
+    // ~1 KB input — captures are small but the source buffer is large
+    large_input {
+        args: func_args![
+            value: "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical/infrastructure/platform/distributed/observability/tracing/spans/service-mesh/sidecar/proxy/configuration/reload/endpoint?trace_id=abc123def456ghijklmnopqrstuvwxyz0123456789&span_id=789xyzabcdefghijklmno&parent_span_id=000aaabbbccc&sampled=true&debug=false&feature_flags=flag_a%3Dtrue%2Cflag_b%3Dfalse%2Cflag_c%3Dtrue&baggage=region%3Dus-east-1%2Cenv%3Dprod%2Cversion%3D2.14.1%2Ccluster%3Dcluster-use1-prod-42%2Chost%3Di-0abc123def456789a HTTP/1.1\" 200 20574 \"-\" \"Mozilla/5.0 (compatible; Datadog Agent/7.x; +https://docs.datadoghq.com/agent/)\" 0.042 upstream_addr=10.0.1.55:8080 upstream_status=200 request_id=req-abc123def456",
+            pattern: Regex::new(r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[\w]+) (?P<path>\S+) HTTP/[\d\.]+" (?P<status>[\d]+) (?P<bytes_out>[\d]+)"#).unwrap()
+        ],
+        want: Ok(value!({
+            "host": "5.86.210.12",
+            "user": "zieme4647",
+            "bytes_in": "5667",
+            "timestamp": "19/06/2019:17:20:49 -0400",
+            "method": "GET",
+            "path": "/embrace/supply-chains/dynamic/vertical/infrastructure/platform/distributed/observability/tracing/spans/service-mesh/sidecar/proxy/configuration/reload/endpoint?trace_id=abc123def456ghijklmnopqrstuvwxyz0123456789&span_id=789xyzabcdefghijklmno&parent_span_id=000aaabbbccc&sampled=true&debug=false&feature_flags=flag_a%3Dtrue%2Cflag_b%3Dfalse%2Cflag_c%3Dtrue&baggage=region%3Dus-east-1%2Cenv%3Dprod%2Cversion%3D2.14.1%2Ccluster%3Dcluster-use1-prod-42%2Chost%3Di-0abc123def456789a",
+            "status": "200",
+            "bytes_out": "20574",
+        }))
+    }
 }
 
 bench_function! {

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -25,6 +25,20 @@ contains the whole match.",
     ]
 });
 
+fn parse_regex(
+    bytes: &bytes::Bytes,
+    pattern: &Regex,
+    capture_names: &[KeyString],
+    numeric_groups: bool,
+) -> Resolved {
+    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
+        let parsed = pattern.captures(s).map(|capture| {
+            util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
+        });
+        Ok(parsed.ok_or("could not find any pattern matches")?.into())
+    })
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct ParseRegex;
 
@@ -152,20 +166,6 @@ impl Function for ParseRegex {
             },
         ]
     }
-}
-
-fn parse_regex(
-    bytes: &bytes::Bytes,
-    pattern: &Regex,
-    capture_names: &[KeyString],
-    numeric_groups: bool,
-) -> Resolved {
-    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
-        let parsed = pattern.captures(s).map(|capture| {
-            util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
-        });
-        Ok(parsed.ok_or("could not find any pattern matches")?.into())
-    })
 }
 
 #[derive(Debug, Clone)]

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -161,9 +161,9 @@ fn parse_regex(
     numeric_groups: bool,
 ) -> Resolved {
     util::with_utf8_bytes(bytes, |s, utf8_bytes| {
-        let parsed = pattern
-            .captures(s)
-            .map(|capture| util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes));
+        let parsed = pattern.captures(s).map(|capture| {
+            util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
+        });
         Ok(parsed.ok_or("could not find any pattern matches")?.into())
     })
 }

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -160,17 +160,12 @@ fn parse_regex(
     capture_names: &[KeyString],
     numeric_groups: bool,
 ) -> Resolved {
-    let parsed = if let Ok(s) = std::str::from_utf8(bytes) {
-        pattern.captures(s).map(|capture| {
-            util::capture_regex_to_map(&capture, capture_names, numeric_groups, Some(bytes))
-        })
-    } else {
-        let s = String::from_utf8_lossy(bytes);
-        pattern.captures(s.as_ref()).map(|capture| {
-            util::capture_regex_to_map(&capture, capture_names, numeric_groups, None)
-        })
-    };
-    Ok(parsed.ok_or("could not find any pattern matches")?.into())
+    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
+        let parsed = pattern
+            .captures(s)
+            .map(|capture| util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes));
+        Ok(parsed.ok_or("could not find any pattern matches")?.into())
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -1,5 +1,5 @@
 use crate::compiler::prelude::*;
-use crate::value::KeyString;
+use crate::value::{KeyString, ObjectMap};
 use regex::Regex;
 
 use super::util;
@@ -29,21 +29,33 @@ fn parse_regex(
     value: &Value,
     pattern: &Regex,
     capture_info: &[(KeyString, usize)],
+    capture_info_by_key: &[(KeyString, usize)],
+    capture_template: &ObjectMap,
     numeric_groups: bool,
 ) -> Resolved {
     let s = value.try_bytes_utf8_lossy()?;
     let valid_utf8 = matches!(s, std::borrow::Cow::Borrowed(_));
+    let utf8_bytes = valid_utf8.then(|| {
+        if let Value::Bytes(b) = value {
+            b
+        } else {
+            unreachable!()
+        }
+    });
     let input_len = s.len();
     let parsed = pattern.captures(s.as_ref()).map(|capture| {
-        let bytes =
-            (valid_utf8 && util::should_zero_copy(input_len, &capture, capture_info)).then(|| {
-                if let Value::Bytes(b) = value {
-                    b.clone()
-                } else {
-                    unreachable!()
-                }
-            });
-        util::capture_regex_to_map(&capture, capture_info, numeric_groups, bytes.as_ref())
+        let bytes = utf8_bytes
+            .filter(|_| util::should_zero_copy(input_len, &capture, capture_info, numeric_groups));
+        if numeric_groups {
+            util::capture_regex_to_map(&capture, capture_info, true, bytes)
+        } else {
+            util::capture_regex_to_map_from_template(
+                &capture,
+                capture_info_by_key,
+                capture_template,
+                bytes,
+            )
+        }
     });
     Ok(parsed.ok_or("could not find any pattern matches")?.into())
 }
@@ -117,12 +129,20 @@ impl Function for ParseRegex {
             .enumerate()
             .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
             .collect();
+        let mut capture_info_by_key = capture_info.clone();
+        capture_info_by_key.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+        let capture_template = capture_info_by_key
+            .iter()
+            .map(|(name, _)| (name.clone(), Value::Null))
+            .collect();
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexFn {
             value,
             pattern,
             capture_info,
+            capture_info_by_key,
+            capture_template,
             numeric_groups,
         }
         .as_expr())
@@ -182,6 +202,8 @@ pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
     pattern: Regex,
     capture_info: Vec<(KeyString, usize)>,
+    capture_info_by_key: Vec<(KeyString, usize)>,
+    capture_template: ObjectMap,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -192,7 +214,14 @@ impl FunctionExpression for ParseRegexFn {
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
             .try_boolean()?;
-        parse_regex(&value, &self.pattern, &self.capture_info, numeric_groups)
+        parse_regex(
+            &value,
+            &self.pattern,
+            &self.capture_info,
+            &self.capture_info_by_key,
+            &self.capture_template,
+            numeric_groups,
+        )
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -26,17 +26,26 @@ contains the whole match.",
 });
 
 fn parse_regex(
-    bytes: &bytes::Bytes,
+    value: &Value,
     pattern: &Regex,
-    capture_names: &[KeyString],
+    capture_info: &[(KeyString, usize)],
     numeric_groups: bool,
 ) -> Resolved {
-    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
-        let parsed = pattern.captures(s).map(|capture| {
-            util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
-        });
-        Ok(parsed.ok_or("could not find any pattern matches")?.into())
-    })
+    let s = value.try_bytes_utf8_lossy()?;
+    let valid_utf8 = matches!(s, std::borrow::Cow::Borrowed(_));
+    let input_len = s.len();
+    let parsed = pattern.captures(s.as_ref()).map(|capture| {
+        let bytes =
+            (valid_utf8 && util::should_zero_copy(input_len, &capture, capture_info)).then(|| {
+                if let Value::Bytes(b) = value {
+                    b.clone()
+                } else {
+                    unreachable!()
+                }
+            });
+        util::capture_regex_to_map(&capture, capture_info, numeric_groups, bytes.as_ref())
+    });
+    Ok(parsed.ok_or("could not find any pattern matches")?.into())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,17 +112,17 @@ impl Function for ParseRegex {
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern", state)?;
-        let capture_names: Vec<KeyString> = pattern
+        let capture_info: Vec<(KeyString, usize)> = pattern
             .capture_names()
-            .flatten()
-            .map(KeyString::from)
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
             .collect();
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexFn {
             value,
             pattern,
-            capture_names,
+            capture_info,
             numeric_groups,
         }
         .as_expr())
@@ -172,7 +181,7 @@ impl Function for ParseRegex {
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
     pattern: Regex,
-    capture_names: Vec<KeyString>,
+    capture_info: Vec<(KeyString, usize)>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -183,12 +192,7 @@ impl FunctionExpression for ParseRegexFn {
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
             .try_boolean()?;
-        parse_regex(
-            &value.try_bytes()?,
-            &self.pattern,
-            &self.capture_names,
-            numeric_groups,
-        )
+        parse_regex(&value, &self.pattern, &self.capture_info, numeric_groups)
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -1,4 +1,5 @@
 use crate::compiler::prelude::*;
+use crate::value::KeyString;
 use regex::Regex;
 
 use super::util;
@@ -23,15 +24,6 @@ contains the whole match.",
         .default(&DEFAULT_NUMERIC_GROUPS),
     ]
 });
-
-fn parse_regex(value: &Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
-    let value = value.try_bytes_utf8_lossy()?;
-    let parsed = pattern
-        .captures(&value)
-        .map(|capture| util::capture_regex_to_map(pattern, &capture, numeric_groups))
-        .ok_or("could not find any pattern matches")?;
-    Ok(parsed.into())
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseRegex;
@@ -97,11 +89,17 @@ impl Function for ParseRegex {
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern", state)?;
+        let capture_names: Vec<KeyString> = pattern
+            .capture_names()
+            .flatten()
+            .map(KeyString::from)
+            .collect();
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexFn {
             value,
             pattern,
+            capture_names,
             numeric_groups,
         }
         .as_expr())
@@ -156,10 +154,30 @@ impl Function for ParseRegex {
     }
 }
 
+fn parse_regex(
+    bytes: &bytes::Bytes,
+    pattern: &Regex,
+    capture_names: &[KeyString],
+    numeric_groups: bool,
+) -> Resolved {
+    let parsed = if let Ok(s) = std::str::from_utf8(bytes) {
+        pattern.captures(s).map(|capture| {
+            util::capture_regex_to_map(&capture, capture_names, numeric_groups, Some(bytes))
+        })
+    } else {
+        let s = String::from_utf8_lossy(bytes);
+        pattern.captures(s.as_ref()).map(|capture| {
+            util::capture_regex_to_map(&capture, capture_names, numeric_groups, None)
+        })
+    };
+    Ok(parsed.ok_or("could not find any pattern matches")?.into())
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
     pattern: Regex,
+    capture_names: Vec<KeyString>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -168,10 +186,14 @@ impl FunctionExpression for ParseRegexFn {
         let value = self.value.resolve(ctx)?;
         let numeric_groups = self
             .numeric_groups
-            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let pattern = &self.pattern;
-
-        parse_regex(&value, numeric_groups.try_boolean()?, pattern)
+            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
+            .try_boolean()?;
+        parse_regex(
+            &value.try_bytes()?,
+            &self.pattern,
+            &self.capture_names,
+            numeric_groups,
+        )
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
-
 use crate::compiler::prelude::*;
+use crate::value::KeyString;
+use regex::Regex;
 
 use super::util;
 use std::sync::LazyLock;
@@ -16,15 +16,6 @@ contains the whole match.")
             .default(&DEFAULT_NUMERIC_GROUPS),
     ]
 });
-
-fn parse_regex_all(value: &Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
-    let value = value.try_bytes_utf8_lossy()?;
-    Ok(pattern
-        .captures_iter(&value)
-        .map(|capture| util::capture_regex_to_map(pattern, &capture, numeric_groups).into())
-        .collect::<Vec<Value>>()
-        .into())
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseRegexAll;
@@ -84,17 +75,26 @@ impl Function for ParseRegexAll {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
+        let capture_names = pattern.resolve_constant(state).and_then(|v| {
+            v.as_regex().map(|r| {
+                r.capture_names()
+                    .flatten()
+                    .map(KeyString::from)
+                    .collect::<Vec<_>>()
+            })
+        });
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexAllFn {
             value,
             pattern,
+            capture_names,
             numeric_groups,
         }
         .as_expr())
@@ -153,10 +153,37 @@ impl Function for ParseRegexAll {
     }
 }
 
+fn parse_regex_all(
+    bytes: &bytes::Bytes,
+    pattern: &Regex,
+    capture_names: &[KeyString],
+    numeric_groups: bool,
+) -> Resolved {
+    let result: Vec<Value> = if let Ok(s) = std::str::from_utf8(bytes) {
+        pattern
+            .captures_iter(s)
+            .map(|capture| {
+                util::capture_regex_to_map(&capture, capture_names, numeric_groups, Some(bytes))
+                    .into()
+            })
+            .collect()
+    } else {
+        let s = String::from_utf8_lossy(bytes);
+        pattern
+            .captures_iter(s.as_ref())
+            .map(|capture| {
+                util::capture_regex_to_map(&capture, capture_names, numeric_groups, None).into()
+            })
+            .collect()
+    };
+    Ok(result.into())
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
     pattern: Box<dyn Expression>,
+    capture_names: Option<Vec<KeyString>>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -165,15 +192,27 @@ impl FunctionExpression for ParseRegexAllFn {
         let value = self.value.resolve(ctx)?;
         let numeric_groups = self
             .numeric_groups
-            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
+            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
+            .try_boolean()?;
         let pattern = self
             .pattern
             .resolve(ctx)?
             .as_regex()
             .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
             .clone();
+        let bytes = value.try_bytes()?;
 
-        parse_regex_all(&value, numeric_groups.try_boolean()?, &pattern)
+        let capture_names: &[KeyString] = if let Some(names) = &self.capture_names {
+            names.as_slice()
+        } else {
+            &pattern
+                .capture_names()
+                .flatten()
+                .map(KeyString::from)
+                .collect::<Vec<_>>()
+        };
+
+        parse_regex_all(&bytes, &pattern, capture_names, numeric_groups)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
@@ -197,6 +236,7 @@ impl FunctionExpression for ParseRegexAllFn {
 #[allow(clippy::trivial_regex)]
 mod tests {
     use crate::{btreemap, value};
+    use regex::Regex;
 
     use super::*;
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -162,7 +162,10 @@ fn parse_regex_all(
     util::with_utf8_bytes(bytes, |s, utf8_bytes| {
         let result: Vec<Value> = pattern
             .captures_iter(s)
-            .map(|capture| util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes).into())
+            .map(|capture| {
+                util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
+                    .into()
+            })
             .collect();
         Ok(result.into())
     })

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -17,6 +17,24 @@ contains the whole match.")
     ]
 });
 
+fn parse_regex_all(
+    bytes: &bytes::Bytes,
+    pattern: &Regex,
+    capture_names: &[KeyString],
+    numeric_groups: bool,
+) -> Resolved {
+    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
+        let result: Vec<Value> = pattern
+            .captures_iter(s)
+            .map(|capture| {
+                util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
+                    .into()
+            })
+            .collect();
+        Ok(result.into())
+    })
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct ParseRegexAll;
 
@@ -151,24 +169,6 @@ impl Function for ParseRegexAll {
             },
         ]
     }
-}
-
-fn parse_regex_all(
-    bytes: &bytes::Bytes,
-    pattern: &Regex,
-    capture_names: &[KeyString],
-    numeric_groups: bool,
-) -> Resolved {
-    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
-        let result: Vec<Value> = pattern
-            .captures_iter(s)
-            .map(|capture| {
-                util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
-                    .into()
-            })
-            .collect();
-        Ok(result.into())
-    })
 }
 
 #[derive(Debug, Clone)]

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -159,24 +159,13 @@ fn parse_regex_all(
     capture_names: &[KeyString],
     numeric_groups: bool,
 ) -> Resolved {
-    let result: Vec<Value> = if let Ok(s) = std::str::from_utf8(bytes) {
-        pattern
+    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
+        let result: Vec<Value> = pattern
             .captures_iter(s)
-            .map(|capture| {
-                util::capture_regex_to_map(&capture, capture_names, numeric_groups, Some(bytes))
-                    .into()
-            })
-            .collect()
-    } else {
-        let s = String::from_utf8_lossy(bytes);
-        pattern
-            .captures_iter(s.as_ref())
-            .map(|capture| {
-                util::capture_regex_to_map(&capture, capture_names, numeric_groups, None).into()
-            })
-            .collect()
-    };
-    Ok(result.into())
+            .map(|capture| util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes).into())
+            .collect();
+        Ok(result.into())
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -26,9 +26,9 @@ fn parse_regex_all(
     let s = value.try_bytes_utf8_lossy()?;
     let input_len = s.len();
     let valid_utf8 = matches!(s, std::borrow::Cow::Borrowed(_));
-    let utf8_bytes: Option<bytes::Bytes> = valid_utf8.then(|| {
+    let utf8_bytes = valid_utf8.then(|| {
         if let Value::Bytes(b) = value {
-            b.clone()
+            b
         } else {
             unreachable!()
         }
@@ -36,9 +36,9 @@ fn parse_regex_all(
     let result: Vec<Value> = pattern
         .captures_iter(s.as_ref())
         .map(|capture| {
-            let bytes = utf8_bytes
-                .as_ref()
-                .filter(|_| util::should_zero_copy(input_len, &capture, capture_info));
+            let bytes = utf8_bytes.filter(|_| {
+                util::should_zero_copy(input_len, &capture, capture_info, numeric_groups)
+            });
             util::capture_regex_to_map(&capture, capture_info, numeric_groups, bytes).into()
         })
         .collect();
@@ -202,14 +202,16 @@ impl FunctionExpression for ParseRegexAllFn {
             .as_regex()
             .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
             .clone();
+        let dynamic_capture_info;
         let capture_info: &[(KeyString, usize)] = if let Some(info) = &self.capture_info {
             info.as_slice()
         } else {
-            &pattern
+            dynamic_capture_info = pattern
                 .capture_names()
                 .enumerate()
                 .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            dynamic_capture_info.as_slice()
         };
 
         parse_regex_all(&value, &pattern, capture_info, numeric_groups)

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -18,21 +18,31 @@ contains the whole match.")
 });
 
 fn parse_regex_all(
-    bytes: &bytes::Bytes,
+    value: &Value,
     pattern: &Regex,
-    capture_names: &[KeyString],
+    capture_info: &[(KeyString, usize)],
     numeric_groups: bool,
 ) -> Resolved {
-    util::with_utf8_bytes(bytes, |s, utf8_bytes| {
-        let result: Vec<Value> = pattern
-            .captures_iter(s)
-            .map(|capture| {
-                util::capture_regex_to_map(&capture, capture_names, numeric_groups, utf8_bytes)
-                    .into()
-            })
-            .collect();
-        Ok(result.into())
-    })
+    let s = value.try_bytes_utf8_lossy()?;
+    let input_len = s.len();
+    let valid_utf8 = matches!(s, std::borrow::Cow::Borrowed(_));
+    let utf8_bytes: Option<bytes::Bytes> = valid_utf8.then(|| {
+        if let Value::Bytes(b) = value {
+            b.clone()
+        } else {
+            unreachable!()
+        }
+    });
+    let result: Vec<Value> = pattern
+        .captures_iter(s.as_ref())
+        .map(|capture| {
+            let bytes = utf8_bytes
+                .as_ref()
+                .filter(|_| util::should_zero_copy(input_len, &capture, capture_info));
+            util::capture_regex_to_map(&capture, capture_info, numeric_groups, bytes).into()
+        })
+        .collect();
+    Ok(result.into())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -99,11 +109,11 @@ impl Function for ParseRegexAll {
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
-        let capture_names = pattern.resolve_constant(state).and_then(|v| {
+        let capture_info = pattern.resolve_constant(state).and_then(|v| {
             v.as_regex().map(|r| {
                 r.capture_names()
-                    .flatten()
-                    .map(KeyString::from)
+                    .enumerate()
+                    .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
                     .collect::<Vec<_>>()
             })
         });
@@ -112,7 +122,7 @@ impl Function for ParseRegexAll {
         Ok(ParseRegexAllFn {
             value,
             pattern,
-            capture_names,
+            capture_info,
             numeric_groups,
         }
         .as_expr())
@@ -175,7 +185,7 @@ impl Function for ParseRegexAll {
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
     pattern: Box<dyn Expression>,
-    capture_names: Option<Vec<KeyString>>,
+    capture_info: Option<Vec<(KeyString, usize)>>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -192,19 +202,17 @@ impl FunctionExpression for ParseRegexAllFn {
             .as_regex()
             .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
             .clone();
-        let bytes = value.try_bytes()?;
-
-        let capture_names: &[KeyString] = if let Some(names) = &self.capture_names {
-            names.as_slice()
+        let capture_info: &[(KeyString, usize)] = if let Some(info) = &self.capture_info {
+            info.as_slice()
         } else {
             &pattern
                 .capture_names()
-                .flatten()
-                .map(KeyString::from)
+                .enumerate()
+                .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
                 .collect::<Vec<_>>()
         };
 
-        parse_regex_all(&bytes, &pattern, capture_names, numeric_groups)
+        parse_regex_all(&value, &pattern, capture_info, numeric_groups)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -27,6 +27,26 @@ where
     fun(num * multiplier) / multiplier
 }
 
+/// Presents `bytes` as `(&str, &Bytes)` for regex matching and zero-copy slicing.
+///
+/// When `bytes` is valid UTF-8 both references point to the original buffer.
+/// Otherwise a lossy copy is allocated and both references point to that copy,
+/// keeping the regex byte offsets aligned with the buffer used for slicing.
+/// The closure receives `(s, utf8_bytes)` and its return value is forwarded.
+pub(crate) fn with_utf8_bytes<F, T>(bytes: &bytes::Bytes, f: F) -> T
+where
+    F: FnOnce(&str, &bytes::Bytes) -> T,
+{
+    let owned;
+    let (s, utf8_bytes): (&str, &bytes::Bytes) = if let Ok(s) = std::str::from_utf8(bytes) {
+        (s, bytes)
+    } else {
+        owned = bytes::Bytes::from(String::from_utf8_lossy(bytes).into_owned());
+        (std::str::from_utf8(&owned).expect("lossy string is valid UTF-8"), &owned)
+    };
+    f(s, utf8_bytes)
+}
+
 /// Fills an [`ObjectMap`] from a regex [`Captures`](regex::Captures).
 ///
 /// Named captures are inserted under their group name; numeric groups (when
@@ -37,22 +57,18 @@ where
 /// [`KeyString`]s for the regex (computed once at VRL compile time via
 /// `regex.capture_names().flatten().map(KeyString::from)`).
 ///
-/// When `original_bytes` is `Some`, each matched substring is produced as a
-/// zero-copy [`bytes::Bytes`] slice of the original input buffer rather than a
-/// heap copy.  Only pass `Some` when the input is valid UTF-8, so that the
-/// byte offsets returned by the regex are valid positions in the buffer.
+/// `bytes` must be the UTF-8 buffer the regex was run against (as produced by
+/// [`with_utf8_bytes`]).  Each matched substring is returned as a zero-copy
+/// [`bytes::Bytes`] slice of that buffer.
 pub(crate) fn capture_regex_to_map(
     capture: &regex::Captures,
     capture_names: &[KeyString],
     numeric_groups: bool,
-    original_bytes: Option<&bytes::Bytes>,
+    bytes: &bytes::Bytes,
 ) -> ObjectMap {
     let names = capture_names.iter().map(|name| {
         let value: Value = match capture.name(name.as_str()) {
-            Some(m) => match original_bytes {
-                Some(b) => b.slice(m.start()..m.end()).into(),
-                None => m.as_str().into(),
-            },
+            Some(m) => bytes.slice(m.start()..m.end()).into(),
             None => Value::Null,
         };
         (name.clone(), value)
@@ -60,11 +76,10 @@ pub(crate) fn capture_regex_to_map(
 
     if numeric_groups {
         let indexed = capture.iter().flatten().enumerate().map(|(idx, c)| {
-            let value: Value = match original_bytes {
-                Some(b) => b.slice(c.start()..c.end()).into(),
-                None => c.as_str().into(),
-            };
-            (KeyString::from(idx.to_string()), value)
+            (
+                KeyString::from(idx.to_string()),
+                bytes.slice(c.start()..c.end()).into(),
+            )
         });
         indexed.chain(names).collect()
     } else {

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -27,32 +27,45 @@ where
     fun(num * multiplier) / multiplier
 }
 
-/// Takes a set of captures that have resulted from matching a regular expression
-/// against some text and fills a `BTreeMap` with the result.
+/// Fills an [`ObjectMap`] from a regex [`Captures`](regex::Captures).
 ///
-/// All captures are inserted with a key as the numeric index of that capture
-/// "0" is the overall match.
-/// Any named captures are also added to the Map with the key as the name.
+/// Named captures are inserted under their group name; numeric groups (when
+/// `numeric_groups` is `true`) are inserted under their zero-based index, with
+/// `"0"` holding the full match.
 ///
+/// `capture_names` must be the pre-computed slice of named-group
+/// [`KeyString`]s for the regex (computed once at VRL compile time via
+/// `regex.capture_names().flatten().map(KeyString::from)`).
+///
+/// When `original_bytes` is `Some`, each matched substring is produced as a
+/// zero-copy [`bytes::Bytes`] slice of the original input buffer rather than a
+/// heap copy.  Only pass `Some` when the input is valid UTF-8, so that the
+/// byte offsets returned by the regex are valid positions in the buffer.
 pub(crate) fn capture_regex_to_map(
-    regex: &regex::Regex,
     capture: &regex::Captures,
+    capture_names: &[KeyString],
     numeric_groups: bool,
+    original_bytes: Option<&bytes::Bytes>,
 ) -> ObjectMap {
-    let names = regex.capture_names().flatten().map(|name| {
-        (
-            name.to_owned().into(),
-            capture.name(name).map(|s| s.as_str()).into(),
-        )
+    let names = capture_names.iter().map(|name| {
+        let value: Value = match capture.name(name.as_str()) {
+            Some(m) => match original_bytes {
+                Some(b) => b.slice(m.start()..m.end()).into(),
+                None => m.as_str().into(),
+            },
+            None => Value::Null,
+        };
+        (name.clone(), value)
     });
 
     if numeric_groups {
-        let indexed = capture
-            .iter()
-            .flatten()
-            .enumerate()
-            .map(|(idx, c)| (KeyString::from(idx.to_string()), c.as_str().into()));
-
+        let indexed = capture.iter().flatten().enumerate().map(|(idx, c)| {
+            let value: Value = match original_bytes {
+                Some(b) => b.slice(c.start()..c.end()).into(),
+                None => c.as_str().into(),
+            };
+            (KeyString::from(idx.to_string()), value)
+        });
         indexed.chain(names).collect()
     } else {
         names.collect()

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -42,15 +42,59 @@ pub(crate) fn should_zero_copy(
     input_len: usize,
     capture: &regex::Captures,
     capture_info: &[(KeyString, usize)],
+    numeric_groups: bool,
 ) -> bool {
-    input_len < 64 || {
-        let total: usize = capture_info
-            .iter()
-            .filter_map(|(_, i)| capture.get(*i))
-            .map(|m| m.end() - m.start())
-            .sum();
-        total * 2 >= input_len
+    if input_len < 64 {
+        return true;
     }
+
+    let emitted_capture_count = capture_info.len() + if numeric_groups { capture.len() } else { 0 };
+    if emitted_capture_count == 0 {
+        return false;
+    }
+
+    if !numeric_groups && capture_info.len() >= 4 {
+        if let (Some((_, first_idx)), Some((_, last_idx))) =
+            (capture_info.first(), capture_info.last())
+            && let (Some(first), Some(last)) = (capture.get(*first_idx), capture.get(*last_idx))
+            && last.end().saturating_sub(first.start()) * 2 >= input_len
+        {
+            return true;
+        }
+    }
+
+    if let Some(full_match) = capture.get(0) {
+        let full_match_len = full_match.end() - full_match.start();
+        if full_match_len
+            .saturating_mul(emitted_capture_count)
+            .saturating_mul(2)
+            < input_len
+        {
+            return false;
+        }
+    }
+
+    let mut total = 0usize;
+
+    if numeric_groups {
+        for m in capture.iter().flatten() {
+            total += m.end() - m.start();
+            if total * 2 >= input_len {
+                return true;
+            }
+        }
+    }
+
+    for (_, i) in capture_info.iter().rev() {
+        if let Some(m) = capture.get(*i) {
+            total += m.end() - m.start();
+            if total * 2 >= input_len {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Fills an [`ObjectMap`] from a regex [`Captures`](regex::Captures).
@@ -72,22 +116,78 @@ pub(crate) fn capture_regex_to_map(
     numeric_groups: bool,
     utf8_bytes: Option<&bytes::Bytes>,
 ) -> ObjectMap {
-    let names = capture_info.iter().map(|(name, idx)| {
-        let value: Value = match (capture.get(*idx), utf8_bytes) {
+    match utf8_bytes {
+        Some(utf8_bytes) => {
+            capture_regex_to_map_zero_copy(capture, capture_info, numeric_groups, utf8_bytes)
+        }
+        None => capture_regex_to_map_copy(capture, capture_info, numeric_groups),
+    }
+}
+
+pub(crate) fn capture_regex_to_map_from_template(
+    capture: &regex::Captures,
+    capture_info_by_key: &[(KeyString, usize)],
+    template: &ObjectMap,
+    utf8_bytes: Option<&bytes::Bytes>,
+) -> ObjectMap {
+    let mut map = template.clone();
+
+    for ((_, idx), value) in capture_info_by_key.iter().zip(map.values_mut()) {
+        *value = match (capture.get(*idx), utf8_bytes) {
             (Some(m), Some(b)) => b.slice(m.start()..m.end()).into(),
             (Some(m), None) => m.as_str().into(),
             (None, _) => Value::Null,
+        };
+    }
+
+    map
+}
+
+fn capture_regex_to_map_copy(
+    capture: &regex::Captures,
+    capture_info: &[(KeyString, usize)],
+    numeric_groups: bool,
+) -> ObjectMap {
+    let names = capture_info.iter().map(|(name, idx)| {
+        let value: Value = match capture.get(*idx) {
+            Some(m) => m.as_str().into(),
+            None => Value::Null,
+        };
+        (name.clone(), value)
+    });
+
+    if numeric_groups {
+        let indexed = capture
+            .iter()
+            .flatten()
+            .enumerate()
+            .map(|(idx, c)| (KeyString::from(idx.to_string()), c.as_str().into()));
+        indexed.chain(names).collect()
+    } else {
+        names.collect()
+    }
+}
+
+fn capture_regex_to_map_zero_copy(
+    capture: &regex::Captures,
+    capture_info: &[(KeyString, usize)],
+    numeric_groups: bool,
+    utf8_bytes: &bytes::Bytes,
+) -> ObjectMap {
+    let names = capture_info.iter().map(|(name, idx)| {
+        let value: Value = match capture.get(*idx) {
+            Some(m) => utf8_bytes.slice(m.start()..m.end()).into(),
+            None => Value::Null,
         };
         (name.clone(), value)
     });
 
     if numeric_groups {
         let indexed = capture.iter().flatten().enumerate().map(|(idx, c)| {
-            let value: Value = match utf8_bytes {
-                Some(b) => b.slice(c.start()..c.end()).into(),
-                None => c.as_str().into(),
-            };
-            (KeyString::from(idx.to_string()), value)
+            (
+                KeyString::from(idx.to_string()),
+                utf8_bytes.slice(c.start()..c.end()).into(),
+            )
         });
         indexed.chain(names).collect()
     } else {

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -27,27 +27,30 @@ where
     fun(num * multiplier) / multiplier
 }
 
-/// Presents `bytes` as `(&str, &Bytes)` for regex matching and zero-copy slicing.
+/// Returns `true` when zero-copy slicing is worthwhile for this capture set.
 ///
-/// When `bytes` is valid UTF-8 both references point to the original buffer.
-/// Otherwise a lossy copy is allocated and both references point to that copy,
-/// keeping the regex byte offsets aligned with the buffer used for slicing.
-/// The closure receives `(s, utf8_bytes)` and its return value is forwarded.
-pub(crate) fn with_utf8_bytes<F, T>(bytes: &bytes::Bytes, f: F) -> T
-where
-    F: FnOnce(&str, &bytes::Bytes) -> T,
-{
-    let owned;
-    let (s, utf8_bytes): (&str, &bytes::Bytes) = if let Ok(s) = std::str::from_utf8(bytes) {
-        (s, bytes)
-    } else {
-        owned = bytes::Bytes::from(String::from_utf8_lossy(bytes).into_owned());
-        (
-            std::str::from_utf8(&owned).expect("lossy string is valid UTF-8"),
-            &owned,
-        )
-    };
-    f(s, utf8_bytes)
+/// Zero-copy is used when:
+/// - The input is `< 64` bytes: the source buffer is small enough that
+///   retaining it is cheaper than the per-value [`bytes::Bytes`] overhead.
+/// - The total length of all named captures is at least half the input
+///   length: most of the retained buffer is actually used.
+///
+/// `capture_info` must contain pre-computed group indices so that
+/// [`regex::Captures::get`] (direct array access) is used instead of
+/// name-based hash lookups.
+pub(crate) fn should_zero_copy(
+    input_len: usize,
+    capture: &regex::Captures,
+    capture_info: &[(KeyString, usize)],
+) -> bool {
+    input_len < 64 || {
+        let total: usize = capture_info
+            .iter()
+            .filter_map(|(_, i)| capture.get(*i))
+            .map(|m| m.end() - m.start())
+            .sum();
+        total * 2 >= input_len
+    }
 }
 
 /// Fills an [`ObjectMap`] from a regex [`Captures`](regex::Captures).
@@ -56,51 +59,33 @@ where
 /// `numeric_groups` is `true`) are inserted under their zero-based index, with
 /// `"0"` holding the full match.
 ///
-/// `capture_names` must be the pre-computed slice of named-group
-/// [`KeyString`]s for the regex (computed once at VRL compile time via
-/// `regex.capture_names().flatten().map(KeyString::from)`).
+/// `capture_info` must be the pre-computed `(name, group_index)` slice
+/// (computed once at VRL compile time).  Group indices allow direct O(1)
+/// array access via [`regex::Captures::get`] instead of name-based hash
+/// lookups.
 ///
-/// `utf8_bytes` must be the UTF-8 buffer the regex was run against (as produced by
-/// [`with_utf8_bytes`]).  Each capture is returned as either a zero-copy
-/// [`bytes::Bytes`] slice of the source buffer or an owned copy, depending on
-/// whether retaining a reference to the full source buffer is worthwhile:
-///
-/// - Input `< 64` bytes: always zero-copy — the source is small enough that
-///   the overhead of a [`bytes::Bytes`] allocation would cost more.
-/// - Otherwise: zero-copy only when the sum of named capture lengths is at
-///   least half the input length.  Below that ratio, keeping the full source
-///   buffer alive retains too many dead bytes relative to what was extracted.
+/// When `utf8_bytes` is `Some`, each matched substring is returned as a
+/// zero-copy [`bytes::Bytes`] slice of that buffer; when `None` each is copied.
 pub(crate) fn capture_regex_to_map(
     capture: &regex::Captures,
-    capture_names: &[KeyString],
+    capture_info: &[(KeyString, usize)],
     numeric_groups: bool,
-    utf8_bytes: &bytes::Bytes,
+    utf8_bytes: Option<&bytes::Bytes>,
 ) -> ObjectMap {
-    let input_len = utf8_bytes.len();
-    let zero_copy = input_len < 64 || {
-        let total_captured: usize = capture_names
-            .iter()
-            .filter_map(|name| capture.name(name.as_str()))
-            .map(|m| m.end() - m.start())
-            .sum();
-        total_captured * 2 >= input_len
-    };
-
-    let names = capture_names.iter().map(|name| {
-        let value: Value = match capture.name(name.as_str()) {
-            Some(m) if zero_copy => utf8_bytes.slice(m.start()..m.end()).into(),
-            Some(m) => m.as_str().into(),
-            None => Value::Null,
+    let names = capture_info.iter().map(|(name, idx)| {
+        let value: Value = match (capture.get(*idx), utf8_bytes) {
+            (Some(m), Some(b)) => b.slice(m.start()..m.end()).into(),
+            (Some(m), None) => m.as_str().into(),
+            (None, _) => Value::Null,
         };
         (name.clone(), value)
     });
 
     if numeric_groups {
         let indexed = capture.iter().flatten().enumerate().map(|(idx, c)| {
-            let value: Value = if zero_copy {
-                utf8_bytes.slice(c.start()..c.end()).into()
-            } else {
-                c.as_str().into()
+            let value: Value = match utf8_bytes {
+                Some(b) => b.slice(c.start()..c.end()).into(),
+                None => c.as_str().into(),
             };
             (KeyString::from(idx.to_string()), value)
         });

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -61,17 +61,35 @@ where
 /// `regex.capture_names().flatten().map(KeyString::from)`).
 ///
 /// `utf8_bytes` must be the UTF-8 buffer the regex was run against (as produced by
-/// [`with_utf8_bytes`]).  Each matched substring is returned as a zero-copy
-/// [`bytes::Bytes`] slice of that buffer.
+/// [`with_utf8_bytes`]).  Each capture is returned as either a zero-copy
+/// [`bytes::Bytes`] slice of the source buffer or an owned copy, depending on
+/// whether retaining a reference to the full source buffer is worthwhile:
+///
+/// - Input `< 64` bytes: always zero-copy — the source is small enough that
+///   the overhead of a [`bytes::Bytes`] allocation would cost more.
+/// - Otherwise: zero-copy only when the sum of named capture lengths is at
+///   least half the input length.  Below that ratio, keeping the full source
+///   buffer alive retains too many dead bytes relative to what was extracted.
 pub(crate) fn capture_regex_to_map(
     capture: &regex::Captures,
     capture_names: &[KeyString],
     numeric_groups: bool,
     utf8_bytes: &bytes::Bytes,
 ) -> ObjectMap {
+    let input_len = utf8_bytes.len();
+    let zero_copy = input_len < 64 || {
+        let total_captured: usize = capture_names
+            .iter()
+            .filter_map(|name| capture.name(name.as_str()))
+            .map(|m| m.end() - m.start())
+            .sum();
+        total_captured * 2 >= input_len
+    };
+
     let names = capture_names.iter().map(|name| {
         let value: Value = match capture.name(name.as_str()) {
-            Some(m) => utf8_bytes.slice(m.start()..m.end()).into(),
+            Some(m) if zero_copy => utf8_bytes.slice(m.start()..m.end()).into(),
+            Some(m) => m.as_str().into(),
             None => Value::Null,
         };
         (name.clone(), value)
@@ -79,10 +97,12 @@ pub(crate) fn capture_regex_to_map(
 
     if numeric_groups {
         let indexed = capture.iter().flatten().enumerate().map(|(idx, c)| {
-            (
-                KeyString::from(idx.to_string()),
-                utf8_bytes.slice(c.start()..c.end()).into(),
-            )
+            let value: Value = if zero_copy {
+                utf8_bytes.slice(c.start()..c.end()).into()
+            } else {
+                c.as_str().into()
+            };
+            (KeyString::from(idx.to_string()), value)
         });
         indexed.chain(names).collect()
     } else {

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -57,18 +57,18 @@ where
 /// [`KeyString`]s for the regex (computed once at VRL compile time via
 /// `regex.capture_names().flatten().map(KeyString::from)`).
 ///
-/// `bytes` must be the UTF-8 buffer the regex was run against (as produced by
+/// `utf8_bytes` must be the UTF-8 buffer the regex was run against (as produced by
 /// [`with_utf8_bytes`]).  Each matched substring is returned as a zero-copy
 /// [`bytes::Bytes`] slice of that buffer.
 pub(crate) fn capture_regex_to_map(
     capture: &regex::Captures,
     capture_names: &[KeyString],
     numeric_groups: bool,
-    bytes: &bytes::Bytes,
+    utf8_bytes: &bytes::Bytes,
 ) -> ObjectMap {
     let names = capture_names.iter().map(|name| {
         let value: Value = match capture.name(name.as_str()) {
-            Some(m) => bytes.slice(m.start()..m.end()).into(),
+            Some(m) => utf8_bytes.slice(m.start()..m.end()).into(),
             None => Value::Null,
         };
         (name.clone(), value)
@@ -78,7 +78,7 @@ pub(crate) fn capture_regex_to_map(
         let indexed = capture.iter().flatten().enumerate().map(|(idx, c)| {
             (
                 KeyString::from(idx.to_string()),
-                bytes.slice(c.start()..c.end()).into(),
+                utf8_bytes.slice(c.start()..c.end()).into(),
             )
         });
         indexed.chain(names).collect()

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -42,7 +42,10 @@ where
         (s, bytes)
     } else {
         owned = bytes::Bytes::from(String::from_utf8_lossy(bytes).into_owned());
-        (std::str::from_utf8(&owned).expect("lossy string is valid UTF-8"), &owned)
+        (
+            std::str::from_utf8(&owned).expect("lossy string is valid UTF-8"),
+            &owned,
+        )
     };
     f(s, utf8_bytes)
 }


### PR DESCRIPTION
## Summary

`parse_regex` does two things per event that can be eliminated. First, it reconstructs the map keys by calling `regex.capture_names()` on every event and allocating a fresh `KeyString` for each. Since the regex is compiled once at VRL compile time when the pattern is static, the names are fixed and can be stored then instead. Second, each captured substring is heap-copied into an owned `Bytes`. The input value is already a refcounted `Bytes` buffer, so captures can be zero-copy slices of it. We now get an `Arc` increment rather than a `memcpy`.

### Benchmarks (`cargo bench -- parse_regex`)

| Benchmark | `origin/main` | this branch | delta |
|---|---|---|---|
| `parse_regex/matches` | 3.061 µs | 2.660 µs | **−13%** |
| `parse_regex/single_match` | 260.9 ns | 233.2 ns | **−11%** |
| `parse_regex_all/matches` | 27.76 µs | 28.51 µs | +3% (noise) |

`parse_regex_all` shows no regression — the benchmark only has two short matches, so per-event overhead savings are small relative to total time.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing unit tests for `parse_regex` and `parse_regex_all` pass unchanged.

`cargo bench --bench stdlib --features="default test" -- --baseline main parse_regex`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA