### PR TITLE
perf(stdlib): Remove converting suffix to owned string in truncate method

### DIFF
--- a/changelog.d/1784.enhancement.md
+++ b/changelog.d/1784.enhancement.md
@@ -1,0 +1,3 @@
+Improved performance of `truncate` function if suffix parameter is provided.
+
+authors: JakubOnderka

--- a/src/stdlib/truncate.rs
+++ b/src/stdlib/truncate.rs
@@ -6,7 +6,7 @@ fn truncate(value: &Value, limit: Value, suffix: &Value) -> Resolved {
     // TODO consider removal options
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let limit = if limit < 0 { 0 } else { limit as usize };
-    let suffix = suffix.try_bytes_utf8_lossy()?.to_string();
+    let suffix = suffix.try_bytes_utf8_lossy()?;
     let pos = if let Some((pos, chr)) = value.char_indices().take(limit).last() {
         // char_indices gives us the starting position of the character at limit,
         // we want the end position.


### PR DESCRIPTION
## Summary

Just small performance improvement and code cleanup

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- `cargo test`
- `vrl_tests.sh`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).