### PR TITLE
chore(deps): remove dependency to deprecated crate sha-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,17 +3405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,7 +4333,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serde_yaml_ng",
- "sha-1",
+ "sha1",
  "sha2",
  "sha3",
  "simdutf8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,9 +110,9 @@ enable_crypto_functions = [
   "dep:md-5",
   "dep:ofb",
   "dep:seahash",
-  "dep:sha-1",
-  "dep:sha-2",
-  "dep:sha-3",
+  "dep:sha1",
+  "dep:sha2",
+  "dep:sha3",
   "dep:xxhash-rust",
   "dep:crc",
 ]
@@ -247,9 +247,9 @@ serde_json = { version = "1", default-features = false, optional = true, feature
 serde_yaml_ng = { version = "0.10.0" }
 simdutf8 = { version = "0.1.5", optional = true }
 fancy-regex = { version = "0.17", default-features = false, optional = true }
-sha-1 = { version = "0.10", optional = true }
-sha-2 = { package = "sha2", version = "0.10", optional = true }
-sha-3 = { package = "sha3", version = "0.10", optional = true }
+sha1 = { version = "0.10", optional = true }
+sha2 = { version = "0.10", optional = true }
+sha3 = { version = "0.10", optional = true }
 strip-ansi-escapes = { version = "0.2", optional = true }
 snap = { version = "1", optional = true }
 syslog_loose = { version = "0.22", optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -292,7 +292,6 @@ serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaa
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_urlencoded,https://github.com/nox/serde_urlencoded,MIT OR Apache-2.0,Anthony Ramine <n.oxyde@gmail.com>
 serde_yaml_ng,https://github.com/acatton/serde-yaml-ng,MIT,Antoine Catton <devel@antoine.catton.fr>
-sha-1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha2,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha3,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers

--- a/src/stdlib/hmac.rs
+++ b/src/stdlib/hmac.rs
@@ -1,7 +1,7 @@
 use crate::compiler::function::EnumVariant;
 use crate::compiler::prelude::*;
 use hmac::{Hmac as HmacHasher, Mac};
-use sha_2::{Sha224, Sha256, Sha384, Sha512};
+use sha2::{Sha224, Sha256, Sha384, Sha512};
 use sha1::Sha1;
 
 macro_rules! hmac {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -500,9 +500,9 @@ cfg_if::cfg_if! {
             #[cfg(feature = "enable_crypto_functions")]
             self::xxhash::Xxhash,
             #[cfg(feature = "enable_crypto_functions")]
-            sha2::Sha2,
+            self::sha2::Sha2,
             #[cfg(feature = "enable_crypto_functions")]
-            sha3::Sha3,
+            self::sha3::Sha3,
         }
 
         #[cfg(feature = "enable_system_functions")]

--- a/src/stdlib/redact.rs
+++ b/src/stdlib/redact.rs
@@ -437,16 +437,16 @@ impl Redactor {
                         .ok_or("`variant` must be a string")?
                         .as_ref()
                     {
-                        b"SHA-224" => encoded_hash::<sha_2::Sha224>,
-                        b"SHA-256" => encoded_hash::<sha_2::Sha256>,
-                        b"SHA-384" => encoded_hash::<sha_2::Sha384>,
-                        b"SHA-512" => encoded_hash::<sha_2::Sha512>,
-                        b"SHA-512/224" => encoded_hash::<sha_2::Sha512_224>,
-                        b"SHA-512/256" => encoded_hash::<sha_2::Sha512_256>,
+                        b"SHA-224" => encoded_hash::<sha2::Sha224>,
+                        b"SHA-256" => encoded_hash::<sha2::Sha256>,
+                        b"SHA-384" => encoded_hash::<sha2::Sha384>,
+                        b"SHA-512" => encoded_hash::<sha2::Sha512>,
+                        b"SHA-512/224" => encoded_hash::<sha2::Sha512_224>,
+                        b"SHA-512/256" => encoded_hash::<sha2::Sha512_256>,
                         _ => return Err("invalid sha2 variant"),
                     }
                 } else {
-                    encoded_hash::<sha_2::Sha512_256>
+                    encoded_hash::<sha2::Sha512_256>
                 };
                 let encoder = obj
                     .get("encoding")
@@ -463,14 +463,14 @@ impl Redactor {
                         .ok_or("`variant must be a string")?
                         .as_ref()
                     {
-                        b"SHA3-224" => encoded_hash::<sha_3::Sha3_224>,
-                        b"SHA3-256" => encoded_hash::<sha_3::Sha3_256>,
-                        b"SHA3-384" => encoded_hash::<sha_3::Sha3_384>,
-                        b"SHA3-512" => encoded_hash::<sha_3::Sha3_512>,
+                        b"SHA3-224" => encoded_hash::<sha3::Sha3_224>,
+                        b"SHA3-256" => encoded_hash::<sha3::Sha3_256>,
+                        b"SHA3-384" => encoded_hash::<sha3::Sha3_384>,
+                        b"SHA3-512" => encoded_hash::<sha3::Sha3_512>,
                         _ => return Err("invalid sha2 variant"),
                     }
                 } else {
-                    encoded_hash::<sha_3::Sha3_512>
+                    encoded_hash::<sha3::Sha3_512>
                 };
                 let encoder = obj
                     .get("encoding")
@@ -509,12 +509,12 @@ impl TryFrom<Value> for Redactor {
                 b"full" => Ok(Redactor::Full),
                 #[cfg(feature = "enable_crypto_functions")]
                 b"sha2" => Ok(Redactor::Hash {
-                    hasher: encoded_hash::<sha_2::Sha512_256>,
+                    hasher: encoded_hash::<sha2::Sha512_256>,
                     encoder: Encoder::Base64,
                 }),
                 #[cfg(feature = "enable_crypto_functions")]
                 b"sha3" => Ok(Redactor::Hash {
-                    hasher: encoded_hash::<sha_3::Sha3_512>,
+                    hasher: encoded_hash::<sha3::Sha3_512>,
                     encoder: Encoder::Base64,
                 }),
                 _ => Err("unknown name of redactor"),

--- a/src/stdlib/sha2.rs
+++ b/src/stdlib/sha2.rs
@@ -1,7 +1,7 @@
 use crate::compiler::function::EnumVariant;
 use crate::compiler::prelude::*;
 use crate::value;
-use sha_2::{Digest, Sha224, Sha256, Sha384, Sha512, Sha512_224, Sha512_256};
+use sha2::{Digest, Sha224, Sha256, Sha384, Sha512, Sha512_224, Sha512_256};
 
 static DEFAULT_VARIANT: Value = Value::Bytes(Bytes::from_static("SHA-512/256".as_bytes()));
 

--- a/src/stdlib/sha3.rs
+++ b/src/stdlib/sha3.rs
@@ -1,7 +1,7 @@
 use crate::compiler::function::EnumVariant;
 use crate::compiler::prelude::*;
 use crate::value;
-use sha_3::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512};
+use sha3::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 
 static DEFAULT_VARIANT: Value = Value::Bytes(Bytes::from_static("SHA3-512".as_bytes()));
 


### PR DESCRIPTION
## Summary

Just code cleanup.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

```
cargo test
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).