### PR TITLE
feat(stdlib): allow dynamic regex pattern in parse_regex

### DIFF
--- a/changelog.d/1774.feature.md
+++ b/changelog.d/1774.feature.md
@@ -1,0 +1,1 @@
+`parse_regex` now accepts dynamic regex patterns (variables and runtime expressions), consistent with `parse_regex_all`. When the pattern is a literal, return type information remains precise based on named capture groups.

--- a/docs/generated/parse_regex.json
+++ b/docs/generated/parse_regex.json
@@ -88,7 +88,8 @@
   ],
   "notices": [
     "VRL aims to provide purpose-specific [parsing functions](/docs/reference/vrl/functions/#parse-functions)\nfor common log formats. Before reaching for the `parse_regex` function, see if a VRL\n[`parse_*` function](/docs/reference/vrl/functions/#parse-functions) already exists\nfor your format. If not, we recommend\n[opening an issue](https://github.com/vectordotdev/vector/issues/new?labels=type%3A+new+feature)\nto request support for the desired format.",
-    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit."
+    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit.",
+    "When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),\nthe regex is compiled on every function call. For high-throughput pipelines, prefer\na regex literal so the pattern is compiled once at program compile time."
   ],
   "pure": true
 }

--- a/docs/generated/parse_regex_all.json
+++ b/docs/generated/parse_regex_all.json
@@ -111,7 +111,8 @@
   ],
   "notices": [
     "VRL aims to provide purpose-specific [parsing functions](/docs/reference/vrl/functions/#parse-functions)\nfor common log formats. Before reaching for the `parse_regex` function, see if a VRL\n[`parse_*` function](/docs/reference/vrl/functions/#parse-functions) already exists\nfor your format. If not, we recommend\n[opening an issue](https://github.com/vectordotdev/vector/issues/new?labels=type%3A+new+feature)\nto request support for the desired format.",
-    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit."
+    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit.",
+    "When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),\nthe regex is compiled on every function call. For high-throughput pipelines, prefer\na regex literal so the pattern is compiled once at program compile time."
   ],
   "pure": true
 }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -480,31 +480,6 @@ impl ArgumentList {
         Ok(required(self.optional_query(keyword)?))
     }
 
-    pub fn optional_regex(
-        &self,
-        keyword: &'static str,
-        state: &TypeState,
-    ) -> Result<Option<regex::Regex>, Error> {
-        self.optional_expr(keyword)
-            .map(|expr| match expr.resolve_constant(state) {
-                Some(Value::Regex(regex)) => Ok((*regex).clone()),
-                _ => Err(Error::UnexpectedExpression {
-                    keyword,
-                    expected: "regex",
-                    expr,
-                }),
-            })
-            .transpose()
-    }
-
-    pub fn required_regex(
-        &self,
-        keyword: &'static str,
-        state: &TypeState,
-    ) -> Result<regex::Regex, Error> {
-        Ok(required(self.optional_regex(keyword, state)?))
-    }
-
     pub fn optional_object(
         &self,
         keyword: &'static str,

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -173,14 +173,12 @@ impl FunctionExpression for ParseRegexFn {
         let numeric_groups = self
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let pattern = self
-            .pattern
-            .resolve(ctx)?
+        let resolved = self.pattern.resolve(ctx)?;
+        let pattern = resolved
             .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
-            .clone();
+            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
 
-        parse_regex(&value, numeric_groups.try_boolean()?, &pattern)
+        parse_regex(&value, numeric_groups.try_boolean()?, pattern)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -1,6 +1,5 @@
 use crate::compiler::prelude::*;
 use regex::Regex;
-
 use super::util;
 use std::sync::LazyLock;
 
@@ -91,12 +90,12 @@ impl Function for ParseRegex {
 
     fn compile(
         &self,
-        state: &state::TypeState,
+        _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required_regex("pattern", state)?;
+        let pattern = arguments.required("pattern");
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexFn {
@@ -159,7 +158,7 @@ impl Function for ParseRegex {
 #[derive(Debug, Clone)]
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
-    pattern: Regex,
+    pattern: Box<dyn Expression>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -169,13 +168,24 @@ impl FunctionExpression for ParseRegexFn {
         let numeric_groups = self
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let pattern = &self.pattern;
+        let pattern = self
+            .pattern
+            .resolve(ctx)?
+            .as_regex()
+            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
+            .clone();
 
-        parse_regex(&value, numeric_groups.try_boolean()?, pattern)
+        parse_regex(&value, numeric_groups.try_boolean()?, &pattern)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::object(util::regex_kind(&self.pattern)).fallible()
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        if let Some(value) = self.pattern.resolve_constant(state)
+            && let Some(regex) = value.as_regex()
+        {
+            return TypeDef::object(util::regex_kind(regex)).fallible();
+        }
+
+        TypeDef::object(Collection::from_unknown(Kind::bytes() | Kind::null())).fallible()
     }
 }
 

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -1,6 +1,6 @@
+use super::util;
 use crate::compiler::prelude::*;
 use regex::Regex;
-use super::util;
 use std::sync::LazyLock;
 
 static DEFAULT_NUMERIC_GROUPS: LazyLock<Value> = LazyLock::new(|| Value::Boolean(false));

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -81,6 +81,11 @@ impl Function for ParseRegex {
                 All values are returned as strings. We recommend manually coercing values to desired
                 types as you see fit.
             "},
+            indoc! {"
+                When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
+                the regex is compiled on every function call. For high-throughput pipelines, prefer
+                a regex literal so the pattern is compiled once at program compile time.
+            "},
         ]
     }
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -171,12 +171,14 @@ impl FunctionExpression for ParseRegexAllFn {
         let numeric_groups = self
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let resolved = self.pattern.resolve(ctx)?;
-        let pattern = resolved
+        let pattern = self
+            .pattern
+            .resolve(ctx)?
             .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
+            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
+            .clone();
 
-        parse_regex_all(&value, numeric_groups.try_boolean()?, pattern)
+        parse_regex_all(&value, numeric_groups.try_boolean()?, &pattern)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -75,6 +75,11 @@ impl Function for ParseRegexAll {
                 All values are returned as strings. We recommend manually coercing values to desired
                 types as you see fit.
             "},
+            indoc! {"
+                When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
+                the regex is compiled on every function call. For high-throughput pipelines, prefer
+                a regex literal so the pattern is compiled once at program compile time.
+            "},
         ]
     }
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -171,14 +171,12 @@ impl FunctionExpression for ParseRegexAllFn {
         let numeric_groups = self
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let pattern = self
-            .pattern
-            .resolve(ctx)?
+        let resolved = self.pattern.resolve(ctx)?;
+        let pattern = resolved
             .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
-            .clone();
+            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
 
-        parse_regex_all(&value, numeric_groups.try_boolean()?, &pattern)
+        parse_regex_all(&value, numeric_groups.try_boolean()?, pattern)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {


### PR DESCRIPTION
## Summary

`parse_regex` previously required the `pattern` argument to be a compile-time regex literal. This aligns it with `parse_regex_all`, which already resolves the pattern at runtime.

When the pattern is a literal, `type_def` still returns precise field types derived from named capture groups. When it's dynamic, it falls back to `Collection::from_unknown(Kind::bytes() | Kind::null())`.

Both functions now include a performance notice warning that dynamic patterns (variables, `to_regex` results) are recompiled on every call.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing unit tests pass. The `parse_regex` test suite covers literal patterns (which exercise the constant-resolution path) and the dynamic path is exercised by the same runtime machinery already tested in `parse_regex_all`.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Closes #187