### PR TITLE
chore(stdlib): Resolve bool and int constants during compilation for

### DIFF
--- a/src/stdlib/replace.rs
+++ b/src/stdlib/replace.rs
@@ -1,4 +1,5 @@
 use crate::compiler::prelude::*;
+use crate::stdlib::resolve_values::ResolveInteger;
 
 static DEFAULT_COUNT: Value = Value::Integer(-1);
 
@@ -23,10 +24,9 @@ const PARAMETERS: &[Parameter] = &[
 ];
 
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)] // TODO consider removal options
-fn replace(value: &Value, with_value: &Value, count: Value, pattern: Value) -> Resolved {
+fn replace(value: &Value, with_value: &Value, count: i64, pattern: Value) -> Resolved {
     let value = value.try_bytes_utf8_lossy()?;
     let with = with_value.try_bytes_utf8_lossy()?;
-    let count = count.try_integer()?;
     match pattern {
         Value::Bytes(bytes) => {
             let pattern = String::from_utf8_lossy(&bytes);
@@ -132,14 +132,15 @@ impl Function for Replace {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
         let with = arguments.required("with");
-        let count = arguments.optional("count");
+        let count =
+            ResolveInteger::new_with_default(arguments.optional("count"), state, &DEFAULT_COUNT)?;
 
         Ok(ReplaceFn {
             value,
@@ -156,16 +157,14 @@ struct ReplaceFn {
     value: Box<dyn Expression>,
     pattern: Box<dyn Expression>,
     with: Box<dyn Expression>,
-    count: Option<Box<dyn Expression>>,
+    count: ResolveInteger,
 }
 
 impl FunctionExpression for ReplaceFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let with_value = self.with.resolve(ctx)?;
-        let count = self
-            .count
-            .map_resolve_with_default(ctx, || DEFAULT_COUNT.clone())?;
+        let count = self.count.resolve(ctx)?;
         let pattern = self.pattern.resolve(ctx)?;
 
         replace(&value, &with_value, count, pattern)

--- a/src/stdlib/resolve_values.rs
+++ b/src/stdlib/resolve_values.rs
@@ -1,0 +1,119 @@
+use crate::compiler::{Context, Expression, state};
+use crate::core::Value;
+use crate::prelude::{ValueError, VrlValueConvert};
+
+#[derive(Clone, Debug)]
+pub(crate) enum ResolveBool {
+    Constant(bool),
+    Expression(Box<dyn Expression>),
+}
+
+impl ResolveBool {
+    pub fn new(
+        expression: Box<dyn Expression>,
+        state: &state::TypeState,
+    ) -> Result<Self, ValueError> {
+        match expression.resolve_constant(state) {
+            None => Ok(Self::Expression(expression)),
+            Some(constant) => Ok(Self::Constant(constant.try_boolean()?)),
+        }
+    }
+
+    pub fn new_with_default(
+        expression: Option<Box<dyn Expression>>,
+        state: &state::TypeState,
+        default: &'static Value,
+    ) -> Result<Self, ValueError> {
+        debug_assert!(
+            default.is_boolean(),
+            "default value for ResolvedBool must be boolean"
+        );
+        match expression {
+            None => match default {
+                Value::Boolean(bool) => Ok(Self::Constant(*bool)),
+                _ => unreachable!("Invalid default value type provided, must be boolean"),
+            },
+            Some(expression) => Self::new(expression, state),
+        }
+    }
+
+    #[inline]
+    pub fn resolve(&self, ctx: &mut Context) -> Result<bool, ValueError> {
+        match self {
+            Self::Constant(value) => Ok(*value),
+            Self::Expression(expression) => expression.resolve(ctx)?.try_boolean(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ResolveInteger {
+    Constant(i64),
+    Expression(Box<dyn Expression>),
+}
+
+impl ResolveInteger {
+    pub fn new(
+        expression: Box<dyn Expression>,
+        state: &state::TypeState,
+    ) -> Result<Self, ValueError> {
+        match expression.resolve_constant(state) {
+            None => Ok(Self::Expression(expression)),
+            Some(constant) => Ok(Self::Constant(constant.try_integer()?)),
+        }
+    }
+
+    pub fn new_with_default(
+        expression: Option<Box<dyn Expression>>,
+        state: &state::TypeState,
+        default: &'static Value,
+    ) -> Result<Self, ValueError> {
+        debug_assert!(
+            default.is_integer(),
+            "default value for ResolveInteger must be integer"
+        );
+        match expression {
+            None => match default {
+                Value::Integer(integer) => Ok(ResolveInteger::Constant(*integer)),
+                _ => unreachable!("Invalid default value type provided, must be integer"),
+            },
+            Some(expression) => Self::new(expression, state),
+        }
+    }
+
+    #[inline]
+    pub fn resolve(&self, ctx: &mut Context) -> Result<i64, ValueError> {
+        match self {
+            Self::Constant(value) => Ok(*value),
+            Self::Expression(expression) => expression.resolve(ctx)?.try_integer(),
+        }
+    }
+}
+/*
+#[derive(Clone, Debug)]
+pub(crate) enum ResolveUsize {
+    Constant(usize),
+    Expression(Box<dyn Expression>),
+}
+
+impl ResolveUsize {
+    pub fn new(
+        expression: Box<dyn Expression>,
+        state: &state::TypeState,
+    ) -> Result<Self, ValueError> {
+        match expression.resolve_constant(state) {
+            None => Ok(Self::Expression(expression)),
+            Some(constant) => {
+                let integer = constant.try_integer()?;
+                match usize::try_from(integer) {
+                    Ok(usize) => Ok(Self::Constant(usize)),
+                    Err(_) => Err(function::Error::InvalidArgument {
+                        keyword: "chunk_size",
+                        value: constant,
+                        error: r#""chunk_size" is too large"#,
+                    }.into())
+                }
+            },
+        }
+    }
+}*/


### PR DESCRIPTION
## Summary

### replace

```
vrl_stdlib/functions/replace/string
                        time:   [50.102 ns 50.335 ns 50.655 ns]
                        thrpt:  [19.741 Melem/s 19.867 Melem/s 19.959 Melem/s]
                 change:
                        time:   [−10.736% −10.389% −10.026%] (p = 0.00 < 0.05)
                        thrpt:  [+11.144% +11.594% +12.028%]
                        Performance has improved.
vrl_stdlib/functions/replace/regex
                        time:   [109.49 ns 109.68 ns 109.88 ns]
                        thrpt:  [9.1007 Melem/s 9.1176 Melem/s 9.1335 Melem/s]
                 change:
                        time:   [−10.824% −9.0012% −7.5097%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1194% +9.8916% +12.137%]
                        Performance has improved.
```

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).