### PR TITLE
perf(value): back KeyString with SmolStr for zero-alloc inline key storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "snafu"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +4332,7 @@ dependencies = [
  "sha2",
  "sha3",
  "simdutf8",
+ "smol_str",
  "snafu 0.8.9",
  "snap",
  "strip-ansi-escapes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,11 +3470,11 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
 serde_yaml_ng = { version = "0.10.0" }
 simdutf8 = { version = "0.1.5", optional = true }
+smol_str = { version = "0.2", features = ["serde"] }
 fancy-regex = { version = "0.17", default-features = false, optional = true }
 sha1 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,7 +246,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std", "raw_value"] }
 serde_yaml_ng = { version = "0.10.0" }
 simdutf8 = { version = "0.1.5", optional = true }
-smol_str = { version = "0.2", features = ["serde"] }
+smol_str = { version = "0.3", default-features = false, features = ["serde"] }
 fancy-regex = { version = "0.17", default-features = false, optional = true }
 sha1 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -300,7 +300,7 @@ simdutf8,https://github.com/rusticstuff/simdutf8,MIT OR Apache-2.0,Hans Kratz <h
 siphasher,https://github.com/jedisct1/rust-siphash,MIT OR Apache-2.0,Frank Denis <github@pureftpd.org>
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
-smol_str,https://github.com/rust-analyzer/smol_str,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
+smol_str,https://github.com/rust-lang/rust-analyzer/tree/master/lib/smol_str,MIT OR Apache-2.0,"Aleksey Kladov <aleksey.kladov@gmail.com>, Lukas Wirth <lukastw97@gmail.com>"
 snafu,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 snafu-derive,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 snap,https://github.com/BurntSushi/rust-snappy,BSD-3-Clause,Andrew Gallant <jamslam@gmail.com>

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -300,6 +300,7 @@ simdutf8,https://github.com/rusticstuff/simdutf8,MIT OR Apache-2.0,Hans Kratz <h
 siphasher,https://github.com/jedisct1/rust-siphash,MIT OR Apache-2.0,Frank Denis <github@pureftpd.org>
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
+smol_str,https://github.com/rust-analyzer/smol_str,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
 snafu,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 snafu-derive,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 snap,https://github.com/BurntSushi/rust-snappy,BSD-3-Clause,Andrew Gallant <jamslam@gmail.com>

--- a/changelog.d/1825.enhancement.md
+++ b/changelog.d/1825.enhancement.md
@@ -1,0 +1,3 @@
+Improved performance of VRL programs that read and write event fields.
+
+authors: thomasqueirozb

--- a/src/value/keystring.rs
+++ b/src/value/keystring.rs
@@ -2,20 +2,23 @@ use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 
-/// The key type value. This is a simple zero-overhead wrapper set up to make it explicit that
-/// object keys are read-only and their underlying type is opaque and may change for efficiency.
+/// The key type for event objects. Backed by [`SmolStr`] so that strings up to
+/// 22 bytes are stored inline (no heap allocation). Every capture-group name in
+/// a typical regex (e.g. "host", "user", "timestamp") fits inline, making
+/// `clone()` a plain 24-byte stack copy — no malloc, no atomic ops.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
 #[serde(transparent)]
-pub struct KeyString(String);
+pub struct KeyString(SmolStr);
 
 impl KeyString {
     /// Convert the key into a boxed slice of bytes (`u8`).
     #[inline]
     #[must_use]
     pub fn into_bytes(self) -> Box<[u8]> {
-        self.0.into_bytes().into()
+        self.0.as_bytes().to_vec().into_boxed_slice()
     }
 
     /// Is this string empty?
@@ -36,7 +39,7 @@ impl KeyString {
     #[inline]
     #[must_use]
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
@@ -48,50 +51,50 @@ impl Display for KeyString {
 
 impl AsRef<str> for KeyString {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
 impl std::ops::Deref for KeyString {
     type Target = str;
     fn deref(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
 impl std::borrow::Borrow<str> for KeyString {
     fn borrow(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
 impl PartialEq<str> for KeyString {
     fn eq(&self, that: &str) -> bool {
-        self.0[..].eq(that)
+        self.0.as_str() == that
     }
 }
 
 impl From<&str> for KeyString {
     fn from(s: &str) -> Self {
-        Self(s.into())
+        Self(SmolStr::new(s))
     }
 }
 
 impl From<String> for KeyString {
     fn from(s: String) -> Self {
-        Self(s)
+        Self(SmolStr::new(s.as_str()))
     }
 }
 
 impl From<Cow<'_, str>> for KeyString {
     fn from(s: Cow<'_, str>) -> Self {
-        Self(s.into())
+        Self(SmolStr::new(s.as_ref()))
     }
 }
 
 impl From<KeyString> for String {
     fn from(s: KeyString) -> Self {
-        s.0
+        s.0.as_str().to_owned()
     }
 }
 
@@ -102,7 +105,7 @@ impl quickcheck::Arbitrary for KeyString {
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        let s = self.0.clone();
+        let s = self.0.as_str().to_string();
         Box::new(s.shrink().map(Into::into))
     }
 }
@@ -122,7 +125,7 @@ mod lua {
 
     impl IntoLua for KeyString {
         fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
-            self.0.into_lua(lua)
+            self.0.as_str().to_owned().into_lua(lua)
         }
     }
 }

--- a/src/value/keystring.rs
+++ b/src/value/keystring.rs
@@ -9,7 +9,6 @@ use smol_str::SmolStr;
 /// a typical regex (e.g. "host", "user", "timestamp") fits inline, making
 /// `clone()` a plain 24-byte stack copy — no malloc, no atomic ops.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
 #[serde(transparent)]
 pub struct KeyString(SmolStr);
 
@@ -107,6 +106,19 @@ impl quickcheck::Arbitrary for KeyString {
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         let s = self.0.as_str().to_string();
         Box::new(s.shrink().map(Into::into))
+    }
+}
+
+#[cfg(any(test, feature = "proptest"))]
+impl proptest::arbitrary::Arbitrary for KeyString {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        use proptest::prelude::Strategy;
+        proptest::arbitrary::any::<String>()
+            .prop_map(KeyString::from)
+            .boxed()
     }
 }
 

--- a/src/value/value/crud/insert.rs
+++ b/src/value/value/crud/insert.rs
@@ -13,11 +13,10 @@ pub fn insert<'a, T: ValueCollection>(
     match path_iter.next() {
         Some(BorrowedSegment::Field(field)) => {
             if let Some(Value::Object(map)) = value.get_mut_value(key.borrow()) {
-                insert(map, field.to_string().into(), path_iter, insert_value)
+                insert(map, field.into(), path_iter, insert_value)
             } else {
                 let mut map = BTreeMap::new();
-                let prev_value =
-                    insert(&mut map, field.to_string().into(), path_iter, insert_value);
+                let prev_value = insert(&mut map, field.into(), path_iter, insert_value);
                 value.insert_value(key, Value::Object(map));
                 prev_value
             }


### PR DESCRIPTION
## Summary

`KeyString` is now backed by [`SmolStr`](https://docs.rs/smol_str) instead of `String`. Strings up to 22 bytes are stored inline in the struct (no heap allocation). All common event key names (regex capture group names, log field names like `message`/`host`/`timestamp`) fit within that limit, so `clone()` becomes a plain 24-byte stack copy instead of a `malloc` + `memcpy`.

Benchmarked on two Vector [test harness](https://github.com/vectordotdev/vector-test-harness) workloads (5x c5.large producers -> 1x c5.large subject -> consumer, 60s measurement window):

| Benchmark | Before | After | Delta |
|---|---|---|---|
| [regex_parsing_performance](https://github.com/vectordotdev/vector-test-harness/tree/master/cases/regex_parsing_performance) | 18.3 MiB/s | 20.5 MiB/s | +12% |
| [real_world_1_performance](https://github.com/vectordotdev/vector-test-harness/tree/master/cases/real_world_1_performance) | 18.2 MiB/s | 19.7 MiB/s | +8% |

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Ran the Vector [regex_parsing_performance](https://github.com/vectordotdev/vector-test-harness/tree/master/cases/regex_parsing_performance) and [real_world_1_performance](https://github.com/vectordotdev/vector-test-harness/tree/master/cases/real_world_1_performance) integration benchmarks (5x c5.large producers -> 1x c5.large Vector -> consumer, 60s measurement window). Confirmed all existing VRL unit tests pass.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA