### PR TITLE
perf(stdlib): pre-compute capture info and use index-based lookup in parse_regex/parse_regex_all

### DIFF
--- a/changelog.d/1811.enhancement.md
+++ b/changelog.d/1811.enhancement.md
@@ -1,0 +1,3 @@
+Improved performance of `parse_regex` and `parse_regex_all` by pre-computing capture group names and indices at compile time, replacing name-based hash lookups with direct index-based access at runtime.
+
+authors: thomasqueirozb

--- a/src/stdlib/parse_regex.rs
+++ b/src/stdlib/parse_regex.rs
@@ -21,11 +21,16 @@ contains the whole match.",
     .default(&DEFAULT_NUMERIC_GROUPS),
 ];
 
-fn parse_regex(value: &Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
+fn parse_regex(
+    value: &Value,
+    pattern: &Regex,
+    capture_info: &[(KeyString, usize)],
+    numeric_groups: bool,
+) -> Resolved {
     let value = value.try_bytes_utf8_lossy()?;
     let parsed = pattern
         .captures(&value)
-        .map(|capture| util::capture_regex_to_map(pattern, &capture, numeric_groups))
+        .map(|capture| util::capture_regex_to_map(&capture, capture_info, numeric_groups))
         .ok_or("could not find any pattern matches")?;
     Ok(parsed.into())
 }
@@ -95,11 +100,16 @@ impl Function for ParseRegex {
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern", state);
+        let capture_info = match &pattern {
+            ConstOrExpr::Const(r) => Some(util::build_capture_info(r)),
+            ConstOrExpr::Expr(_) => None,
+        };
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexFn {
             value,
             pattern,
+            capture_info,
             numeric_groups,
         }
         .as_expr())
@@ -158,6 +168,7 @@ impl Function for ParseRegex {
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
     pattern: ConstOrExpr<Regex>,
+    capture_info: Option<Vec<(crate::value::KeyString, usize)>>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -170,13 +181,20 @@ impl FunctionExpression for ParseRegexFn {
             .try_boolean()?;
 
         match &self.pattern {
-            ConstOrExpr::Const(pattern) => parse_regex(&value, numeric_groups, pattern),
+            ConstOrExpr::Const(pattern) => {
+                let capture_info = self
+                    .capture_info
+                    .as_deref()
+                    .expect("capture_info always set for Const pattern");
+                parse_regex(&value, pattern, capture_info, numeric_groups)
+            }
             ConstOrExpr::Expr(expr) => {
                 let resolved = expr.resolve(ctx)?;
                 let pattern = resolved
                     .as_regex()
                     .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
-                parse_regex(&value, numeric_groups, pattern)
+                let dynamic_capture_info = util::build_capture_info(pattern);
+                parse_regex(&value, pattern, &dynamic_capture_info, numeric_groups)
             }
         }
     }

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -22,11 +22,16 @@ contains the whole match.",
     .default(&DEFAULT_NUMERIC_GROUPS),
 ];
 
-fn parse_regex_all(value: &Value, numeric_groups: bool, pattern: &Regex) -> Resolved {
+fn parse_regex_all(
+    value: &Value,
+    pattern: &Regex,
+    capture_info: &[(crate::value::KeyString, usize)],
+    numeric_groups: bool,
+) -> Resolved {
     let value = value.try_bytes_utf8_lossy()?;
     Ok(pattern
         .captures_iter(&value)
-        .map(|capture| util::capture_regex_to_map(pattern, &capture, numeric_groups).into())
+        .map(|capture| util::capture_regex_to_map(&capture, capture_info, numeric_groups).into())
         .collect::<Vec<Value>>()
         .into())
 }
@@ -96,11 +101,16 @@ impl Function for ParseRegexAll {
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern", state);
+        let capture_info = match &pattern {
+            ConstOrExpr::Const(r) => Some(util::build_capture_info(r)),
+            ConstOrExpr::Expr(_) => None,
+        };
         let numeric_groups = arguments.optional("numeric_groups");
 
         Ok(ParseRegexAllFn {
             value,
             pattern,
+            capture_info,
             numeric_groups,
         }
         .as_expr())
@@ -163,6 +173,7 @@ impl Function for ParseRegexAll {
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
     pattern: ConstOrExpr<Regex>,
+    capture_info: Option<Vec<(crate::value::KeyString, usize)>>,
     numeric_groups: Option<Box<dyn Expression>>,
 }
 
@@ -175,13 +186,20 @@ impl FunctionExpression for ParseRegexAllFn {
             .try_boolean()?;
 
         match &self.pattern {
-            ConstOrExpr::Const(pattern) => parse_regex_all(&value, numeric_groups, pattern),
+            ConstOrExpr::Const(pattern) => {
+                let capture_info = self
+                    .capture_info
+                    .as_deref()
+                    .expect("capture_info always set for Const pattern");
+                parse_regex_all(&value, pattern, capture_info, numeric_groups)
+            }
             ConstOrExpr::Expr(expr) => {
                 let resolved = expr.resolve(ctx)?;
                 let pattern = resolved
                     .as_regex()
                     .ok_or_else(|| ExpressionError::from("failed to resolve regex"))?;
-                parse_regex_all(&value, numeric_groups, pattern)
+                let dynamic_capture_info = util::build_capture_info(pattern);
+                parse_regex_all(&value, pattern, &dynamic_capture_info, numeric_groups)
             }
         }
     }

--- a/src/stdlib/util.rs
+++ b/src/stdlib/util.rs
@@ -32,23 +32,32 @@ where
     fun(num * multiplier) / multiplier
 }
 
-/// Takes a set of captures that have resulted from matching a regular expression
-/// against some text and fills a `BTreeMap` with the result.
+pub(crate) fn build_capture_info(regex: &regex::Regex) -> Vec<(KeyString, usize)> {
+    regex
+        .capture_names()
+        .enumerate()
+        .filter_map(|(i, name)| name.map(|n| (KeyString::from(n), i)))
+        .collect()
+}
+
+/// Fills an [`ObjectMap`] from a regex [`Captures`](regex::Captures).
 ///
-/// All captures are inserted with a key as the numeric index of that capture
-/// "0" is the overall match.
-/// Any named captures are also added to the Map with the key as the name.
+/// Named captures are inserted under their group name; numeric groups (when
+/// `numeric_groups` is `true`) are inserted under their zero-based index, with
+/// `"0"` holding the full match.
 ///
+/// `capture_info` must be the pre-computed `(name, group_index)` slice
+/// (computed once at VRL compile time).  Group indices allow direct O(1)
+/// array access via [`regex::Captures::get`] instead of name-based hash
+/// lookups.
 pub(crate) fn capture_regex_to_map(
-    regex: &regex::Regex,
     capture: &regex::Captures,
+    capture_info: &[(KeyString, usize)],
     numeric_groups: bool,
 ) -> ObjectMap {
-    let names = regex.capture_names().flatten().map(|name| {
-        (
-            name.to_owned().into(),
-            capture.name(name).map(|s| s.as_str()).into(),
-        )
+    let names = capture_info.iter().map(|(name, idx)| {
+        let value: Value = capture.get(*idx).map(|m| m.as_str()).into();
+        (name.clone(), value)
     });
 
     if numeric_groups {


### PR DESCRIPTION
## Summary

Re-implements the performance improvements from #1773 (reverted in #1789) on top of the current codebase which already has the `ConstOrExpr<Regex>` architecture from the subsequent dynamic pattern rework.

Named capture group info (name + index) is pre-computed once at VRL compile time for constant patterns and stored in the function node. At runtime, `capture.get(idx)` is used instead of `capture.name(name)`, replacing a hash lookup with a direct array access.

Benchmarks vs `main`:

| Benchmark | Median Time | Throughput | Time Change | Result |
|---|---|---|---|---|
| `parse_regex/matches` | 2.727 µs | +8.77% | −8.07% | Improved |
| `parse_regex/single_match` | 210.76 ns | +14.31% | −12.52% | Improved |
| `parse_regex/large_input_small_captures` | 294.85 ns | +10.82% | −9.76% | Improved |
| `parse_regex/large_input` | 4.4548 µs | −1.43% | +1.45% | Within noise |
| `parse_regex_all/matches` | 959.08 ns | +7.30% | −6.80% | Improved |
| `parse_regex_all/all_matches` | 516.93 ns | +14.02% | −12.29% | Improved |
| `parse_regex_all/large_input_small_captures` | 342.23 ns | +9.20% | −8.42% | Improved |
| `parse_regex_all/large_input` | 4.3848 µs | +4.70% | −4.49% | Within noise |
| `parse_regex_concurrent/8_threads` | 2.8052 µs | +6.56% | −6.16% | Within noise |
| `parse_regex_all_concurrent/8_threads` | 2.9758 µs | +16.59% | −14.23% | Improved |


No regressions in the concurrent benchmarks (the original reason for the revert).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

All existing tests pass. Benchmarked against `main` using criterion with `--baseline`.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Re-implements #1773
- Reverted in #1789