### PR TITLE
test(stdlib): replace httpbin.org with local mock server in http_request tests

### DIFF
--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -520,6 +520,7 @@ impl Function for HttpRequest {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use crate::compiler::value::VrlValueConvert;
     use crate::value;
 
     fn execute_http_request(http_request_fn: &HttpRequestFn) -> Resolved {
@@ -530,10 +531,36 @@ mod tests {
         http_request_fn.resolve(&mut ctx)
     }
 
+    async fn start_mock_server(body: String) -> u16 {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = vec![0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+
+        port
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_basic_get_request() {
+        let port = start_mock_server(r#"{"args":{}}"#.to_string()).await;
+        let url = format!("http://127.0.0.1:{port}/get");
+
         let func: HttpRequestFn = HttpRequestFn {
-            url: expr!("https://httpbin.org/get"),
+            url: Value::from(url.as_str()).into_expression(),
             method: Some(expr!("get")),
             headers: Some(expr!({})),
             body: Some(expr!("")),
@@ -549,8 +576,7 @@ mod tests {
         let response: serde_json::Value =
             serde_json::from_str(body.as_ref()).expect("Failed to parse JSON");
 
-        assert!(response.get("url").is_some());
-        assert_eq!(response["url"], "https://httpbin.org/get");
+        assert!(response.get("args").is_some());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -573,7 +599,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_invalid_header() {
         let func = HttpRequestFn {
-            url: expr!("https://httpbin.org/get"),
+            url: expr!("http://127.0.0.1:1/get"),
             method: Some(expr!("get")),
             headers: Some(expr!({"Invalid Header With Spaces": "value"})),
             body: Some(expr!("")),
@@ -590,7 +616,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_invalid_proxy() {
         let func = HttpRequestFn {
-            url: expr!("https://httpbin.org/get"),
+            url: expr!("http://127.0.0.1:1/get"),
             method: Some(expr!("get")),
             headers: Some(expr!({})),
             body: Some(expr!("")),


### PR DESCRIPTION
## Summary

The `http_request` stdlib tests were making live HTTP requests to `httpbin.org`. This replaces the external dependency with a local mock server spun up per-test using `tokio::net::TcpListener`. Test references to httpbin.org were removed.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Ran `cargo test --workspace test_invalid_header` and `cargo test --package vrl --lib stdlib::http_request --features enable_network_functions`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA