### PR TITLE
chore(releasing): Prepare 0.33.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 
 <!-- changelog start -->
 
+## [0.33.1 (2026-06-02)]
+
+### Fixes
+
+- Reverted `parse_regex` changes from 0.33.0 which introduced a performance regression in multi-threaded scenarios.
+
+  (https://github.com/vectordotdev/vrl/pull/1789)
+
+
 ## [0.33.0 (2026-05-28)]
 
 ### New Features
@@ -11,9 +20,9 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 - VRL string literals now support `\u{HEX}` Unicode escape sequences. Any valid Unicode scalar value can be expressed, e.g. `"hello\u{1F30E}world"`. Invalid sequences (empty braces, non-hex digits, surrogate codepoints, or values above U+10FFFF) are reported as a compile-time error.
 
   (https://github.com/vectordotdev/vrl/pull/1771)
-- `parse_regex` now accepts dynamic regex patterns (variables and runtime expressions), consistent with `parse_regex_all`. When the pattern is a literal, return type information remains precise based on named capture groups.
+~- `parse_regex` now accepts dynamic regex patterns (variables and runtime expressions), consistent with `parse_regex_all`. When the pattern is a literal, return type information remains precise based on named capture groups.~
 
-  (https://github.com/vectordotdev/vrl/pull/1774)
+  ~(https://github.com/vectordotdev/vrl/pull/1774)~
 
 ### Enhancements
 
@@ -26,9 +35,9 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 - Added an optional `allow_lossy_string_coercion` argument to `encode_proto`. VRL's protobuf encoding stringifies `Boolean`, `Integer`, `Float`, and `Timestamp` values when assigned to a protobuf `string` field as a convenience for callers handling loosely typed input. The [protobuf JSON mapping](https://protobuf.dev/programming-guides/json/) only accepts a JSON string for a `string` field, so callers who want strict spec-compliant encoding can now pass `allow_lossy_string_coercion: false`. The default stays `true`, so today's behavior is unchanged.
 
   (https://github.com/vectordotdev/vrl/pull/1764)
-- Improved performance of `parse_regex`/`parse_regex_all` by pre-computing capture group names and indices at compile time. Users may see anywhere from 4% to 13% speedups in some cases.
+~- Improved performance of `parse_regex`/`parse_regex_all` by pre-computing capture group names and indices at compile time. Users may see anywhere from 4% to 13% speedups in some cases.~
 
-  (https://github.com/vectordotdev/vrl/pull/1773)
+  ~(https://github.com/vectordotdev/vrl/pull/1773)~
 - Improved performance of `parse_regex_all` by reusing the compiled regex across invocations.
 
   (https://github.com/vectordotdev/vrl/pull/1775)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,7 +4257,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrl"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "aes",
  "aes-siv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl"
-version = "0.33.0"
+version = "0.33.1"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 license = "MPL-2.0"

--- a/changelog.d/1789.fix.md
+++ b/changelog.d/1789.fix.md
@@ -1,1 +1,0 @@
-Reverted `parse_regex` changes from 0.33.0 which introduced a performance regression in multi-threaded scenarios.


### PR DESCRIPTION
Release 0.33.1

Published to crates.io: https://crates.io/crates/vrl/0.33.1
Tag: `v0.33.1`