### PR TITLE
chore(releasing): publish to crates.io after prep PR is merged

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -5,11 +5,8 @@ title: "VRL [version] release"
 labels: "domain: releasing"
 ---
 
-- [ ] Create release preparation PR
-  - [ ] Bump [Cargo.toml](https://github.com/vectordotdev/vrl/blob/main/Cargo.toml#L3) version and commit the change.
-  - [ ] Run `cargo check` to update `Cargo.lock`.
-  - [ ] Run the [./scripts/generate_release_changelog.sh](https://github.com/vectordotdev/vrl/blob/main/scripts/generate_release_changelog.sh) script
-    and commit the changes.
-- [ ] After the above PR is merged, run the [./scripts/publish.py](https://github.com/vectordotdev/vrl/blob/main/scripts/publish.py) script.
-  - [ ] Confirm that the new tag was created: https://github.com/vectordotdev/vrl/tags
-  - [ ] Confirm that the new VRL release was published: https://crates.io/crates/vrl
+- [ ] Run `cargo run -p release` (use `--dry-run` to preview, `--issue <url>` to link this issue)
+  - [ ] Review/edit `CHANGELOG.md` when prompted, then press Enter to push and create the prep PR
+  - [ ] Get the prep PR reviewed and merged (the script will poll and continue automatically)
+  - [ ] The script will publish to crates.io, tag, and push the tag
+- [ ] Confirm the new VRL release was published: https://crates.io/crates/vrl

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -8,5 +8,6 @@ labels: "domain: releasing"
 - [ ] Run `cargo run -p release` (use `--dry-run` to preview, `--issue <url>` to link this issue)
   - [ ] Review/edit `CHANGELOG.md` when prompted, then press Enter to push and create the prep PR
   - [ ] Get the prep PR reviewed and merged (the script will poll and continue automatically)
-  - [ ] The script will publish to crates.io, tag, and push the tag
+  - The script will publish to crates.io, tag, and push the tag
 - [ ] Confirm the new VRL release was published: https://crates.io/crates/vrl
+- [ ] Confirm that the new tag was created: https://github.com/vectordotdev/vrl/tags

--- a/release/README.md
+++ b/release/README.md
@@ -30,9 +30,10 @@ The release flow:
 3. Bumps version in `Cargo.toml`
 4. Generates changelog from `changelog.d/` fragments
 5. Pauses for you to review/edit `CHANGELOG.md`
-6. Publishes to crates.io
-7. Tags and pushes
-8. Creates a PR to merge the release into main
+6. Pushes the branch and creates a PR
+7. Waits for the PR to be merged to main
+8. Switches to main, tags the release commit
+9. Checks out the tag, publishes to crates.io, pushes the tag
 
 ### Check Changelog Fragments
 

--- a/release/src/main.rs
+++ b/release/src/main.rs
@@ -123,33 +123,18 @@ fn release(version_arg: Option<&str>, dry_run: bool, issue: Option<&str>) -> Res
         &root,
     )?;
 
-    println!("Publishing to crates.io...");
-    run("cargo", &["publish"], &root)?;
-    println!("Published vrl v{new_version} to crates.io.");
-
-    let tag = format!("v{new_version}");
-    run(
-        "git",
-        &["tag", "-a", &tag, "-m", &format!("Release {new_version}")],
-        &root,
-    )?;
-
     println!("Pushing...");
     run("git", &["push", "-u", "origin", &branch], &root)?;
-    run("git", &["push", "origin", &tag], &root)?;
 
     println!("Creating pull request...");
     let title = format!("chore(releasing): Prepare {new_version} release");
     let mut body = formatdoc! {"
-        Release {new_version}
-
-        Published to crates.io: https://crates.io/crates/vrl/{new_version}
-        Tag: `{tag}`"
+        Release {new_version}"
     };
     if let Some(link) = issue {
         body.push_str(&format!("\n\nRelated issue: {link}"));
     }
-    run(
+    let pr_url = run(
         "gh",
         &[
             "pr",
@@ -167,8 +152,46 @@ fn release(version_arg: Option<&str>, dry_run: bool, issue: Option<&str>) -> Res
         ],
         &root,
     )?;
+    let pr_url = pr_url.trim().to_string();
+    println!("PR: {pr_url}");
+
+    println!("Waiting for the PR to be merged to main...");
+    loop {
+        let state = run(
+            "gh",
+            &["pr", "view", &pr_url, "--json", "state", "--jq", ".state"],
+            &root,
+        )?;
+        if state.trim() == "MERGED" {
+            println!("PR merged.");
+            break;
+        }
+        println!("  state: {}. Checking again in 15s...", state.trim());
+        std::thread::sleep(std::time::Duration::from_secs(15));
+    }
+
+    println!("Switching to main...");
+    run("git", &["checkout", "main"], &root)?;
+    run("git", &["pull", "origin", "main"], &root)?;
+
+    let tag = format!("v{new_version}");
+    run(
+        "git",
+        &["tag", "-a", &tag, "-m", &format!("Release {new_version}")],
+        &root,
+    )?;
+
+    run("git", &["checkout", &tag], &root)?;
+
+    println!("Publishing to crates.io...");
+    run("cargo", &["publish"], &root)?;
+    println!("Published vrl v{new_version} to crates.io.");
+
+    run("git", &["push", "origin", &tag], &root)?;
 
     println!("\nRelease {new_version} complete!");
+    println!("Tag: {tag}");
+    println!("crates.io: https://crates.io/crates/vrl/{new_version}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

The release script was publishing to crates.io and tagging before creating the prep PR, meaning releases landed on a non-main branch. The script now creates the PR first, polls until it is merged, then tags on main, checks out the tag, publishes, and pushes the tag.

Also updates the release issue template to reference `cargo run -p release` instead of the removed manual scripts.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

NA - not able to test easily until next release

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA