### PR TITLE
refactor(stdlib): replace local IpCidrType enum with ConstOrExpr in ip_cidr_contains

### DIFF
--- a/src/stdlib/ip_cidr_contains.rs
+++ b/src/stdlib/ip_cidr_contains.rs
@@ -137,8 +137,8 @@ impl Function for IpCidrContains {
         let cidr = arguments.required("cidr");
 
         let cidr = match cidr.resolve_constant(state) {
-            None => IpCidrType::Expression(cidr),
-            Some(value) => IpCidrType::Constant(match value {
+            None => ConstOrExpr::Expr(cidr),
+            Some(value) => ConstOrExpr::Const(match value {
                 Value::Bytes(_) => vec![value_to_cidr(&value)?],
                 Value::Array(vec) => {
                     let mut output = Vec::with_capacity(vec.len());
@@ -165,14 +165,8 @@ impl Function for IpCidrContains {
 }
 
 #[derive(Debug, Clone)]
-enum IpCidrType {
-    Constant(Vec<IpCidr>),
-    Expression(Box<dyn Expression>),
-}
-
-#[derive(Debug, Clone)]
 struct IpCidrContainsFn {
-    cidr: IpCidrType,
+    cidr: ConstOrExpr<Vec<IpCidr>>,
     value: Box<dyn Expression>,
 }
 
@@ -181,9 +175,9 @@ impl FunctionExpression for IpCidrContainsFn {
         let value = self.value.resolve(ctx)?;
 
         match &self.cidr {
-            IpCidrType::Constant(cidr_vec) => ip_cidr_contains_constant(&value, cidr_vec),
-            IpCidrType::Expression(exp) => {
-                let cidr = exp.resolve(ctx)?;
+            ConstOrExpr::Const(cidr_vec) => ip_cidr_contains_constant(&value, cidr_vec),
+            ConstOrExpr::Expr(expr) => {
+                let cidr = expr.resolve(ctx)?;
                 ip_cidr_contains(&value, &cidr)
             }
         }


### PR DESCRIPTION
## Summary

Replaces the local `IpCidrType` enum in `ip_cidr_contains` with the shared `ConstOrExpr` type, following the pattern introduced in #1809.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Existing tests cover the behaviour unchanged.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- #1809