### PR TITLE
chore: update crate keywords to better reflect VRL's purpose

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Vector Remap Language"
 homepage = "https://vrl.dev/"
 repository = "https://github.com/vectordotdev/vrl"
 readme = "README.md"
-keywords = ["vector", "datadog", "compiler"]
+keywords = ["vector", "dsl", "processing", "observability", "datadog"]
 categories = ["compilers"]
 rust-version = "1.90" # msrv
 


### PR DESCRIPTION
## Summary

Updates the `keywords` field in `Cargo.toml` for better discoverability on crates.io.

Before: `["vector", "datadog", "compiler"]`
After: `["vector", "dsl", "processing", "observability", "datadog"]`

`compiler` is replaced since VRL is an interpreter, not a compiler. `dsl`, `processing`, and `observability` are more accurate descriptors. `datadog` is moved last as it's a brand, not a technical term.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Metadata-only change.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.