### PR TITLE
fix(stdlib): pop also removes last item from type definition

### DIFF
--- a/src/stdlib/pop.rs
+++ b/src/stdlib/pop.rs
@@ -72,10 +72,19 @@ impl FunctionExpression for PopFn {
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
-        self.value
+        let mut typedef = self.value
             .type_def(state)
             .fallible_unless(Kind::array(Collection::any()))
-            .restrict_array()
+            .restrict_array();
+
+        // Remove last element from type definition if array contains just know elements
+        if let Some(col) = typedef.kind_mut().as_array_mut() {
+            if col.unknown_kind().is_undefined() {
+                col.known_mut().pop_last();
+            }
+        }
+
+        typedef
     }
 }
 
@@ -108,7 +117,6 @@ mod tests {
                 Index::from(2) => Kind::integer(),
                 Index::from(3) => Kind::boolean(),
                 Index::from(4) => Kind::float(),
-                Index::from(5) => Kind::bytes(),
             }),
         }
 
@@ -119,9 +127,7 @@ mod tests {
                 Index::from(0) => Kind::integer(),
                 Index::from(1) => Kind::integer(),
                 Index::from(2) => Kind::integer(),
-                Index::from(3) => Kind::integer(),
             }),
         }
-
     ];
 }


### PR DESCRIPTION
## Summary

### Before

```
$ int(pop([1,2,3])[2])
function call error for "int" at (0:20): expected integer, got null
```

### After

```
$ int(pop([1,2,3])[2])

error[E100]: unhandled error
  ┌─ :1:1
  │
1 │ int(pop([1,2,3])[2])
  │ ^^^^^^^^^^^^^^^^^^^^
  │ │
  │ expression can result in runtime error
  │ handle the error case to ensure runtime success
  │
  = see documentation about error handling at https://errors.vrl.dev/#handling
  = learn more about error code 100 at https://errors.vrl.dev/100
  = see language documentation at https://vrl.dev
  = try your code in the VRL REPL, learn more at https://vrl.dev/examples
```

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

```
cargo test
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).