### PR TITLE
perf(stdlib): avoid Regex clone on each parse_regex_all call

### DIFF
--- a/changelog.d/1775.enhancement.md
+++ b/changelog.d/1775.enhancement.md
@@ -1,0 +1,1 @@
+Improved performance of `parse_regex_all` by reusing the compiled regex across invocations.

--- a/changelog.d/1775.fix.md
+++ b/changelog.d/1775.fix.md
@@ -1,1 +1,0 @@
-Fixed a performance bug in `parse_regex_all` where `Regex::clone()` was called on every invocation, resetting the lazy DFA cache and forcing full state recomputation on each event.

--- a/changelog.d/1775.fix.md
+++ b/changelog.d/1775.fix.md
@@ -1,0 +1,1 @@
+Fixed a performance bug in `parse_regex_all` where `Regex::clone()` was called on every invocation, resetting the lazy DFA cache and forcing full state recomputation on each event.

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -166,14 +166,12 @@ impl FunctionExpression for ParseRegexAllFn {
         let numeric_groups = self
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let pattern = self
-            .pattern
-            .resolve(ctx)?
+        let resolved = self.pattern.resolve(ctx)?;
+        let pattern = resolved
             .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?
-            .clone();
+            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
 
-        parse_regex_all(&value, numeric_groups.try_boolean()?, &pattern)
+        parse_regex_all(&value, numeric_groups.try_boolean()?, pattern)
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {


### PR DESCRIPTION
## Summary

`parse_regex_all` was calling `Regex::clone()` on every invocation. In the `regex` crate, cloning a `Regex` creates a new instance with a fresh, empty lazy DFA cache pool, forcing full DFA state recomputation on every event. By binding the resolved `Value` to a local variable and borrowing `&Regex` from it instead, the same `Regex` object is reused across calls and its cache warms up normally.

Benchmarks show a ~96% reduction in execution time for the `matches` case.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Benchmarked with `cargo bench --bench stdlib --features="default test" -- "parse_regex_all"` against the `main` baseline.

```sh
$  cargo bench -q --bench stdlib --features="default test" -- --baseline main "parse_regex_all"
vrl_stdlib/functions/parse_regex_all/matches
                        time:   [1.0900 µs 1.0979 µs 1.1067 µs]
                        thrpt:  [903.60 Kelem/s 910.79 Kelem/s 917.44 Kelem/s]
                 change:
                        time:   [−96.163% −96.141% −96.117%] (p = 0.00 < 0.05)
                        thrpt:  [+2475.6% +2491.3% +2505.9%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Found during implementation of #1774 which exposed a performance regression in `parse_regex` when copying this pattern from `parse_regex_all`.