### PR TITLE
chore: remove redundant labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,8 +1,6 @@
 name: Bug
 description: 🐛 Let us know about an unexpected error, a crash, or an incorrect behavior.
-type: 'Bug'
-labels:
-  - 'type: bug'
+type: "Bug"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,8 +1,6 @@
 name: Feature
-type: 'Feature'
+type: "Feature"
 description: 🚀 Suggest a new feature.
-labels:
-  - 'type: feature'
 body:
   - type: markdown
     attributes:
@@ -33,7 +31,6 @@ body:
 
         Please keep this section focused on the problem and not on the suggested
         solution. We'll get to that in a moment, below!
-
 
   - type: textarea
     id: attempted-solutions


### PR DESCRIPTION
## Summary

- Removes the `labels` field from `bug.yml` and `feature.yml` issue templates
- Keeps the `type` field which serves the same categorization purpose via GitHub's native issue type system
- Also normalizes quote style from single to double quotes on the `type` field

The `type` field covers categorization without polluting the label list and the only field we want to rely on moving forward.