### PR TITLE
test(stdlib): gate dns_lookup and reverse_dns network tests behind the test feature

### DIFF
--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -692,9 +692,12 @@ impl Function for DnsLookup {
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::BTreeMap;
+    #[cfg(feature = "test")]
+    use std::collections::HashSet;
 
     use super::*;
+    #[cfg(feature = "test")]
     use crate::value;
 
     impl Default for DnsLookupFn {
@@ -708,6 +711,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "test")]
     #[test]
     fn test_invalid_name() {
         let result = execute_dns_lookup(&DnsLookupFn {
@@ -728,6 +732,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "test")]
     #[test]
     #[cfg(target_os = "linux")]
     // MacOS resolver doesn't always handle localhost
@@ -752,6 +757,7 @@ mod tests {
         assert_eq!(answer["rData"], value!("127.0.0.1"));
     }
 
+    #[cfg(feature = "test")]
     #[test]
     fn test_custom_type() {
         let result = execute_dns_lookup(&DnsLookupFn {
@@ -773,6 +779,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "test")]
     #[test]
     fn test_google() {
         let result = execute_dns_lookup(&DnsLookupFn {
@@ -807,6 +814,7 @@ mod tests {
         assert_eq!(answers, expected);
     }
 
+    #[cfg(feature = "test")]
     #[test]
     fn unknown_options_ignored() {
         let result = execute_dns_lookup(&DnsLookupFn {
@@ -852,6 +860,7 @@ mod tests {
         dns_lookup_fn.resolve(&mut ctx)
     }
 
+    #[cfg(feature = "test")]
     fn execute_dns_lookup(dns_lookup_fn: &DnsLookupFn) -> ObjectMap {
         prepare_dns_lookup(dns_lookup_fn)
             .map_err(|e| format!("{:#}", anyhow::anyhow!(e)))

--- a/src/stdlib/reverse_dns.rs
+++ b/src/stdlib/reverse_dns.rs
@@ -116,22 +116,37 @@ mod tests {
             tdef: TypeDef::bytes().fallible(),
         }
 
-        google_ipv4 {
-            args: func_args![value: value!("8.8.8.8")],
-            want: Ok(value!("dns.google")),
-            tdef: TypeDef::bytes().fallible(),
-        }
-
-        google_ipv6 {
-            args: func_args![value: value!("2001:4860:4860::8844")],
-            want: Ok(value!("dns.google")),
-            tdef: TypeDef::bytes().fallible(),
-        }
-
         invalid_type {
             args: func_args![value: value!(1)],
             want: Err("expected string, got integer"),
             tdef: TypeDef::bytes().fallible(),
         }
     ];
+
+    #[cfg(feature = "test")]
+    fn execute_reverse_dns(ip_fn: &ReverseDnsFn) -> crate::value::Value {
+        let tz = TimeZone::default();
+        let mut object = value!({});
+        let mut runtime_state = state::RuntimeState::default();
+        let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
+        ip_fn.resolve(&mut ctx).unwrap()
+    }
+
+    #[cfg(feature = "test")]
+    #[test]
+    fn google_ipv4() {
+        let result = execute_reverse_dns(&ReverseDnsFn {
+            value: expr!("8.8.8.8"),
+        });
+        assert_eq!(result, value!("dns.google"));
+    }
+
+    #[cfg(feature = "test")]
+    #[test]
+    fn google_ipv6() {
+        let result = execute_reverse_dns(&ReverseDnsFn {
+            value: expr!("2001:4860:4860::8844"),
+        });
+        assert_eq!(result, value!("dns.google"));
+    }
 }


### PR DESCRIPTION
## Summary

`dns_lookup` and `reverse_dns` tests were making live external DNS queries (to `google.com`, `dns.google`, `8.8.8.8`, etc.) on every test run. These are now gated behind the existing `test` feature flag, which is already documented as the mechanism for tests with external network dependencies.

`invalid_option_type` and `negative_int_type` in `dns_lookup` are unchanged since they fail at option validation before any DNS call is made.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

`cargo test -p vrl --lib --features stdlib` passes clean (1845 tests, 0 failures).

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA