### PR TITLE
feat(stdlib): allow dynamic regex pattern in parse_regex

### DIFF
--- a/changelog.d/1809.enhancement.md
+++ b/changelog.d/1809.enhancement.md
@@ -1,0 +1,3 @@
+Improved performance of `parse_regex` when using a literal regex pattern in concurrent workloads.
+
+authors: thomasqueirozb

--- a/changelog.d/1809.enhancement.md
+++ b/changelog.d/1809.enhancement.md
@@ -1,3 +1,0 @@
-Improved performance of `parse_regex` when using a literal regex pattern in concurrent workloads.
-
-authors: thomasqueirozb

--- a/changelog.d/1809.feature.md
+++ b/changelog.d/1809.feature.md
@@ -1,0 +1,3 @@
+Added support for dynamic regex patterns in `parse_regex`, allowing variables and runtime expressions to be passed as the `pattern` argument.
+
+authors: thomasqueirozb

--- a/docs/generated/parse_regex.json
+++ b/docs/generated/parse_regex.json
@@ -88,7 +88,8 @@
   ],
   "notices": [
     "VRL aims to provide purpose-specific [parsing functions](/docs/reference/vrl/functions/#parse-functions)\nfor common log formats. Before reaching for the `parse_regex` function, see if a VRL\n[`parse_*` function](/docs/reference/vrl/functions/#parse-functions) already exists\nfor your format. If not, we recommend\n[opening an issue](https://github.com/vectordotdev/vector/issues/new?labels=type%3A+new+feature)\nto request support for the desired format.",
-    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit."
+    "All values are returned as strings. We recommend manually coercing values to desired\ntypes as you see fit.",
+    "When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),\nthe regex is compiled on every function call. For high-throughput pipelines, prefer\na regex literal so the pattern is compiled once at program compile time."
   ],
   "pure": true
 }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use super::{
-    CompileConfig, Span, TypeDef,
+    CompileConfig, Context, Resolved, Span, TypeDef,
     expression::{Block, Container, Expr, Expression, container::Variant},
     state::TypeState,
     value::{Kind, kind},
@@ -378,6 +378,38 @@ impl Parameter {
 
 // -----------------------------------------------------------------------------
 
+/// A value that is either a compile-time constant or a runtime expression.
+///
+/// When `T = regex::Regex`, cloning a `Const` variant allocates a fresh `Pool` per clone so
+/// each worker thread gets its own pool (the underlying NFA/DFA is `Arc`-shared).
+#[derive(Debug, Clone)]
+pub enum ConstOrExpr<T = Value> {
+    /// Value resolved at compile time.
+    Const(T),
+    /// Expression resolved at runtime on every call.
+    Expr(Box<dyn Expression>),
+}
+
+impl ConstOrExpr<Value> {
+    pub fn new(expr: Box<dyn Expression>, state: &TypeState) -> Self {
+        match expr.resolve_constant(state) {
+            Some(cnst) => Self::Const(cnst),
+            None => Self::Expr(expr),
+        }
+    }
+
+    pub fn optional(expr: Option<Box<dyn Expression>>, state: &TypeState) -> Option<Self> {
+        expr.map(|expr| Self::new(expr, state))
+    }
+
+    pub fn resolve(&self, ctx: &mut Context) -> Resolved {
+        match self {
+            Self::Const(value) => Ok(value.clone()),
+            Self::Expr(expr) => expr.resolve(ctx),
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct ArgumentList {
     pub(crate) arguments: HashMap<&'static str, Expr>,
@@ -484,25 +516,24 @@ impl ArgumentList {
         &self,
         keyword: &'static str,
         state: &TypeState,
-    ) -> Result<Option<regex::Regex>, Error> {
-        self.optional_expr(keyword)
-            .map(|expr| match expr.resolve_constant(state) {
-                Some(Value::Regex(regex)) => Ok((*regex).clone()),
-                _ => Err(Error::UnexpectedExpression {
-                    keyword,
-                    expected: "regex",
-                    expr: Box::new(expr),
-                }),
-            })
-            .transpose()
+    ) -> Option<ConstOrExpr<regex::Regex>> {
+        self.optional_expr(keyword).map(|expr| {
+            match expr
+                .resolve_constant(state)
+                .and_then(|v| v.as_regex().cloned())
+            {
+                Some(regex) => ConstOrExpr::Const(regex),
+                None => ConstOrExpr::Expr(Box::new(expr)),
+            }
+        })
     }
 
     pub fn required_regex(
         &self,
         keyword: &'static str,
         state: &TypeState,
-    ) -> Result<regex::Regex, Error> {
-        Ok(required(self.optional_regex(keyword, state)?))
+    ) -> ConstOrExpr<regex::Regex> {
+        required(self.optional_regex(keyword, state))
     }
 
     pub fn optional_object(

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -379,9 +379,6 @@ impl Parameter {
 // -----------------------------------------------------------------------------
 
 /// A value that is either a compile-time constant or a runtime expression.
-///
-/// When `T = regex::Regex`, cloning a `Const` variant allocates a fresh `Pool` per clone so
-/// each worker thread gets its own pool (the underlying NFA/DFA is `Arc`-shared).
 #[derive(Debug, Clone)]
 pub enum ConstOrExpr<T = Value> {
     /// Value resolved at compile time.
@@ -512,6 +509,9 @@ impl ArgumentList {
         Ok(required(self.optional_query(keyword)?))
     }
 
+    /// Cloning a `Const` variant allocates a fresh `Pool` per clone so each worker thread gets its
+    /// own pool (the underlying NFA/DFA is `Arc`-shared). A shared `Arc<Regex>` would collapse all
+    /// workers onto one pool, routing all but one through the slow path.
     pub fn optional_regex(
         &self,
         keyword: &'static str,

--- a/src/compiler/prelude.rs
+++ b/src/compiler/prelude.rs
@@ -21,7 +21,10 @@ pub use super::Resolved;
 pub use super::{
     Context, Expression, ExpressionError, ExpressionExt, Function, FunctionExpression, Parameter,
     TimeZone, TypeDef, expression,
-    function::{self, ArgumentList, Closure, Compiled, Example, FunctionCompileContext, closure},
+    function::{
+        self, ArgumentList, Closure, Compiled, ConstOrExpr, Example, FunctionCompileContext,
+        closure,
+    },
     state::{self, TypeInfo, TypeState},
     type_def,
     value::{ValueError, VrlValueArithmetic, VrlValueConvert, kind},

--- a/src/stdlib/object_from_array.rs
+++ b/src/stdlib/object_from_array.rs
@@ -1,4 +1,3 @@
-use super::util::ConstOrExpr;
 use crate::compiler::prelude::*;
 
 fn make_object_1(values: Vec<Value>) -> Resolved {

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -79,6 +79,11 @@ impl Function for ParseRegex {
                 All values are returned as strings. We recommend manually coercing values to desired
                 types as you see fit.
             "},
+            indoc! {"
+                When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
+                the regex is compiled on every function call. For high-throughput pipelines, prefer
+                a regex literal so the pattern is compiled once at program compile time.
+            "},
         ]
     }
 
@@ -93,7 +98,7 @@ impl Function for ParseRegex {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern = arguments.required_regex("pattern", state)?;
+        let pattern = arguments.required_regex("pattern", state);
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexFn {
@@ -156,7 +161,7 @@ impl Function for ParseRegex {
 #[derive(Debug, Clone)]
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
-    pattern: Regex,
+    pattern: ConstOrExpr<Regex>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -165,14 +170,28 @@ impl FunctionExpression for ParseRegexFn {
         let value = self.value.resolve(ctx)?;
         let numeric_groups = self
             .numeric_groups
-            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?;
-        let pattern = &self.pattern;
+            .map_resolve_with_default(ctx, || DEFAULT_NUMERIC_GROUPS.clone())?
+            .try_boolean()?;
 
-        parse_regex(&value, numeric_groups.try_boolean()?, pattern)
+        match &self.pattern {
+            ConstOrExpr::Const(pattern) => parse_regex(&value, numeric_groups, pattern),
+            ConstOrExpr::Expr(expr) => {
+                let resolved = expr.resolve(ctx)?;
+                let pattern = resolved
+                    .as_regex()
+                    .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
+                parse_regex(&value, numeric_groups, pattern)
+            }
+        }
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::object(util::regex_kind(&self.pattern)).fallible()
+        match &self.pattern {
+            ConstOrExpr::Const(regex) => TypeDef::object(util::regex_kind(regex)).fallible(),
+            ConstOrExpr::Expr(_) => {
+                TypeDef::object(Collection::from_unknown(Kind::bytes() | Kind::null())).fallible()
+            }
+        }
     }
 }
 

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -79,11 +79,7 @@ impl Function for ParseRegex {
                 All values are returned as strings. We recommend manually coercing values to desired
                 types as you see fit.
             "},
-            indoc! {"
-                When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
-                the regex is compiled on every function call. For high-throughput pipelines, prefer
-                a regex literal so the pattern is compiled once at program compile time.
-            "},
+            util::DYNAMIC_REGEX_NOTICE,
         ]
     }
 

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -99,19 +99,8 @@ impl Function for ParseRegexAll {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        let pattern_expr = arguments.required("pattern");
+        let pattern = arguments.required_regex("pattern", state);
         let numeric_groups = arguments.optional("numeric_groups");
-
-        // Clone literal regexes so each worker gets its own `Pool` (the compiled
-        // NFA/DFA is Arc-shared). A shared `Arc<Regex>` would collapse all workers
-        // onto one Pool, routing all but one through the slow path.
-        let pattern = match pattern_expr
-            .resolve_constant(state)
-            .and_then(|v| v.as_regex().cloned())
-        {
-            Some(regex) => PatternSource::Constant(regex),
-            None => PatternSource::Expression(pattern_expr),
-        };
 
         Ok(ParseRegexAllFn {
             value,
@@ -175,18 +164,9 @@ impl Function for ParseRegexAll {
 }
 
 #[derive(Debug, Clone)]
-enum PatternSource {
-    /// Literal regex pattern held by value. `Regex::clone` allocates a fresh
-    /// Pool per clone — see comment in `ParseRegexAll::compile`.
-    Constant(Regex),
-    /// Pattern resolved from an expression on every call.
-    Expression(Box<dyn Expression>),
-}
-
-#[derive(Debug, Clone)]
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
-    pattern: PatternSource,
+    pattern: ConstOrExpr<Regex>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -199,8 +179,8 @@ impl FunctionExpression for ParseRegexAllFn {
             .try_boolean()?;
 
         match &self.pattern {
-            PatternSource::Constant(pattern) => parse_regex_all(&value, numeric_groups, pattern),
-            PatternSource::Expression(expr) => {
+            ConstOrExpr::Const(pattern) => parse_regex_all(&value, numeric_groups, pattern),
+            ConstOrExpr::Expr(expr) => {
                 let resolved = expr.resolve(ctx)?;
                 let pattern = resolved
                     .as_regex()
@@ -212,11 +192,11 @@ impl FunctionExpression for ParseRegexAllFn {
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
         match &self.pattern {
-            PatternSource::Constant(regex) => TypeDef::array(Collection::from_unknown(
+            ConstOrExpr::Const(regex) => TypeDef::array(Collection::from_unknown(
                 Kind::object(util::regex_kind(regex)).or_null(),
             ))
             .fallible(),
-            PatternSource::Expression(_) => TypeDef::array(Collection::from_unknown(
+            ConstOrExpr::Expr(_) => TypeDef::array(Collection::from_unknown(
                 Kind::object(Collection::from_unknown(Kind::bytes() | Kind::null())).or_null(),
             ))
             .fallible(),

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -80,11 +80,7 @@ impl Function for ParseRegexAll {
                 All values are returned as strings. We recommend manually coercing values to desired
                 types as you see fit.
             "},
-            indoc! {"
-                When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
-                the regex is compiled on every function call. For high-throughput pipelines, prefer
-                a regex literal so the pattern is compiled once at program compile time.
-            "},
+            util::DYNAMIC_REGEX_NOTICE,
         ]
     }
 

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -5,7 +5,6 @@ cfg_if::cfg_if! {
     }
 }
 
-use crate::compiler::{Context, Expression, Resolved, TypeState};
 use crate::value::{KeyString, ObjectMap, Value};
 
 #[cfg(feature = "enable_network_functions")]
@@ -107,32 +106,6 @@ impl Base64Charset {
             b"standard" => Ok(Self::Standard),
             b"url_safe" => Ok(Self::UrlSafe),
             _ => Err("unknown charset"),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(super) enum ConstOrExpr {
-    Const(Value),
-    Expr(Box<dyn Expression>),
-}
-
-impl ConstOrExpr {
-    pub(super) fn new(expr: Box<dyn Expression>, state: &TypeState) -> Self {
-        match expr.resolve_constant(state) {
-            Some(cnst) => Self::Const(cnst),
-            None => Self::Expr(expr),
-        }
-    }
-
-    pub(super) fn optional(expr: Option<Box<dyn Expression>>, state: &TypeState) -> Option<Self> {
-        expr.map(|expr| Self::new(expr, state))
-    }
-
-    pub(super) fn resolve(&self, ctx: &mut Context) -> Resolved {
-        match self {
-            Self::Const(value) => Ok(value.clone()),
-            Self::Expr(expr) => expr.resolve(ctx),
         }
     }
 }

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -7,6 +7,12 @@ cfg_if::cfg_if! {
 
 use crate::value::{KeyString, ObjectMap, Value};
 
+pub(crate) const DYNAMIC_REGEX_NOTICE: &str = indoc::indoc! {"
+    When `pattern` is a dynamic expression (e.g. a variable or the result of `to_regex`),
+    the regex is compiled on every function call. For high-throughput pipelines, prefer
+    a regex literal so the pattern is compiled once at program compile time.
+"};
+
 #[cfg(feature = "enable_network_functions")]
 pub(crate) const NETWORK_CALL_NOTICE: &str = indoc::indoc! {"
     This function performs synchronous blocking operations and is not recommended for

--- a/src/stdlib/zip.rs
+++ b/src/stdlib/zip.rs
@@ -1,4 +1,3 @@
-use super::util::ConstOrExpr;
 use crate::compiler::prelude::*;
 
 fn zip2(value0: Value, value1: Value) -> Resolved {


### PR DESCRIPTION
## Summary

Adds support for dynamic regex patterns (variables, runtime expressions) as the `pattern` argument to `parse_regex`, matching the existing behavior of `parse_regex_all`.

Also generalizes `ConstOrExpr` from `stdlib/util` into `compiler/function` as a generic `ConstOrExpr<T>` (defaulting to `Value`), replacing the ad-hoc `PatternSource` enum from #1798. `required_regex` on `ArgumentList` now returns `ConstOrExpr<Regex>` directly.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing unit tests cover the literal pattern path. Benchmarks (`parse_regex_concurrent/8_threads`) confirm no regression on the hot path.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Follows up on #1798.
- Reimplements: #1774
- Related: #1789