### PR TITLE
perf(stdlib): add PatternSource to parse_regex_all for per-clone Pool optimization

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -3,11 +3,11 @@ use constcat::concat;
 use criterion::{Criterion, criterion_group, criterion_main};
 use regex::Regex;
 
+use crate::value::Value;
 use std::{env, path::PathBuf, sync::LazyLock};
 use vrl::{
     bench_function, bench_query_function, btreemap, compiler::prelude::*, func_args, query, value,
 };
-use crate::value::Value;
 
 criterion_group!(
     name = benches;

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2074,6 +2074,26 @@ const PARSE_REGEX_LARGE_INPUT: &str = concat!(
     " HTTP/1.1\" 200 20574 \"-\" \"Mozilla/5.0 (compatible; Datadog Agent/7.x; +https://docs.datadoghq.com/agent/)\"",
     " 0.042 upstream_addr=10.0.1.55:8080 upstream_status=200 request_id=req-abc123def456",
 );
+const PARSE_REGEX_SINGLE_MATCH_PATTERN: &str = "(?P<number>.*?) group";
+const PARSE_REGEX_LARGE_INPUT_SMALL_CAPTURES_PATTERN: &str =
+    r#"^(?P<host>[\w\.]+) - [\w]+ [\d]+ \[(?P<timestamp>[^\]]+)\]"#;
+const PARSE_REGEX_LARGE_INPUT_PATTERN: &str = r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[\w]+) (?P<path>\S+) HTTP/[\d\.]+" (?P<status>[\d]+) (?P<bytes_out>[\d]+)"#;
+
+const LARGE_INPUT_SMALL_CAPTURES_RESULT: Value = value!({
+    "host": "5.86.210.12",
+    "timestamp": "19/06/2019:17:20:49 -0400",
+});
+
+const LARGE_INPUT_RESULT: Value = value!({
+    "host": "5.86.210.12",
+    "user": "zieme4647",
+    "bytes_in": "5667",
+    "timestamp": "19/06/2019:17:20:49 -0400",
+    "method": "GET",
+    "path": PARSE_REGEX_LARGE_INPUT_PATH,
+    "status": "200",
+    "bytes_out": "20574",
+});
 
 bench_function! {
     parse_regex => vrl::stdlib::ParseRegex;
@@ -2109,7 +2129,7 @@ bench_function! {
     single_match {
         args: func_args! [
             value: "first group and second group",
-            pattern: Regex::new("(?P<number>.*?) group").unwrap()
+            pattern: Regex::new(PARSE_REGEX_SINGLE_MATCH_PATTERN).unwrap()
         ],
         want: Ok(value!({
             "number": "first",
@@ -2120,30 +2140,18 @@ bench_function! {
     large_input_small_captures {
         args: func_args![
             value: PARSE_REGEX_LARGE_INPUT,
-            pattern: Regex::new(r#"^(?P<host>[\w\.]+) - [\w]+ [\d]+ \[(?P<timestamp>[^\]]+)\]"#).unwrap()
+            pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_SMALL_CAPTURES_PATTERN).unwrap()
         ],
-        want: Ok(value!({
-            "host": "5.86.210.12",
-            "timestamp": "19/06/2019:17:20:49 -0400",
-        }))
+        want: Ok(LARGE_INPUT_SMALL_CAPTURES_RESULT)
     }
 
     // ~1 KB input, captures span most of the string
     large_input {
         args: func_args![
             value: PARSE_REGEX_LARGE_INPUT,
-            pattern: Regex::new(r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[\w]+) (?P<path>\S+) HTTP/[\d\.]+" (?P<status>[\d]+) (?P<bytes_out>[\d]+)"#).unwrap()
+            pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_PATTERN).unwrap()
         ],
-        want: Ok(value!({
-            "host": "5.86.210.12",
-            "user": "zieme4647",
-            "bytes_in": "5667",
-            "timestamp": "19/06/2019:17:20:49 -0400",
-            "method": "GET",
-            "path": PARSE_REGEX_LARGE_INPUT_PATH,
-            "status": "200",
-            "bytes_out": "20574",
-        }))
+        want: Ok(LARGE_INPUT_RESULT)
     }
 }
 
@@ -2242,6 +2250,35 @@ bench_function! {
                     "1": "peaches",
                     "2": "peas"
                 }]))
+    }
+
+    all_matches {
+        args: func_args! [
+            value: "first group and second group",
+            pattern: Regex::new(PARSE_REGEX_SINGLE_MATCH_PATTERN).unwrap()
+        ],
+        want: Ok(value!([
+            { "number": "first" },
+            { "number": "second" },
+        ]))
+    }
+
+    // ~1 KB input, only 2 short named captures at the start
+    large_input_small_captures {
+        args: func_args![
+            value: PARSE_REGEX_LARGE_INPUT,
+            pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_SMALL_CAPTURES_PATTERN).unwrap()
+        ],
+        want: Ok(value!([(LARGE_INPUT_SMALL_CAPTURES_RESULT)]))
+    }
+
+    // ~1 KB input, captures span most of the string
+    large_input {
+        args: func_args![
+            value: PARSE_REGEX_LARGE_INPUT,
+            pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_PATTERN).unwrap()
+        ],
+        want: Ok(value!([(LARGE_INPUT_RESULT)]))
     }
 }
 

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -122,6 +122,8 @@ criterion_group!(
               parse_query_string,
               parse_regex,
               parse_regex_all,
+              parse_regex_concurrent,
+              parse_regex_all_concurrent,
               parse_ruby_hash,
               parse_syslog,
               parse_timestamp,
@@ -2145,6 +2147,77 @@ bench_function! {
     }
 }
 
+// Shared inputs for the concurrent regex benchmarks so the two functions are
+// directly comparable.
+const REGEX_CONCURRENT_THREADS: usize = 8;
+const REGEX_CONCURRENT_INPUT: &str = "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \
+    \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574";
+const REGEX_CONCURRENT_PATTERN: &str = r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#;
+
+/// Measures `parse_regex` throughput under concurrent execution.
+///
+/// The single-threaded `bench_function!` harness is blind to `Pool::get_slow`
+/// because one thread calls `Pool::get()`, becomes the owner, and hits the
+/// lock-free fast path on every subsequent iteration with no contention.
+/// Runtimes like Vector clone the compiled expression once per worker thread,
+/// so Pool ownership and contention are determined by how the compiled
+/// expression clones, not by how it runs single-threaded.
+///
+/// This benchmark compiles once and clones N times (matching the per-worker
+/// clone pattern), then runs all clones concurrently. `Regex::clone()` allocates
+/// a fresh `Pool` per clone, giving each thread its own owner slot. Any
+/// implementation that shares a single `Pool` across clones (e.g. by storing an
+/// `Arc<Regex>`) will show elevated `Pool::get_slow` overhead here.
+fn parse_regex_concurrent(c: &mut Criterion) {
+    use std::time::Instant;
+
+    let state = vrl::compiler::state::TypeState::default();
+    let args = func_args![
+        value: REGEX_CONCURRENT_INPUT,
+        pattern: Regex::new(REGEX_CONCURRENT_PATTERN).unwrap()
+    ];
+    let (expression, _) = vrl::__prep_bench_or_test!(
+        vrl::stdlib::ParseRegex,
+        &state,
+        args,
+        Ok::<vrl::value::Value, String>(vrl::value::Value::Null)
+    );
+    let expression = expression.unwrap();
+    let expressions: Vec<_> = (0..REGEX_CONCURRENT_THREADS)
+        .map(|_| expression.clone())
+        .collect();
+
+    let mut group = c.benchmark_group("vrl_stdlib/functions/parse_regex_concurrent");
+    group.throughput(criterion::Throughput::Elements(
+        REGEX_CONCURRENT_THREADS as u64,
+    ));
+
+    group.bench_function(format!("{REGEX_CONCURRENT_THREADS}_threads"), |b| {
+        b.iter_custom(|iters| {
+            let per_thread = (iters as usize).max(1);
+            let start = Instant::now();
+            std::thread::scope(|s| {
+                for expr in &expressions {
+                    s.spawn(move || {
+                        let mut runtime_state = vrl::compiler::state::RuntimeState::default();
+                        let mut target: vrl::value::Value =
+                            std::collections::BTreeMap::default().into();
+                        let tz = vrl::compiler::TimeZone::Named(chrono_tz::Tz::UTC);
+                        let mut ctx =
+                            vrl::compiler::Context::new(&mut target, &mut runtime_state, &tz);
+                        for _ in 0..per_thread {
+                            let _ = std::hint::black_box(expr.resolve(&mut ctx));
+                        }
+                    });
+                }
+            });
+            start.elapsed()
+        });
+    });
+
+    group.finish();
+}
+
 bench_function! {
     parse_regex_all => vrl::stdlib::ParseRegexAll;
 
@@ -2170,6 +2243,56 @@ bench_function! {
                     "2": "peas"
                 }]))
     }
+}
+
+/// Mirrors `parse_regex_concurrent` for `parse_regex_all`. Uses the same input
+/// and pattern so the two benchmarks are directly comparable.
+fn parse_regex_all_concurrent(c: &mut Criterion) {
+    use std::time::Instant;
+
+    let state = vrl::compiler::state::TypeState::default();
+    let args = func_args![
+        value: REGEX_CONCURRENT_INPUT,
+        pattern: Regex::new(REGEX_CONCURRENT_PATTERN).unwrap()
+    ];
+    let (expression, _) = vrl::__prep_bench_or_test!(
+        vrl::stdlib::ParseRegexAll,
+        &state,
+        args,
+        Ok::<vrl::value::Value, String>(vrl::value::Value::Null)
+    );
+    let expression = expression.unwrap();
+    let expressions: Vec<_> = (0..REGEX_CONCURRENT_THREADS)
+        .map(|_| expression.clone())
+        .collect();
+
+    let mut group = c.benchmark_group("vrl_stdlib/functions/parse_regex_all_concurrent");
+    group.throughput(criterion::Throughput::Elements(REGEX_CONCURRENT_THREADS as u64));
+
+    group.bench_function(format!("{REGEX_CONCURRENT_THREADS}_threads"), |b| {
+        b.iter_custom(|iters| {
+            let per_thread = (iters as usize).max(1);
+            let start = Instant::now();
+            std::thread::scope(|s| {
+                for expr in &expressions {
+                    s.spawn(move || {
+                        let mut runtime_state = vrl::compiler::state::RuntimeState::default();
+                        let mut target: vrl::value::Value =
+                            std::collections::BTreeMap::default().into();
+                        let tz = vrl::compiler::TimeZone::Named(chrono_tz::Tz::UTC);
+                        let mut ctx =
+                            vrl::compiler::Context::new(&mut target, &mut runtime_state, &tz);
+                        for _ in 0..per_thread {
+                            let _ = std::hint::black_box(expr.resolve(&mut ctx));
+                        }
+                    });
+                }
+            });
+            start.elapsed()
+        });
+    });
+
+    group.finish();
 }
 
 bench_function! {

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -3,7 +3,7 @@ use constcat::concat;
 use criterion::{Criterion, criterion_group, criterion_main};
 use regex::Regex;
 
-use std::{env, path::PathBuf};
+use std::{env, path::PathBuf, sync::LazyLock};
 use vrl::{bench_function, btreemap, compiler::prelude::*, func_args, value};
 
 use crate::value::Value;
@@ -2079,20 +2079,24 @@ const PARSE_REGEX_LARGE_INPUT_SMALL_CAPTURES_PATTERN: &str =
     r#"^(?P<host>[\w\.]+) - [\w]+ [\d]+ \[(?P<timestamp>[^\]]+)\]"#;
 const PARSE_REGEX_LARGE_INPUT_PATTERN: &str = r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[\w]+) (?P<path>\S+) HTTP/[\d\.]+" (?P<status>[\d]+) (?P<bytes_out>[\d]+)"#;
 
-const LARGE_INPUT_SMALL_CAPTURES_RESULT: Value = value!({
-    "host": "5.86.210.12",
-    "timestamp": "19/06/2019:17:20:49 -0400",
+static LARGE_INPUT_SMALL_CAPTURES_RESULT: LazyLock<Value> = LazyLock::new(|| {
+    value!({
+        "host": "5.86.210.12",
+        "timestamp": "19/06/2019:17:20:49 -0400",
+    })
 });
 
-const LARGE_INPUT_RESULT: Value = value!({
-    "host": "5.86.210.12",
-    "user": "zieme4647",
-    "bytes_in": "5667",
-    "timestamp": "19/06/2019:17:20:49 -0400",
-    "method": "GET",
-    "path": PARSE_REGEX_LARGE_INPUT_PATH,
-    "status": "200",
-    "bytes_out": "20574",
+static LARGE_INPUT_RESULT: LazyLock<Value> = LazyLock::new(|| {
+    value!({
+        "host": "5.86.210.12",
+        "user": "zieme4647",
+        "bytes_in": "5667",
+        "timestamp": "19/06/2019:17:20:49 -0400",
+        "method": "GET",
+        "path": PARSE_REGEX_LARGE_INPUT_PATH,
+        "status": "200",
+        "bytes_out": "20574",
+    })
 });
 
 bench_function! {
@@ -2142,7 +2146,7 @@ bench_function! {
             value: PARSE_REGEX_LARGE_INPUT,
             pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_SMALL_CAPTURES_PATTERN).unwrap()
         ],
-        want: Ok(LARGE_INPUT_SMALL_CAPTURES_RESULT)
+        want: Ok(LARGE_INPUT_SMALL_CAPTURES_RESULT.clone())
     }
 
     // ~1 KB input, captures span most of the string
@@ -2151,7 +2155,7 @@ bench_function! {
             value: PARSE_REGEX_LARGE_INPUT,
             pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_PATTERN).unwrap()
         ],
-        want: Ok(LARGE_INPUT_RESULT)
+        want: Ok(LARGE_INPUT_RESULT.clone())
     }
 }
 
@@ -2269,7 +2273,7 @@ bench_function! {
             value: PARSE_REGEX_LARGE_INPUT,
             pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_SMALL_CAPTURES_PATTERN).unwrap()
         ],
-        want: Ok(value!([(LARGE_INPUT_SMALL_CAPTURES_RESULT)]))
+        want: Ok(value!([(LARGE_INPUT_SMALL_CAPTURES_RESULT.clone())]))
     }
 
     // ~1 KB input, captures span most of the string
@@ -2278,7 +2282,7 @@ bench_function! {
             value: PARSE_REGEX_LARGE_INPUT,
             pattern: Regex::new(PARSE_REGEX_LARGE_INPUT_PATTERN).unwrap()
         ],
-        want: Ok(value!([(LARGE_INPUT_RESULT)]))
+        want: Ok(value!([(LARGE_INPUT_RESULT.clone())]))
     }
 }
 

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -2267,7 +2267,9 @@ fn parse_regex_all_concurrent(c: &mut Criterion) {
         .collect();
 
     let mut group = c.benchmark_group("vrl_stdlib/functions/parse_regex_all_concurrent");
-    group.throughput(criterion::Throughput::Elements(REGEX_CONCURRENT_THREADS as u64));
+    group.throughput(criterion::Throughput::Elements(
+        REGEX_CONCURRENT_THREADS as u64,
+    ));
 
     group.bench_function(format!("{REGEX_CONCURRENT_THREADS}_threads"), |b| {
         b.iter_custom(|iters| {

--- a/changelog.d/1798.enhancement.md
+++ b/changelog.d/1798.enhancement.md
@@ -1,0 +1,1 @@
+Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads. Users may see throughput improvements up to ~10%.

--- a/changelog.d/1798.enhancement.md
+++ b/changelog.d/1798.enhancement.md
@@ -1,3 +1,3 @@
-Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads. Users may see throughput improvements up to ~10%.
+Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads.
 
 authors: thomasqueirozb

--- a/changelog.d/1798.enhancement.md
+++ b/changelog.d/1798.enhancement.md
@@ -1,1 +1,3 @@
 Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads. Users may see throughput improvements up to ~10%.
+
+authors: thomasqueirozb

--- a/docs/generated/parse_regex_all.json
+++ b/docs/generated/parse_regex_all.json
@@ -111,7 +111,8 @@
   ],
   "notices": [
     "VRL aims to provide purpose-specific [parsing functions](/docs/reference/vrl/functions/#parse-functions)\nfor common log formats. Before reaching for the `parse_regex` function, see if a VRL\n[`parse_*` function](/docs/reference/vrl/functions/#parse-functions) already exists\nfor your format. If not, we recommend\n[opening an issue](https://github.com/vectordotdev/vector/issues/new?labels=type%3A+new+feature)\nto request support for the desired format.",
-    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit."
+    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit.",
+    "When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),\nthe regex is compiled on every function call. For high-throughput pipelines, prefer\na regex literal so the pattern is compiled once at program compile time."
   ],
   "pure": true
 }

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -89,13 +89,29 @@ impl Function for ParseRegexAll {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required("pattern");
+        let pattern_expr = arguments.required("pattern");
         let numeric_groups = arguments.optional("numeric_groups");
+
+        // When the pattern is a literal regex, clone the `Regex` and hold it by
+        // value. `regex::Regex::clone` allocates a fresh `Pool` per clone (only
+        // the compiled NFA/DFA is Arc-shared), so each clone of `ParseRegexAllFn`
+        // — and therefore each Tokio worker that holds one — gets its own Pool
+        // with its own owner-thread fast path. Holding the pattern as a
+        // `Box<dyn Expression>` instead would resolve to the same `Arc<Regex>`
+        // across all workers, collapsing them onto a single Pool and forcing all
+        // but one through `Pool::get_slow`.
+        let pattern = match pattern_expr
+            .resolve_constant(state)
+            .and_then(|v| v.as_regex().cloned())
+        {
+            Some(regex) => PatternSource::Constant(regex),
+            None => PatternSource::Expression(pattern_expr),
+        };
 
         Ok(ParseRegexAllFn {
             value,
@@ -159,9 +175,18 @@ impl Function for ParseRegexAll {
 }
 
 #[derive(Debug, Clone)]
+enum PatternSource {
+    /// Literal regex pattern held by value. `Regex::clone` allocates a fresh
+    /// Pool per clone — see comment in `ParseRegexAll::compile`.
+    Constant(Regex),
+    /// Pattern resolved from an expression on every call.
+    Expression(Box<dyn Expression>),
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
-    pattern: Box<dyn Expression>,
+    pattern: PatternSource,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -170,29 +195,32 @@ impl FunctionExpression for ParseRegexAllFn {
         let value = self.value.resolve(ctx)?;
         let numeric_groups = self
             .numeric_groups
-            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let resolved = self.pattern.resolve(ctx)?;
-        let pattern = resolved
-            .as_regex()
-            .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
+            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
+            .try_boolean()?;
 
-        parse_regex_all(&value, numeric_groups.try_boolean()?, pattern)
+        match &self.pattern {
+            PatternSource::Constant(pattern) => parse_regex_all(&value, numeric_groups, pattern),
+            PatternSource::Expression(expr) => {
+                let resolved = expr.resolve(ctx)?;
+                let pattern = resolved
+                    .as_regex()
+                    .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
+                parse_regex_all(&value, numeric_groups, pattern)
+            }
+        }
     }
 
-    fn type_def(&self, state: &state::TypeState) -> TypeDef {
-        if let Some(value) = self.pattern.resolve_constant(state)
-            && let Some(regex) = value.as_regex()
-        {
-            return TypeDef::array(Collection::from_unknown(
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        match &self.pattern {
+            PatternSource::Constant(regex) => TypeDef::array(Collection::from_unknown(
                 Kind::object(util::regex_kind(regex)).or_null(),
             ))
-            .fallible();
+            .fallible(),
+            PatternSource::Expression(_) => TypeDef::array(Collection::from_unknown(
+                Kind::object(Collection::from_unknown(Kind::bytes() | Kind::null())).or_null(),
+            ))
+            .fallible(),
         }
-
-        TypeDef::array(Collection::from_unknown(
-            Kind::object(Collection::from_unknown(Kind::bytes() | Kind::null())).or_null(),
-        ))
-        .fallible()
     }
 }
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -80,6 +80,11 @@ impl Function for ParseRegexAll {
                 All values are returned as strings. We recommend manually coercing values to desired
                 types as you see fit.
             "},
+            indoc! {"
+                When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
+                the regex is compiled on every function call. For high-throughput pipelines, prefer
+                a regex literal so the pattern is compiled once at program compile time.
+            "},
         ]
     }
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -102,14 +102,9 @@ impl Function for ParseRegexAll {
         let pattern_expr = arguments.required("pattern");
         let numeric_groups = arguments.optional("numeric_groups");
 
-        // When the pattern is a literal regex, clone the `Regex` and hold it by
-        // value. `regex::Regex::clone` allocates a fresh `Pool` per clone (only
-        // the compiled NFA/DFA is Arc-shared), so each clone of `ParseRegexAllFn`
-        // — and therefore each Tokio worker that holds one — gets its own Pool
-        // with its own owner-thread fast path. Holding the pattern as a
-        // `Box<dyn Expression>` instead would resolve to the same `Arc<Regex>`
-        // across all workers, collapsing them onto a single Pool and forcing all
-        // but one through `Pool::get_slow`.
+        // Clone literal regexes so each worker gets its own `Pool` (the compiled
+        // NFA/DFA is Arc-shared). A shared `Arc<Regex>` would collapse all workers
+        // onto one Pool, routing all but one through the slow path.
         let pattern = match pattern_expr
             .resolve_constant(state)
             .and_then(|v| v.as_regex().cloned())


### PR DESCRIPTION
## Summary

When the regex pattern is a compile-time literal, `parse_regex_all` now clones the `Regex` and holds it by value in a `PatternSource::Constant` variant rather than keeping it as a `Box<dyn Expression>`. `regex::Regex::clone` allocates a fresh `Pool` per clone, so each worker that holds a copy of the compiled function gets its own owner-thread fast path. Previously all workers resolved to the same `Arc<Regex>`, sharing a single `Pool` and forcing all but one through `Pool::get_slow` under concurrent load.

Dynamic patterns (non-literal regex arguments) continue to resolve through the `PatternSource::Expression` path with no behavioral change.

The `Constant`/`Expression` naming matches the same pattern already used in `ip_cidr_contains`.

Also adds `parse_regex_concurrent` and `parse_regex_all_concurrent` benchmarks (both using identical inputs) to make the pool contention improvement measurable.

**Benchmark results (8 threads, criterion `--baseline main`):**

| Benchmark | Before | After | Change |
|---|---|---|---|
| `parse_regex_concurrent` | 2.82 µs | 2.86 µs | ~+1.5% (noise) |
| `parse_regex_all_concurrent` | 3.48 µs | 3.19 µs | **−8.3% / +8.3% throughput** |

`parse_regex_concurrent` is unchanged as expected — it already held the pattern by value. `parse_regex_all_concurrent` shows a statistically significant improvement confirmed by criterion.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing test suite covers correctness. Added `parse_regex_concurrent` and `parse_regex_all_concurrent` benchmarks; ran with `--save-baseline main` on unmodified code and `--baseline main` on this branch. `parse_regex_all_concurrent` improved ~8% throughput under 8 concurrent threads.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Related: #1788