### PR TITLE
Add module documentation to json_utils

### DIFF
--- a/src/stdlib/json_utils/mod.rs
+++ b/src/stdlib/json_utils/mod.rs
@@ -1,2 +1,4 @@
+//! Provides JSON utility modules for BOM handling and type definitions.
+
 pub(crate) mod bom;
 pub(crate) mod json_type_def;


### PR DESCRIPTION
## Problem Background
The `json_utils` module in the VRL standard library lacked documentation comments, which reduced code readability and made maintenance more difficult. Good documentation is essential for open-source projects to help contributors and users understand the codebase.

## Changes Made
Added a module-level documentation comment to `src/stdlib/json_utils/mod.rs` to describe the module's purpose: it provides utility modules for BOM (Byte Order Mark) handling and JSON type definitions. This is a minimal, non-functional change that aligns with Rust documentation best practices.

## Verification
This change is purely additive and does not affect functionality or API. It can be verified by:
- Reviewing the updated code for clarity and correctness.
- Running existing tests (e.g., `cargo test`) to ensure no regressions, as only comments were added.