### PR TITLE
chore(stdlib): Resolve bool and int constants during compilation

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -24,6 +24,7 @@ criterion_group!(
               community_id,
               compact,
               contains,
+              contains_all,
               crc,
               decode_base16,
               decode_base64,
@@ -296,6 +297,20 @@ bench_function! {
 
     case_insensitive {
         args: func_args![value: "abcdefg", substring: "CDE", case_sensitive: false],
+        want: Ok(value!(true)),
+    }
+}
+
+bench_function! {
+    contains_all => vrl::stdlib::ContainsAll;
+
+    case_sensitive {
+        args: func_args![value: "abcdefg", substrings: value!(["cde"]), case_sensitive: true],
+        want: Ok(value!(true)),
+    }
+
+    case_insensitive {
+        args: func_args![value: "abcdefg", substrings: value!(["CDE"]), case_sensitive: false],
         want: Ok(value!(true)),
     }
 }

--- a/changelog.d/1803.enhancement.md
+++ b/changelog.d/1803.enhancement.md
@@ -1,0 +1,3 @@
+Improved performance of some functions when boolean or integer parameters are provided as constant.
+
+authors: JakubOnderka

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -4,6 +4,7 @@ pub mod closure;
 use crate::diagnostic::{DiagnosticMessage, Label, Note};
 use crate::parser::ast::Ident;
 use crate::path::OwnedTargetPath;
+use crate::prelude::{ValueError, VrlValueConvert};
 use crate::value::{KeyString, Value, kind::Collection};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -403,6 +404,76 @@ impl ConstOrExpr<Value> {
         match self {
             Self::Const(value) => Ok(value.clone()),
             Self::Expr(expr) => expr.resolve(ctx),
+        }
+    }
+}
+
+impl ConstOrExpr<bool> {
+    pub fn new(expr: Box<dyn Expression>, state: &TypeState) -> Result<Self, ValueError> {
+        Ok(match expr.resolve_constant(state) {
+            Some(cnst) => Self::Const(cnst.try_boolean()?),
+            None => Self::Expr(expr),
+        })
+    }
+
+    pub fn default(
+        expr: Option<Box<dyn Expression>>,
+        state: &TypeState,
+        default: &'static Value,
+    ) -> Result<Self, ValueError> {
+        debug_assert!(
+            default.is_boolean(),
+            "default value for ConstOrExpr<bool> must be boolean"
+        );
+        match expr {
+            None => match default {
+                Value::Boolean(bool) => Ok(Self::Const(*bool)),
+                _ => unreachable!("Invalid default value type provided, must be boolean"),
+            },
+            Some(expression) => Self::new(expression, state),
+        }
+    }
+
+    #[inline]
+    pub fn resolve(&self, ctx: &mut Context) -> Result<bool, ValueError> {
+        match self {
+            Self::Const(value) => Ok(*value),
+            Self::Expr(expr) => expr.resolve(ctx)?.try_boolean(),
+        }
+    }
+}
+
+impl ConstOrExpr<i64> {
+    pub fn new(expr: Box<dyn Expression>, state: &TypeState) -> Result<Self, ValueError> {
+        Ok(match expr.resolve_constant(state) {
+            Some(cnst) => Self::Const(cnst.try_integer()?),
+            None => Self::Expr(expr),
+        })
+    }
+
+    pub fn default(
+        expr: Option<Box<dyn Expression>>,
+        state: &TypeState,
+        default: &'static Value,
+    ) -> Result<Self, ValueError> {
+        debug_assert!(
+            default.is_integer(),
+            "default value for ConstOrExpr<i64> must be integer"
+        );
+        match expr {
+            None => match default {
+                Value::Integer(int) => Ok(Self::Const(*int)),
+                _ => unreachable!("Invalid default value type provided, must be integer"),
+            },
+            Some(expression) => Self::new(expression, state),
+        }
+    }
+
+    #[inline]
+    pub fn resolve(&self, ctx: &mut Context) -> Result<i64, ValueError> {
+        match self {
+            Self::Const(value) => Ok(*value),
+            Self::Expr(expr) => expr.resolve(ctx)?.try_integer(),
         }
     }
 }

--- a/src/compiler/value/error.rs
+++ b/src/compiler/value/error.rs
@@ -99,3 +99,9 @@ impl From<ValueError> for ExpressionError {
         }
     }
 }
+
+impl From<ValueError> for Box<dyn crate::diagnostic::DiagnosticMessage> {
+    fn from(error: ValueError) -> Self {
+        Box::new(error) as _
+    }
+}

--- a/src/stdlib/chunks.rs
+++ b/src/stdlib/chunks.rs
@@ -1,8 +1,7 @@
 use crate::compiler::prelude::*;
 
-fn chunks(value: Value, chunk_size: Value) -> Resolved {
+fn chunks(value: Value, chunk_size: i64) -> Resolved {
     let bytes = value.try_bytes()?;
-    let chunk_size = chunk_size.try_integer()?;
 
     if chunk_size < 1 {
         return Err(r#""chunk_size" must be at least 1 byte"#.into());
@@ -86,17 +85,15 @@ impl Function for Chunks {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let chunk_size = arguments.required("chunk_size");
+        let chunk_size = ConstOrExpr::<i64>::new(arguments.required("chunk_size"), state)?;
 
         // chunk_size is converted to a usize, so if a user-supplied Value::Integer (i64) is
         // larger than the platform's usize::MAX, it could fail to convert.
-        if let Some(literal) = chunk_size.resolve_constant(state)
-            && let Some(integer) = literal.as_integer()
-        {
+        if let ConstOrExpr::Const(integer) = chunk_size {
             if integer < 1 {
                 return Err(function::Error::InvalidArgument {
                     keyword: "chunk_size",
-                    value: literal,
+                    value: Value::Integer(integer),
                     error: r#""chunk_size" must be at least 1 byte"#,
                 }
                 .into());
@@ -105,7 +102,7 @@ impl Function for Chunks {
             if usize::try_from(integer).is_err() {
                 return Err(function::Error::InvalidArgument {
                     keyword: "chunk_size",
-                    value: literal,
+                    value: Value::Integer(integer),
                     error: r#""chunk_size" is too large"#,
                 }
                 .into());
@@ -119,7 +116,7 @@ impl Function for Chunks {
 #[derive(Debug, Clone)]
 struct ChunksFn {
     value: Box<dyn Expression>,
-    chunk_size: Box<dyn Expression>,
+    chunk_size: ConstOrExpr<i64>,
 }
 
 impl FunctionExpression for ChunksFn {
@@ -130,8 +127,8 @@ impl FunctionExpression for ChunksFn {
         chunks(value, chunk_size)
     }
 
-    fn type_def(&self, state: &TypeState) -> TypeDef {
-        let not_literal = self.chunk_size.resolve_constant(state).is_none();
+    fn type_def(&self, _state: &TypeState) -> TypeDef {
+        let not_literal = matches!(self.chunk_size, ConstOrExpr::Expr(_));
 
         TypeDef::array(Collection::from_unknown(Kind::bytes())).maybe_fallible(not_literal)
     }

--- a/src/stdlib/compact.rs
+++ b/src/stdlib/compact.rs
@@ -29,21 +29,21 @@ const PARAMETERS: &[Parameter] = &[
 ];
 
 fn compact(
-    recursive: Value,
-    null: Value,
-    string: Value,
-    object: Value,
-    array: Value,
-    nullish: Value,
+    recursive: bool,
+    null: bool,
+    string: bool,
+    object: bool,
+    array: bool,
+    nullish: bool,
     value: Value,
 ) -> Resolved {
     let options = CompactOptions {
-        recursive: recursive.try_boolean()?,
-        null: null.try_boolean()?,
-        string: string.try_boolean()?,
-        object: object.try_boolean()?,
-        array: array.try_boolean()?,
-        nullish: nullish.try_boolean()?,
+        recursive,
+        null,
+        string,
+        object,
+        array,
+        nullish,
     };
 
     match value {
@@ -117,17 +117,25 @@ impl Function for Compact {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let recursive = arguments.optional("recursive");
-        let null = arguments.optional("null");
-        let string = arguments.optional("string");
-        let object = arguments.optional("object");
-        let array = arguments.optional("array");
-        let nullish = arguments.optional("nullish");
+        let recursive = ConstOrExpr::<bool>::default(
+            arguments.optional("recursive"),
+            state,
+            &DEFAULT_RECURSIVE,
+        )?;
+        let null = ConstOrExpr::<bool>::default(arguments.optional("null"), state, &DEFAULT_NULL)?;
+        let string =
+            ConstOrExpr::<bool>::default(arguments.optional("string"), state, &DEFAULT_STRING)?;
+        let object =
+            ConstOrExpr::<bool>::default(arguments.optional("object"), state, &DEFAULT_OBJECT)?;
+        let array =
+            ConstOrExpr::<bool>::default(arguments.optional("array"), state, &DEFAULT_ARRAY)?;
+        let nullish =
+            ConstOrExpr::<bool>::default(arguments.optional("nullish"), state, &DEFAULT_NULLISH)?;
 
         Ok(CompactFn {
             value,
@@ -145,12 +153,12 @@ impl Function for Compact {
 #[derive(Debug, Clone)]
 struct CompactFn {
     value: Box<dyn Expression>,
-    recursive: Option<Box<dyn Expression>>,
-    null: Option<Box<dyn Expression>>,
-    string: Option<Box<dyn Expression>>,
-    object: Option<Box<dyn Expression>>,
-    array: Option<Box<dyn Expression>>,
-    nullish: Option<Box<dyn Expression>>,
+    recursive: ConstOrExpr<bool>,
+    null: ConstOrExpr<bool>,
+    string: ConstOrExpr<bool>,
+    object: ConstOrExpr<bool>,
+    array: ConstOrExpr<bool>,
+    nullish: ConstOrExpr<bool>,
 }
 
 #[derive(Debug)]
@@ -196,24 +204,12 @@ impl CompactOptions {
 
 impl FunctionExpression for CompactFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let recursive = self
-            .recursive
-            .map_resolve_with_default(ctx, || DEFAULT_RECURSIVE.clone())?;
-        let null = self
-            .null
-            .map_resolve_with_default(ctx, || DEFAULT_NULL.clone())?;
-        let string = self
-            .string
-            .map_resolve_with_default(ctx, || DEFAULT_STRING.clone())?;
-        let object = self
-            .object
-            .map_resolve_with_default(ctx, || DEFAULT_OBJECT.clone())?;
-        let array = self
-            .array
-            .map_resolve_with_default(ctx, || DEFAULT_ARRAY.clone())?;
-        let nullish = self
-            .nullish
-            .map_resolve_with_default(ctx, || DEFAULT_NULLISH.clone())?;
+        let recursive = self.recursive.resolve(ctx)?;
+        let null = self.null.resolve(ctx)?;
+        let string = self.string.resolve(ctx)?;
+        let object = self.object.resolve(ctx)?;
+        let array = self.array.resolve(ctx)?;
+        let nullish = self.nullish.resolve(ctx)?;
         let value = self.value.resolve(ctx)?;
 
         compact(recursive, null, string, object, array, nullish, value)
@@ -272,7 +268,7 @@ mod test {
 
     #[test]
     fn test_compacted_array() {
-        let cases = vec![
+        let cases = [
             (
                 vec!["".into(), "".into()],              // expected
                 vec!["".into(), Value::Null, "".into()], // original
@@ -333,7 +329,7 @@ mod test {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn test_compacted_map() {
-        let cases = vec![
+        let cases = [
             (
                 btreemap! {
                     "key1" => "",

--- a/src/stdlib/contains.rs
+++ b/src/stdlib/contains.rs
@@ -18,8 +18,7 @@ const PARAMETERS: &[Parameter] = &[
     .default(&DEFAULT_CASE_SENSITIVE),
 ];
 
-fn contains(value: &Value, substring: &Value, case_sensitive: Value) -> Resolved {
-    let case_sensitive = case_sensitive.try_boolean()?;
+fn contains(value: &Value, substring: &Value, case_sensitive: bool) -> Resolved {
     let value = convert_to_string(value, !case_sensitive)?;
     let substring = convert_to_string(substring, !case_sensitive)?;
     Ok(value.contains(substring.as_ref()).into())
@@ -51,13 +50,17 @@ impl Function for Contains {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
-        let case_sensitive = arguments.optional("case_sensitive");
+        let case_sensitive = ConstOrExpr::<bool>::default(
+            arguments.optional("case_sensitive"),
+            state,
+            &DEFAULT_CASE_SENSITIVE,
+        )?;
 
         Ok(ContainsFn {
             value,
@@ -87,16 +90,14 @@ impl Function for Contains {
 struct ContainsFn {
     value: Box<dyn Expression>,
     substring: Box<dyn Expression>,
-    case_sensitive: Option<Box<dyn Expression>>,
+    case_sensitive: ConstOrExpr<bool>,
 }
 
 impl FunctionExpression for ContainsFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let substring = self.substring.resolve(ctx)?;
-        let case_sensitive = self
-            .case_sensitive
-            .map_resolve_with_default(ctx, || DEFAULT_CASE_SENSITIVE.clone())?;
+        let case_sensitive = self.case_sensitive.resolve(ctx)?;
 
         contains(&value, &substring, case_sensitive)
     }
@@ -188,6 +189,15 @@ mod tests {
                              case_sensitive: false
             ],
             want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        case_insensitive_invalid_type {
+            args: func_args![value: value!("foobar"),
+                             substring: value!("BAR"),
+                             case_sensitive: value!("no")
+            ],
+            want: Err("expected boolean, got string"),
             tdef: TypeDef::boolean().infallible(),
         }
     ];

--- a/src/stdlib/contains_all.rs
+++ b/src/stdlib/contains_all.rs
@@ -1,12 +1,7 @@
 use crate::compiler::prelude::*;
 use crate::stdlib::string_utils::convert_to_string;
 
-fn contains_all(value: &Value, substrings: Value, case_sensitive: Option<Value>) -> Resolved {
-    let case_sensitive = match case_sensitive {
-        Some(v) => v.try_boolean()?,
-        None => true,
-    };
-
+fn contains_all(value: &Value, substrings: Value, case_sensitive: bool) -> Resolved {
     let value_string = convert_to_string(value, !case_sensitive)?;
     let substring_values = substrings.try_array()?;
 
@@ -58,13 +53,17 @@ impl Function for ContainsAll {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substrings = arguments.required("substrings");
-        let case_sensitive = arguments.optional("case_sensitive");
+        let case_sensitive = ConstOrExpr::<bool>::default(
+            arguments.optional("case_sensitive"),
+            state,
+            &Value::Boolean(true),
+        )?;
 
         Ok(ContainsAllFn {
             value,
@@ -99,18 +98,14 @@ impl Function for ContainsAll {
 struct ContainsAllFn {
     value: Box<dyn Expression>,
     substrings: Box<dyn Expression>,
-    case_sensitive: Option<Box<dyn Expression>>,
+    case_sensitive: ConstOrExpr<bool>,
 }
 
 impl FunctionExpression for ContainsAllFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let substrings = self.substrings.resolve(ctx)?;
-        let case_sensitive = self
-            .case_sensitive
-            .as_ref()
-            .map(|expr| expr.resolve(ctx))
-            .transpose()?;
+        let case_sensitive = self.case_sensitive.resolve(ctx)?;
         contains_all(&value, substrings, case_sensitive)
     }
 

--- a/src/stdlib/del.rs
+++ b/src/stdlib/del.rs
@@ -154,12 +154,13 @@ impl Function for Del {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("target")?;
-        let compact = arguments.optional("compact");
+        let compact =
+            ConstOrExpr::<bool>::default(arguments.optional("compact"), state, &DEFAULT_COMPACT)?;
 
         if let Some(target_path) = query.external_path()
             && ctx.is_read_only_path(&target_path)
@@ -177,7 +178,7 @@ impl Function for Del {
 #[derive(Debug, Clone)]
 pub(crate) struct DelFn {
     query: expression::Query,
-    compact: Option<Box<dyn Expression>>,
+    compact: ConstOrExpr<bool>,
 }
 
 impl DelFn {
@@ -190,7 +191,7 @@ impl DelFn {
                 expression::Target::External(PathPrefix::Event),
                 parse_value_path(path).unwrap(),
             ),
-            compact: None,
+            compact: ConstOrExpr::Const(false),
         }
     }
 }
@@ -211,10 +212,7 @@ impl Expression for DelFn {
     //
     // see tracking issue: https://github.com/vectordotdev/vector/issues/5887
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let compact = self
-            .compact
-            .map_resolve_with_default(ctx, || DEFAULT_COMPACT.clone())?
-            .try_boolean()?;
+        let compact = self.compact.resolve(ctx)?;
         del(&self.query, compact, ctx)
     }
 
@@ -223,13 +221,7 @@ impl Expression for DelFn {
 
         let return_type = self.query.apply_type_info(&mut state).impure();
 
-        let compact: Option<bool> = self
-            .compact
-            .as_ref()
-            .and_then(|compact| compact.resolve_constant(&state))
-            .and_then(|compact| compact.as_boolean());
-
-        if let Some(compact) = compact {
+        if let ConstOrExpr::Const(compact) = self.compact {
             self.query.delete_type_def(&mut state.external, compact);
         } else {
             let mut false_result = state.external.clone();
@@ -259,7 +251,7 @@ mod tests {
 
     #[test]
     fn del() {
-        let cases = vec![
+        let cases = [
             (
                 // String field exists
                 btreemap! { "exists" => "value" },

--- a/src/stdlib/ends_with.rs
+++ b/src/stdlib/ends_with.rs
@@ -18,8 +18,7 @@ const PARAMETERS: &[Parameter] = &[
     .default(&DEFAULT_CASE_SENSITIVE),
 ];
 
-fn ends_with(value: &Value, substring: &Value, case_sensitive: Value) -> Resolved {
-    let case_sensitive = case_sensitive.try_boolean()?;
+fn ends_with(value: &Value, substring: &Value, case_sensitive: bool) -> Resolved {
     let value = convert_to_string(value, !case_sensitive)?;
     let substring = convert_to_string(substring, !case_sensitive)?;
     Ok(value.ends_with(substring.as_ref()).into())
@@ -51,13 +50,17 @@ impl Function for EndsWith {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
-        let case_sensitive = arguments.optional("case_sensitive");
+        let case_sensitive = ConstOrExpr::<bool>::default(
+            arguments.optional("case_sensitive"),
+            state,
+            &DEFAULT_CASE_SENSITIVE,
+        )?;
 
         Ok(EndsWithFn {
             value,
@@ -92,14 +95,12 @@ impl Function for EndsWith {
 struct EndsWithFn {
     value: Box<dyn Expression>,
     substring: Box<dyn Expression>,
-    case_sensitive: Option<Box<dyn Expression>>,
+    case_sensitive: ConstOrExpr<bool>,
 }
 
 impl FunctionExpression for EndsWithFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let case_sensitive = self
-            .case_sensitive
-            .map_resolve_with_default(ctx, || DEFAULT_CASE_SENSITIVE.clone())?;
+        let case_sensitive = self.case_sensitive.resolve(ctx)?;
         let substring = self.substring.resolve(ctx)?;
         let value = self.value.resolve(ctx)?;
 

--- a/src/stdlib/find.rs
+++ b/src/stdlib/find.rs
@@ -13,10 +13,10 @@ const PARAMETERS: &[Parameter] = &[
 ];
 
 #[allow(clippy::cast_possible_wrap)]
-fn find(value: Value, pattern: Value, from: Value) -> Resolved {
+fn find(value: Value, pattern: Value, from: i64) -> Resolved {
     // TODO consider removal options
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    let from = from.try_integer()? as usize;
+    let from = from as usize;
 
     Ok(FindFn::find(value, pattern, from)?
         .map_or(Value::Null, |value| Value::Integer(value as i64)))
@@ -78,13 +78,13 @@ impl Function for Find {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
-        let from = arguments.optional("from");
+        let from = ConstOrExpr::<i64>::default(arguments.optional("from"), state, &DEFAULT_FROM)?;
 
         Ok(FindFn {
             value,
@@ -99,7 +99,7 @@ impl Function for Find {
 struct FindFn {
     value: Box<dyn Expression>,
     pattern: Box<dyn Expression>,
-    from: Option<Box<dyn Expression>>,
+    from: ConstOrExpr<i64>,
 }
 
 impl FindFn {
@@ -145,9 +145,7 @@ impl FunctionExpression for FindFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let pattern = self.pattern.resolve(ctx)?;
-        let from = self
-            .from
-            .map_resolve_with_default(ctx, || DEFAULT_FROM.clone())?;
+        let from = self.from.resolve(ctx)?;
 
         find(value, pattern, from)
     }

--- a/src/stdlib/log.rs
+++ b/src/stdlib/log.rs
@@ -93,7 +93,7 @@ impl Function for Log {
         ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let levels = vec![
+        let levels: &[Value] = &[
             "trace".into(),
             "debug".into(),
             "info".into(),
@@ -103,11 +103,15 @@ impl Function for Log {
 
         let value = arguments.required("value");
         let level = arguments
-            .optional_enum("level", &levels, state)?
+            .optional_enum("level", levels, state)?
             .unwrap_or_else(|| DEFAULT_LEVEL.clone())
             .try_bytes()
             .expect("log level not bytes");
-        let rate_limit_secs = arguments.optional("rate_limit_secs");
+        let rate_limit_secs = ConstOrExpr::<i64>::default(
+            arguments.optional("rate_limit_secs"),
+            state,
+            &DEFAULT_RATE_LIMIT_SECS,
+        )?;
 
         Ok(implementation::LogFn {
             span: ctx.span(),
@@ -133,16 +137,9 @@ impl Function for Log {
 mod implementation {
     use tracing::{debug, error, info, trace, warn};
 
-    use super::DEFAULT_RATE_LIMIT_SECS;
     use crate::compiler::prelude::*;
 
-    pub(super) fn log(
-        rate_limit_secs: Value,
-        level: &Bytes,
-        value: &Value,
-        span: Span,
-    ) -> Resolved {
-        let rate_limit_secs = rate_limit_secs.try_integer()?;
+    pub(super) fn log(rate_limit_secs: i64, level: &Bytes, value: &Value, span: Span) -> Resolved {
         let res = value.to_string_lossy();
         match level.as_ref() {
             b"trace" => {
@@ -169,15 +166,13 @@ mod implementation {
         pub(super) span: Span,
         pub(super) value: Box<dyn Expression>,
         pub(super) level: Bytes,
-        pub(super) rate_limit_secs: Option<Box<dyn Expression>>,
+        pub(super) rate_limit_secs: ConstOrExpr<i64>,
     }
 
     impl FunctionExpression for LogFn {
         fn resolve(&self, ctx: &mut Context) -> Resolved {
             let value = self.value.resolve(ctx)?;
-            let rate_limit_secs = self
-                .rate_limit_secs
-                .map_resolve_with_default(ctx, || DEFAULT_RATE_LIMIT_SECS.clone())?;
+            let rate_limit_secs = self.rate_limit_secs.resolve(ctx)?;
 
             let span = self.span;
 
@@ -214,7 +209,7 @@ mod tests {
     fn output_quotes() {
         // Check that a message is logged without additional quotes
         implementation::log(
-            value!(1),
+            1,
             &Bytes::from("warn"),
             &value!("simple test message"),
             Span::default(),

--- a/src/stdlib/log.rs
+++ b/src/stdlib/log.rs
@@ -93,6 +93,8 @@ impl Function for Log {
         ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
+        use tracing::Level;
+
         let levels: &[Value] = &[
             "trace".into(),
             "debug".into(),
@@ -107,6 +109,16 @@ impl Function for Log {
             .unwrap_or_else(|| DEFAULT_LEVEL.clone())
             .try_bytes()
             .expect("log level not bytes");
+
+        let level = match level.as_ref() {
+            b"trace" => Level::TRACE,
+            b"debug" => Level::DEBUG,
+            b"info" => Level::INFO,
+            b"warn" => Level::WARN,
+            b"error" => Level::ERROR,
+            _ => unreachable!(),
+        };
+
         let rate_limit_secs = ConstOrExpr::<i64>::default(
             arguments.optional("rate_limit_secs"),
             state,
@@ -135,26 +147,26 @@ impl Function for Log {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod implementation {
-    use tracing::{debug, error, info, trace, warn};
+    use tracing::{Level, debug, error, info, trace, warn};
 
     use crate::compiler::prelude::*;
 
-    pub(super) fn log(rate_limit_secs: i64, level: &Bytes, value: &Value, span: Span) -> Resolved {
+    pub(super) fn log(rate_limit_secs: i64, level: Level, value: &Value, span: Span) -> Resolved {
         let res = value.to_string_lossy();
-        match level.as_ref() {
-            b"trace" => {
+        match level {
+            Level::TRACE => {
                 trace!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start());
             }
-            b"debug" => {
+            Level::DEBUG => {
                 debug!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start());
             }
-            b"warn" => {
+            Level::WARN => {
                 warn!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start());
             }
-            b"error" => {
+            Level::ERROR => {
                 error!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start());
             }
-            _ => {
+            Level::INFO => {
                 info!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start());
             }
         }
@@ -165,7 +177,7 @@ mod implementation {
     pub(super) struct LogFn {
         pub(super) span: Span,
         pub(super) value: Box<dyn Expression>,
-        pub(super) level: Bytes,
+        pub(super) level: Level,
         pub(super) rate_limit_secs: ConstOrExpr<i64>,
     }
 
@@ -176,7 +188,7 @@ mod implementation {
 
             let span = self.span;
 
-            log(rate_limit_secs, &self.level, &value, span)
+            log(rate_limit_secs, self.level, &value, span)
         }
 
         fn type_def(&self, _: &state::TypeState) -> TypeDef {
@@ -188,6 +200,7 @@ mod implementation {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use tracing_test::traced_test;
+    use tracing::Level;
 
     use super::*;
     use crate::value;
@@ -210,7 +223,7 @@ mod tests {
         // Check that a message is logged without additional quotes
         implementation::log(
             1,
-            &Bytes::from("warn"),
+            Level::WARN,
             &value!("simple test message"),
             Span::default(),
         )

--- a/src/stdlib/object_from_array.rs
+++ b/src/stdlib/object_from_array.rs
@@ -118,10 +118,10 @@ impl Function for ObjectFromArray {
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let values = ConstOrExpr::new(arguments.required("values"), state);
+        let values = ConstOrExpr::<Value>::new(arguments.required("values"), state);
         let keys = arguments
             .optional("keys")
-            .map(|keys| ConstOrExpr::new(keys, state));
+            .map(|keys| ConstOrExpr::<Value>::new(keys, state));
 
         Ok(OFAFn { keys, values }.as_expr())
     }

--- a/src/stdlib/parse_json.rs
+++ b/src/stdlib/parse_json.rs
@@ -33,8 +33,7 @@ if there are any invalid UTF-8 characters present.",
     .default(&DEFAULT_LOSSY),
 ];
 
-fn parse_json(value: Value, lossy: Value) -> Resolved {
-    let lossy = lossy.try_boolean()?;
+fn parse_json(value: Value, lossy: bool) -> Resolved {
     Ok(if lossy {
         serde_json::from_str(value.try_bytes_utf8_lossy()?.strip_bom())
     } else {
@@ -45,9 +44,8 @@ fn parse_json(value: Value, lossy: Value) -> Resolved {
 
 // parse_json_with_depth method recursively traverses the value and returns raw JSON-formatted bytes
 // after reaching provided depth.
-fn parse_json_with_depth(value: Value, max_depth: Value, lossy: Value) -> Resolved {
+fn parse_json_with_depth(value: Value, max_depth: Value, lossy: bool) -> Resolved {
     let parsed_depth = validate_depth(max_depth)?;
-    let lossy = lossy.try_boolean()?;
     let bytes = if lossy {
         value.try_bytes_utf8_lossy()?.into_owned().into()
     } else {
@@ -222,14 +220,14 @@ impl Function for ParseJson {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let max_depth = arguments.optional("max_depth");
-        let lossy = arguments.optional("lossy");
-
+        let lossy =
+            ConstOrExpr::<bool>::default(arguments.optional("lossy"), state, &DEFAULT_LOSSY)?;
         match max_depth {
             Some(max_depth) => Ok(ParseJsonMaxDepthFn {
                 value,
@@ -245,15 +243,13 @@ impl Function for ParseJson {
 #[derive(Debug, Clone)]
 struct ParseJsonFn {
     value: Box<dyn Expression>,
-    lossy: Option<Box<dyn Expression>>,
+    lossy: ConstOrExpr<bool>,
 }
 
 impl FunctionExpression for ParseJsonFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let lossy = self
-            .lossy
-            .map_resolve_with_default(ctx, || DEFAULT_LOSSY.clone())?;
+        let lossy = self.lossy.resolve(ctx)?;
         parse_json(value, lossy)
     }
 
@@ -266,16 +262,15 @@ impl FunctionExpression for ParseJsonFn {
 struct ParseJsonMaxDepthFn {
     value: Box<dyn Expression>,
     max_depth: Box<dyn Expression>,
-    lossy: Option<Box<dyn Expression>>,
+    lossy: ConstOrExpr<bool>,
 }
 
 impl FunctionExpression for ParseJsonMaxDepthFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let max_depth = self.max_depth.resolve(ctx)?;
-        let lossy = self
-            .lossy
-            .map_resolve_with_default(ctx, || DEFAULT_LOSSY.clone())?;
+
+        let lossy = self.lossy.resolve(ctx)?;
         parse_json_with_depth(value, max_depth, lossy)
     }
 

--- a/src/stdlib/replace.rs
+++ b/src/stdlib/replace.rs
@@ -23,10 +23,9 @@ const PARAMETERS: &[Parameter] = &[
 ];
 
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)] // TODO consider removal options
-fn replace(value: &Value, with_value: &Value, count: Value, pattern: Value) -> Resolved {
+fn replace(value: &Value, with_value: &Value, count: i64, pattern: Value) -> Resolved {
     let value = value.try_bytes_utf8_lossy()?;
     let with = with_value.try_bytes_utf8_lossy()?;
-    let count = count.try_integer()?;
     match pattern {
         Value::Bytes(bytes) => {
             let pattern = String::from_utf8_lossy(&bytes);
@@ -132,14 +131,15 @@ impl Function for Replace {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
         let with = arguments.required("with");
-        let count = arguments.optional("count");
+        let count =
+            ConstOrExpr::<i64>::default(arguments.optional("count"), state, &DEFAULT_COUNT)?;
 
         Ok(ReplaceFn {
             value,
@@ -156,16 +156,14 @@ struct ReplaceFn {
     value: Box<dyn Expression>,
     pattern: Box<dyn Expression>,
     with: Box<dyn Expression>,
-    count: Option<Box<dyn Expression>>,
+    count: ConstOrExpr<i64>,
 }
 
 impl FunctionExpression for ReplaceFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let with_value = self.with.resolve(ctx)?;
-        let count = self
-            .count
-            .map_resolve_with_default(ctx, || DEFAULT_COUNT.clone())?;
+        let count = self.count.resolve(ctx)?;
         let pattern = self.pattern.resolve(ctx)?;
 
         replace(&value, &with_value, count, pattern)

--- a/src/stdlib/split.rs
+++ b/src/stdlib/split.rs
@@ -1,8 +1,8 @@
 use crate::compiler::prelude::*;
 
-fn split(value: &Value, limit: Value, pattern: Value) -> Resolved {
+fn split(value: &Value, limit: i64, pattern: Value) -> Resolved {
     let string = value.try_bytes_utf8_lossy()?;
-    let limit = match limit.try_integer()? {
+    let limit = match limit {
         x if x < 0 => 0,
         // TODO consider removal options
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
@@ -99,13 +99,17 @@ impl Function for Split {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
-        let limit = arguments.optional("limit").unwrap_or(expr!(999_999_999));
+        let limit = arguments
+            .optional("limit")
+            .map_or(Ok(ConstOrExpr::Const(999_999_999)), |expression| {
+                ConstOrExpr::<i64>::new(expression, state)
+            })?;
 
         Ok(SplitFn {
             value,
@@ -120,7 +124,7 @@ impl Function for Split {
 pub(crate) struct SplitFn {
     value: Box<dyn Expression>,
     pattern: Box<dyn Expression>,
-    limit: Box<dyn Expression>,
+    limit: ConstOrExpr<i64>,
 }
 
 impl FunctionExpression for SplitFn {

--- a/src/stdlib/starts_with.rs
+++ b/src/stdlib/starts_with.rs
@@ -127,13 +127,17 @@ impl Function for StartsWith {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
-        let case_sensitive = arguments.optional("case_sensitive");
+        let case_sensitive = ConstOrExpr::<bool>::default(
+            arguments.optional("case_sensitive"),
+            state,
+            &DEFAULT_CASE_SENSITIVE,
+        )?;
 
         Ok(StartsWithFn {
             value,
@@ -148,15 +152,12 @@ impl Function for StartsWith {
 struct StartsWithFn {
     value: Box<dyn Expression>,
     substring: Box<dyn Expression>,
-    case_sensitive: Option<Box<dyn Expression>>,
+    case_sensitive: ConstOrExpr<bool>,
 }
 
 impl FunctionExpression for StartsWithFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let case_sensitive = self
-            .case_sensitive
-            .map_resolve_with_default(ctx, || DEFAULT_CASE_SENSITIVE.clone())?
-            .try_boolean()?;
+        let case_sensitive = self.case_sensitive.resolve(ctx)?;
         let case_sensitive = if case_sensitive {
             Case::Sensitive
         } else {

--- a/src/stdlib/truncate.rs
+++ b/src/stdlib/truncate.rs
@@ -1,8 +1,7 @@
 use crate::compiler::prelude::*;
 
-fn truncate(value: &Value, limit: Value, suffix: &Value) -> Resolved {
+fn truncate(value: &Value, limit: i64, suffix: &Value) -> Resolved {
     let mut value = value.try_bytes_utf8_lossy()?.into_owned();
-    let limit = limit.try_integer()?;
     // TODO consider removal options
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let limit = if limit < 0 { 0 } else { limit as usize };
@@ -90,12 +89,12 @@ impl Function for Truncate {
 
     fn compile(
         &self,
-        _state: &TypeState,
+        state: &TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let limit = arguments.required("limit");
+        let limit = ConstOrExpr::<i64>::new(arguments.required("limit"), state)?;
         let suffix = arguments.optional("suffix").unwrap_or(expr!(""));
 
         Ok(TruncateFn {
@@ -110,7 +109,7 @@ impl Function for Truncate {
 #[derive(Debug, Clone)]
 struct TruncateFn {
     value: Box<dyn Expression>,
-    limit: Box<dyn Expression>,
+    limit: ConstOrExpr<i64>,
     suffix: Box<dyn Expression>,
 }
 

--- a/src/stdlib/zip.rs
+++ b/src/stdlib/zip.rs
@@ -115,8 +115,8 @@ impl Function for Zip {
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let array_0 = ConstOrExpr::new(arguments.required("array_0"), state);
-        let array_1 = ConstOrExpr::optional(arguments.optional("array_1"), state);
+        let array_0 = ConstOrExpr::<Value>::new(arguments.required("array_0"), state);
+        let array_1 = ConstOrExpr::<Value>::optional(arguments.optional("array_1"), state);
 
         Ok(ZipFn { array_0, array_1 }.as_expr())
     }


### PR DESCRIPTION
## Summary

For simple method, resolving function parameters during runtime that are usually not defined or constants can take significant amount of time. This patch checks if these parameters are constants and if yes, resolve then in compilation phase. The advantage is also that variable type in that case is checked during compilation. 

## Benchmark results

### compact

```
vrl_stdlib/functions/compact/array
                        time:   [55.689 ns 55.746 ns 55.812 ns]
                        thrpt:  [17.917 Melem/s 17.938 Melem/s 17.957 Melem/s]
                 change:
                        time:   [−36.734% −35.852% −34.619%] (p = 0.00 < 0.05)
                        thrpt:  [+52.950% +55.889% +58.063%]
                        Performance has improved.
vrl_stdlib/functions/compact/map
                        time:   [212.83 ns 213.84 ns 215.70 ns]
                        thrpt:  [4.6360 Melem/s 4.6765 Melem/s 4.6986 Melem/s]
                 change:
                        time:   [−18.066% −17.031% −15.958%] (p = 0.00 < 0.05)
                        thrpt:  [+18.988% +20.527% +22.049%]
                        Performance has improved.
```

### del

```
vrl_stdlib/functions/del/default
                        time:   [120.36 ns 122.95 ns 125.23 ns]
                        thrpt:  [7.9853 Melem/s 8.1331 Melem/s 8.3081 Melem/s]
                 change:
                        time:   [−8.0325% −6.6988% −5.2953%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5914% +7.1798% +8.7340%]
                        Performance has improved.
vrl_stdlib/functions/del/compact
                        time:   [204.08 ns 205.46 ns 207.03 ns]
                        thrpt:  [4.8302 Melem/s 4.8670 Melem/s 4.9001 Melem/s]
                 change:
                        time:   [−7.5981% −6.6643% −5.7761%] (p = 0.00 < 0.05)
                        thrpt:  [+6.1301% +7.1401% +8.2228%]
                        Performance has improved.
```

### replace

```
vrl_stdlib/functions/replace/string
                        time:   [50.102 ns 50.335 ns 50.655 ns]
                        thrpt:  [19.741 Melem/s 19.867 Melem/s 19.959 Melem/s]
                 change:
                        time:   [−10.736% −10.389% −10.026%] (p = 0.00 < 0.05)
                        thrpt:  [+11.144% +11.594% +12.028%]
                        Performance has improved.
vrl_stdlib/functions/replace/regex
                        time:   [109.49 ns 109.68 ns 109.88 ns]
                        thrpt:  [9.1007 Melem/s 9.1176 Melem/s 9.1335 Melem/s]
                 change:
                        time:   [−10.824% −9.0012% −7.5097%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1194% +9.8916% +12.137%]
                        Performance has improved.
```

### log

```
vrl_stdlib/functions/log/literal
                        time:   [10.571 ns 10.591 ns 10.618 ns]
                        thrpt:  [94.180 Melem/s 94.418 Melem/s 94.596 Melem/s]
                 change:
                        time:   [−23.837% −23.483% −22.978%] (p = 0.00 < 0.05)
                        thrpt:  [+29.832% +30.689% +31.297%]
                        Performance has improved.
```

### starts_with

```
vrl_stdlib/functions/starts_with/case_sensitive
                        time:   [16.927 ns 16.992 ns 17.089 ns]
                        thrpt:  [58.517 Melem/s 58.850 Melem/s 59.079 Melem/s]
                 change:
                        time:   [−29.057% −28.704% −28.273%] (p = 0.00 < 0.05)
                        thrpt:  [+39.417% +40.260% +40.957%]
                        Performance has improved.
vrl_stdlib/functions/starts_with/case_insensitive
                        time:   [22.146 ns 22.178 ns 22.212 ns]
                        thrpt:  [45.020 Melem/s 45.089 Melem/s 45.156 Melem/s]
                 change:
                        time:   [−27.875% −27.625% −27.423%] (p = 0.00 < 0.05)
                        thrpt:  [+37.785% +38.169% +38.648%]
                        Performance has improved.
```

### find

```
vrl_stdlib/functions/find/str_matching
                        time:   [20.990 ns 21.342 ns 21.713 ns]
                        thrpt:  [46.055 Melem/s 46.856 Melem/s 47.642 Melem/s]
                 change:
                        time:   [−12.793% −11.362% −9.9652%] (p = 0.00 < 0.05)
                        thrpt:  [+11.068% +12.819% +14.670%]
                        Performance has improved.
vrl_stdlib/functions/find/str_too_long
                        time:   [17.727 ns 17.994 ns 18.279 ns]
                        thrpt:  [54.709 Melem/s 55.574 Melem/s 56.410 Melem/s]
                 change:
                        time:   [−15.983% −14.959% −13.915%] (p = 0.00 < 0.05)
                        thrpt:  [+16.164% +17.591% +19.024%]
                        Performance has improved.
vrl_stdlib/functions/find/regex_matching_start
                        time:   [47.567 ns 47.938 ns 48.348 ns]
                        thrpt:  [20.683 Melem/s 20.860 Melem/s 21.023 Melem/s]
                 change:
                        time:   [−5.0520% −4.2456% −3.3554%] (p = 0.00 < 0.05)
                        thrpt:  [+3.4719% +4.4339% +5.3208%]
                        Change within noise threshold.
```

### contains

```
vrl_stdlib/functions/contains/case_sensitive
                        time:   [34.275 ns 34.357 ns 34.448 ns]
                        thrpt:  [29.029 Melem/s 29.106 Melem/s 29.176 Melem/s]
                 change:
                        time:   [−17.199% −16.570% −15.999%] (p = 0.00 < 0.05)
                        thrpt:  [+19.047% +19.861% +20.771%]
                        Performance has improved.
vrl_stdlib/functions/contains/case_insensitive
                        time:   [55.680 ns 56.032 ns 56.472 ns]
                        thrpt:  [17.708 Melem/s 17.847 Melem/s 17.960 Melem/s]
                 change:
                        time:   [−11.270% −10.369% −9.4892%] (p = 0.00 < 0.05)
                        thrpt:  [+10.484% +11.569% +12.702%]
                        Performance has improved.
```

### contains_all

```
vrl_stdlib/functions/contains_all/case_sensitive
                        time:   [58.320 ns 58.572 ns 58.901 ns]
                        thrpt:  [16.978 Melem/s 17.073 Melem/s 17.147 Melem/s]
                 change:
                        time:   [−10.723% −10.144% −9.6083%] (p = 0.00 < 0.05)
                        thrpt:  [+10.630% +11.289% +12.011%]
                        Performance has improved.
vrl_stdlib/functions/contains_all/case_insensitive
                        time:   [78.815 ns 80.079 ns 81.745 ns]
                        thrpt:  [12.233 Melem/s 12.488 Melem/s 12.688 Melem/s]
                 change:
                        time:   [−32.477% −27.657% −23.524%] (p = 0.00 < 0.05)
                        thrpt:  [+30.760% +38.231% +48.097%]
                        Performance has improved.
```

### ends_with

```
vrl_stdlib/functions/ends_with/case_sensitive
                        time:   [32.750 ns 33.122 ns 33.556 ns]
                        thrpt:  [29.801 Melem/s 30.191 Melem/s 30.535 Melem/s]
                 change:
                        time:   [−17.446% −16.664% −15.714%] (p = 0.00 < 0.05)
                        thrpt:  [+18.644% +19.997% +21.133%]
                        Performance has improved.
vrl_stdlib/functions/ends_with/case_insensitive
                        time:   [57.567 ns 58.363 ns 59.238 ns]
                        thrpt:  [16.881 Melem/s 17.134 Melem/s 17.371 Melem/s]
                 change:
                        time:   [−4.7430% −3.5296% −2.3262%] (p = 0.00 < 0.05)
                        thrpt:  [+2.3816% +3.6588% +4.9792%]
                        Change within noise threshold.
```

### split

```
vrl_stdlib/functions/split/string
                        time:   [97.414 ns 97.544 ns 97.669 ns]
                        thrpt:  [10.239 Melem/s 10.252 Melem/s 10.266 Melem/s]
                 change:
                        time:   [−6.8591% −6.0057% −5.3581%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6614% +6.3894% +7.3642%]
                        Performance has improved.
vrl_stdlib/functions/split/regex
                        time:   [100.40 ns 101.05 ns 102.09 ns]
                        thrpt:  [9.7952 Melem/s 9.8958 Melem/s 9.9600 Melem/s]
                 change:
                        time:   [−4.9707% −4.6059% −4.1117%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2880% +4.8283% +5.2307%]
                        Change within noise threshold.
```

### parse_json

```
vrl_stdlib/functions/parse_json/map
                        time:   [86.202 ns 86.285 ns 86.363 ns]
                        thrpt:  [11.579 Melem/s 11.590 Melem/s 11.601 Melem/s]
                 change:
                        time:   [−9.1121% −8.2558% −7.5367%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1510% +8.9987% +10.026%]
                        Performance has improved.
```

### truncate

```
vrl_stdlib/functions/truncate/ellipsis
                        time:   [51.877 ns 51.959 ns 52.046 ns]
                        thrpt:  [19.214 Melem/s 19.246 Melem/s 19.277 Melem/s]
                 change:
                        time:   [−9.7180% −9.4334% −9.1434%] (p = 0.00 < 0.05)
                        thrpt:  [+10.064% +10.416% +10.764%]
                        Performance has improved.
vrl_stdlib/functions/truncate/no_suffix
                        time:   [49.554 ns 49.707 ns 49.859 ns]
                        thrpt:  [20.056 Melem/s 20.118 Melem/s 20.180 Melem/s]
                 change:
                        time:   [−12.231% −11.872% −11.517%] (p = 0.00 < 0.05)
                        thrpt:  [+13.016% +13.471% +13.935%]
                        Performance has improved.
```

### chunks

```
vrl_stdlib/functions/chunks/literal
                        time:   [61.683 ns 62.292 ns 62.948 ns]
                        thrpt:  [15.886 Melem/s 16.054 Melem/s 16.212 Melem/s]
                 change:
                        time:   [−11.093% −9.5756% −8.1253%] (p = 0.00 < 0.05)
                        thrpt:  [+8.8439% +10.590% +12.477%]
```

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

```
cargo test
./scripts/vrl_tests.sh
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).