### PR TITLE
perf(parse_regex, parse_regex_all): literal regex in parse_regex/parse_regex_all and fix performance regression

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -122,6 +122,7 @@ criterion_group!(
               parse_query_string,
               parse_regex,
               parse_regex_all,
+              parse_regex_concurrent,
               parse_ruby_hash,
               parse_syslog,
               parse_timestamp,
@@ -2170,6 +2171,76 @@ bench_function! {
                     "2": "peas"
                 }]))
     }
+}
+
+/// Measures `parse_regex` throughput under concurrent execution.
+///
+/// The single-threaded `bench_function!` harness is blind to `Pool::get_slow`
+/// because one thread calls `Pool::get()`, becomes the owner, and hits the
+/// lock-free fast path on every subsequent iteration with no contention.
+/// Runtimes like Vector clone the compiled expression once per worker thread,
+/// so Pool ownership and contention are determined by how the compiled
+/// expression clones, not by how it runs single-threaded.
+///
+/// This benchmark compiles once and clones N times (matching the per-worker
+/// clone pattern), then runs all clones concurrently.  `Regex::clone()`
+/// allocates a fresh `Pool` per clone, giving each thread its own owner slot.
+/// Any implementation that shares a single `Pool` across clones (e.g. by
+/// storing an `Arc<Regex>`) will show elevated `Pool::get_slow` overhead here.
+fn parse_regex_concurrent(c: &mut Criterion) {
+    use std::time::Instant;
+
+    const THREADS: usize = 8;
+    const INPUT: &str = "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \
+        \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574";
+    const PATTERN: &str =
+        r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#;
+
+    // Compile once, then clone per thread. `Expression` implements `DynClone`
+    // (via `clone_trait_object!`), so cloning calls through to
+    // `ParseRegexFn::clone()` which in turn calls `Regex::clone()`, giving
+    // each thread an independent Pool with its own owner slot.
+    let state = vrl::compiler::state::TypeState::default();
+    let args = func_args![
+        value: INPUT,
+        pattern: Regex::new(PATTERN).unwrap()
+    ];
+    let (expression, _) = vrl::__prep_bench_or_test!(
+        vrl::stdlib::ParseRegex,
+        &state,
+        args,
+        Ok::<vrl::value::Value, String>(vrl::value::Value::Null)
+    );
+    let expression = expression.unwrap();
+    let expressions: Vec<_> = (0..THREADS).map(|_| expression.clone()).collect();
+
+    let mut group = c.benchmark_group("vrl_stdlib/functions/parse_regex_concurrent");
+    group.throughput(criterion::Throughput::Elements(THREADS as u64));
+
+    group.bench_function(format!("{THREADS}_threads"), |b| {
+        b.iter_custom(|iters| {
+            let per_thread = (iters as usize).max(1);
+            let start = Instant::now();
+            std::thread::scope(|s| {
+                for expr in &expressions {
+                    s.spawn(move || {
+                        let mut runtime_state = vrl::compiler::state::RuntimeState::default();
+                        let mut target: vrl::value::Value =
+                            std::collections::BTreeMap::default().into();
+                        let tz = vrl::compiler::TimeZone::Named(chrono_tz::Tz::UTC);
+                        let mut ctx =
+                            vrl::compiler::Context::new(&mut target, &mut runtime_state, &tz);
+                        for _ in 0..per_thread {
+                            let _ = std::hint::black_box(expr.resolve(&mut ctx));
+                        }
+                    });
+                }
+            });
+            start.elapsed()
+        });
+    });
+
+    group.finish();
 }
 
 bench_function! {

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -103,16 +103,31 @@ impl Function for ParseRegex {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required("pattern");
-        let capture_info = pattern.resolve_constant(state).and_then(|v| {
-            v.as_regex().map(|r| {
-                r.capture_names()
+        let pattern_expr = arguments.required("pattern");
+        let numeric_groups = arguments.optional("numeric_groups");
+
+        // When the pattern is a literal regex, clone the `Regex` out and store it
+        // by value. `regex::Regex::clone()` allocates a fresh `Pool` per clone
+        // (only the compiled state is Arc-shared), so each clone of `ParseRegexFn`
+        // — and therefore each Tokio worker that holds one — gets its own Pool
+        // with its own owner-thread fast path. Holding the pattern as a
+        // `Box<dyn Expression>` instead would resolve to the same `Arc<Regex>`
+        // across all workers, collapsing them onto a single Pool and forcing all
+        // but one through `Pool::get_slow`.
+        let (pattern, capture_info) = match pattern_expr
+            .resolve_constant(state)
+            .and_then(|v| v.as_regex().cloned())
+        {
+            Some(regex) => {
+                let info = regex
+                    .capture_names()
                     .enumerate()
                     .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
-                    .collect::<Vec<_>>()
-            })
-        });
-        let numeric_groups = arguments.optional("numeric_groups");
+                    .collect::<Vec<_>>();
+                (PatternSource::Static(regex), Some(info))
+            }
+            None => (PatternSource::Dynamic(pattern_expr), None),
+        };
 
         Ok(ParseRegexFn {
             value,
@@ -173,9 +188,19 @@ impl Function for ParseRegex {
 }
 
 #[derive(Debug, Clone)]
+enum PatternSource {
+    /// Literal regex pattern, owned. `Regex::clone` allocates a fresh Pool per
+    /// clone — see comment in `ParseRegex::compile`.
+    Static(Regex),
+    /// Dynamic pattern resolved on every call. Shares one Pool across all
+    /// clones via the literal's `Arc<Regex>`.
+    Dynamic(Box<dyn Expression>),
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
-    pattern: Box<dyn Expression>,
+    pattern: PatternSource,
     capture_info: Option<Vec<(KeyString, usize)>>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
@@ -187,33 +212,34 @@ impl FunctionExpression for ParseRegexFn {
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
             .try_boolean()?;
-        let resolved = self.pattern.resolve(ctx)?;
-        let pattern = resolved
-            .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
 
-        let dynamic_capture_info;
-        let capture_info: &[(KeyString, usize)] = if let Some(info) = &self.capture_info {
-            info.as_slice()
-        } else {
-            dynamic_capture_info = pattern
-                .capture_names()
-                .enumerate()
-                .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
-                .collect::<Vec<_>>();
-            dynamic_capture_info.as_slice()
-        };
-        parse_regex(&value, pattern, capture_info, numeric_groups)
+        match &self.pattern {
+            PatternSource::Static(pattern) => {
+                let capture_info = self.capture_info.as_deref().unwrap_or(&[]);
+                parse_regex(&value, pattern, capture_info, numeric_groups)
+            }
+            PatternSource::Dynamic(expr) => {
+                let resolved = expr.resolve(ctx)?;
+                let pattern = resolved
+                    .as_regex()
+                    .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
+                let dynamic_capture_info: Vec<(KeyString, usize)> = pattern
+                    .capture_names()
+                    .enumerate()
+                    .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
+                    .collect();
+                parse_regex(&value, pattern, &dynamic_capture_info, numeric_groups)
+            }
+        }
     }
 
-    fn type_def(&self, state: &state::TypeState) -> TypeDef {
-        if let Some(value) = self.pattern.resolve_constant(state)
-            && let Some(regex) = value.as_regex()
-        {
-            return TypeDef::object(util::regex_kind(regex)).fallible();
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        match &self.pattern {
+            PatternSource::Static(regex) => TypeDef::object(util::regex_kind(regex)).fallible(),
+            PatternSource::Dynamic(_) => {
+                TypeDef::object(Collection::from_unknown(Kind::bytes() | Kind::null())).fallible()
+            }
         }
-
-        TypeDef::object(Collection::from_unknown(Kind::bytes() | Kind::null())).fallible()
     }
 }
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -104,16 +104,28 @@ impl Function for ParseRegexAll {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required("pattern");
-        let capture_info = pattern.resolve_constant(state).and_then(|v| {
-            v.as_regex().map(|r| {
-                r.capture_names()
+        let pattern_expr = arguments.required("pattern");
+        let numeric_groups = arguments.optional("numeric_groups");
+
+        // See `ParseRegex::compile` for why literal patterns are held by value:
+        // `Regex::clone` allocates a fresh `Pool` per clone, giving each Tokio
+        // worker its own owner-thread fast path. Holding the pattern as
+        // `Box<dyn Expression>` shares one Pool across all workers and forces
+        // all but one through `Pool::get_slow`.
+        let (pattern, capture_info) = match pattern_expr
+            .resolve_constant(state)
+            .and_then(|v| v.as_regex().cloned())
+        {
+            Some(regex) => {
+                let info = regex
+                    .capture_names()
                     .enumerate()
                     .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
-                    .collect::<Vec<_>>()
-            })
-        });
-        let numeric_groups = arguments.optional("numeric_groups");
+                    .collect::<Vec<_>>();
+                (PatternSource::Static(regex), Some(info))
+            }
+            None => (PatternSource::Dynamic(pattern_expr), None),
+        };
 
         Ok(ParseRegexAllFn {
             value,
@@ -178,9 +190,18 @@ impl Function for ParseRegexAll {
 }
 
 #[derive(Debug, Clone)]
+enum PatternSource {
+    /// Literal regex pattern, owned. `Regex::clone` allocates a fresh Pool per
+    /// clone — see comment in `ParseRegexAll::compile`.
+    Static(Regex),
+    /// Dynamic pattern resolved on every call.
+    Dynamic(Box<dyn Expression>),
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
-    pattern: Box<dyn Expression>,
+    pattern: PatternSource,
     capture_info: Option<Vec<(KeyString, usize)>>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
@@ -192,38 +213,38 @@ impl FunctionExpression for ParseRegexAllFn {
             .numeric_groups
             .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
             .try_boolean()?;
-        let resolved = self.pattern.resolve(ctx)?;
-        let pattern = resolved
-            .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
-        let dynamic_capture_info;
-        let capture_info: &[(KeyString, usize)] = if let Some(info) = &self.capture_info {
-            info.as_slice()
-        } else {
-            dynamic_capture_info = pattern
-                .capture_names()
-                .enumerate()
-                .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
-                .collect::<Vec<_>>();
-            dynamic_capture_info.as_slice()
-        };
-        parse_regex_all(&value, pattern, capture_info, numeric_groups)
+
+        match &self.pattern {
+            PatternSource::Static(pattern) => {
+                let capture_info = self.capture_info.as_deref().unwrap_or(&[]);
+                parse_regex_all(&value, pattern, capture_info, numeric_groups)
+            }
+            PatternSource::Dynamic(expr) => {
+                let resolved = expr.resolve(ctx)?;
+                let pattern = resolved
+                    .as_regex()
+                    .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
+                let dynamic_capture_info: Vec<(KeyString, usize)> = pattern
+                    .capture_names()
+                    .enumerate()
+                    .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
+                    .collect();
+                parse_regex_all(&value, pattern, &dynamic_capture_info, numeric_groups)
+            }
+        }
     }
 
-    fn type_def(&self, state: &state::TypeState) -> TypeDef {
-        if let Some(value) = self.pattern.resolve_constant(state)
-            && let Some(regex) = value.as_regex()
-        {
-            return TypeDef::array(Collection::from_unknown(
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        match &self.pattern {
+            PatternSource::Static(regex) => TypeDef::array(Collection::from_unknown(
                 Kind::object(util::regex_kind(regex)).or_null(),
             ))
-            .fallible();
+            .fallible(),
+            PatternSource::Dynamic(_) => TypeDef::array(Collection::from_unknown(
+                Kind::object(Collection::from_unknown(Kind::bytes() | Kind::null())).or_null(),
+            ))
+            .fallible(),
         }
-
-        TypeDef::array(Collection::from_unknown(
-            Kind::object(Collection::from_unknown(Kind::bytes() | Kind::null())).or_null(),
-        ))
-        .fallible()
     }
 }
 


### PR DESCRIPTION
## Summary

When the regex pattern is a compile-time literal, `parse_regex` and `parse_regex_all` now clone the `Regex` and hold it by value in a `PatternSource::Static` variant rather than keeping it as a `Box<dyn Expression>`. `regex::Regex::clone` allocates a fresh `Pool` per clone, so each Tokio worker that holds a copy of the function gets its own owner-thread fast path. Previously all workers shared a single `Arc<Regex>` (and therefore a single `Pool`), forcing all but one through `Pool::get_slow` under concurrent load.

Dynamic patterns (non-literal regex arguments) continue to resolve through the `PatternSource::Dynamic` path with no behavioral change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing test suite covers correctness. The performance improvement is mechanical: each clone of the compiled function now gets its own `Pool`.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA