### PR TITLE
fix: correct author username from prontidis to pront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 
 - Fixed a bug where the REPL input validator was executing programs instead of only compiling them, causing functions with side effects (e.g. `http_request`) to run twice per submission.
 
-  authors: prontidis (https://github.com/vectordotdev/vrl/pull/1701)
+  authors: pront (https://github.com/vectordotdev/vrl/pull/1701)
 
 
 ## [0.31.0 (2026-03-05)]

--- a/changelog.d/1756.fix.md
+++ b/changelog.d/1756.fix.md
@@ -1,3 +1,3 @@
 Allowed the `else` keyword (and `else if`) to appear on a new line after the closing `}` of an `if`-block. Previously the trailing newline terminated the if-expression at the parser level, forcing `else` to share a line with `}`.
 
-authors: prontidis
+authors: pront


### PR DESCRIPTION
## Summary

Corrects a typo in two places where the author username was recorded as `prontidis` instead of the correct `pront`:
- `changelog.d/1756.fix.md`
- `CHANGELOG.md` (entry for v0.32.0)

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## How did you test this PR?

Grep confirmed no remaining occurrences of `prontidis` in the repo.

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.