### PR TITLE
experiment(value): evaluate flat ObjectMap backends

### DIFF
--- a/BENCH_PLAN.md
+++ b/BENCH_PLAN.md
@@ -1,0 +1,262 @@
+# KeyString Optimization Benchmark Plan
+
+## Background
+
+VRL's `Value::Object` stores its keys as `KeyString`, a newtype wrapper around a
+string type. Currently this wraps `String`. We are evaluating alternative backing
+types (`CompactString`, `EcoString`) that offer small-string optimization (inline
+storage for short strings, avoiding heap allocation) and/or cheaper clones
+(reference counting instead of full copy).
+
+### The problem
+
+Changing the `KeyString` backing type should be a transparent optimization, but
+benchmark results show surprising interactions with VRL's flat `ObjectMap`
+implementation. To understand why, we need targeted benchmarks that isolate the
+different layers where `KeyString` is used.
+
+### What we've learned so far
+
+1. **The flat ObjectMap delivers +29% throughput** on a VRL-heavy Vector
+   regression benchmark (`datadog_agent_remap_blackhole`). This win comes from
+   contiguous memory layout and cheaper structural clones, not from KeyString
+   changes.
+
+2. **EcoString (16 bytes, refcounted, 15-byte inline) hurts the flat map by
+   ~10%.** Its `as_str()` has a double-branch (inline vs spilled check) that
+   penalizes the flat map's linear scan, which calls `as_str()` on every key for
+   every lookup.
+
+3. **CompactString (24 bytes, non-refcounted, 24-byte inline) is neutral on the
+   flat map.** Its `as_str()` has a single discriminant check, close enough to
+   `String`'s direct deref. Its `From<String>` is zero-copy (can take ownership
+   of the String's heap buffer), unlike EcoString which always copies.
+
+4. **Copy elimination (removing gratuitous `String` intermediaries in KeyString
+   construction) shows -0.8% — statistical noise.** This is because with
+   `String`-backed `KeyString`, the optimizer already collapses `s.to_string().into()`
+   into the same code as `s.into()`. The fixes become load-bearing only with an
+   SSO string type where `From<&str>` can inline short strings.
+
+5. **The regression benchmark is lookup-dominated.** The VRL program does ~6 path
+   lookups and ~4 path inserts per event, constructing only one small 2-key
+   object. It does not exercise parse-heavy stdlib functions (`parse_syslog`,
+   `parse_grok`, `flatten`, etc.) at all.
+
+### The KeyString roundtrip problem
+
+Compiled VRL expressions store paths as `OwnedValuePath`, which contains
+`OwnedSegment::Field(KeyString)` — a pre-allocated key. But the path system
+unifies compiled paths and runtime string paths behind a single iterator type
+(`BorrowedSegment::Field(Cow<str>)`). This forces the compiled path to:
+
+1. Convert `KeyString` → `&str` (via `as_str()`)
+2. Wrap in `Cow::Borrowed(&str)`
+3. In `crud/insert.rs`, convert back to `KeyString` (allocating a new one)
+
+This means every path insert reconstructs a `KeyString` that already existed.
+For reads (`get`, `get_mut`, `remove`), only the `&str` is needed so there's no
+wasted allocation, but the conversion through `Cow` still happens.
+
+### How Vector deserializes events
+
+The Datadog Agent source (`datadog_agent_remap_blackhole` benchmark):
+
+1. **Outer parse**: `serde_json::from_slice::<Vec<LogMsg>>()` deserializes into a
+   Datadog-specific struct with typed fields (`message: Bytes`, `hostname: Bytes`,
+   etc.). No `KeyString` construction here — serde matches JSON keys against
+   struct fields at compile time.
+
+2. **Event building**: Vector moves `LogMsg` fields onto a `LogEvent` using known
+   field names. `KeyString` values are constructed from `&str` literals in
+   Vector's code.
+
+3. **Inner parse** (only if JSON decoding is configured): The `message` bytes are
+   parsed via `serde_json::from_slice::<serde_json::Value>()`, then converted to
+   `vrl::Value` via `From<serde_json::Value>`. Object keys go `String → KeyString`
+   (from serde_json's `Map<String, Value>`). This does NOT use `Value`'s
+   `Deserialize` impl — it uses the `From` conversion.
+
+   `Value` also has a hand-written `Deserialize` impl where `visit_map`
+   deserializes keys directly as `KeyString` (calling the inner type's
+   `visit_str`/`visit_string`). This path is more efficient because it skips the
+   `String` intermediate, but Vector doesn't use it today for JSON decoding.
+
+---
+
+## Benchmark Groups
+
+### Bench 1: `keystring_micro`
+
+**Purpose**: Ground truth for KeyString construction costs. Directly measures the
+operations we're optimizing, with no surrounding noise. Use this to compare
+`String` vs `CompactString` vs `EcoString` head-to-head.
+
+**Cases**:
+
+| Case | Operation | What it tests |
+|------|-----------|---------------|
+| `from_short_str` | `KeyString::from("hostname")` (8 bytes) | `From<&str>` — inline path for SSO types |
+| `from_long_str` | `KeyString::from("upstream_response_time")` (22 bytes) | `From<&str>` — near inline limit |
+| `from_string_short` | `KeyString::from(String::from("hostname"))` | `From<String>` — CompactString can take ownership |
+| `from_string_long` | `KeyString::from(String::from("upstream_response_time"))` | `From<String>` — zero-copy for CompactString, copy for EcoString |
+| `from_cow_borrowed` | `KeyString::from(Cow::Borrowed("hostname"))` | The path traversal conversion |
+| `clone_short` | `short_key.clone()` | Clone cost — memcpy for CompactString, refcount for EcoString |
+| `clone_long` | `long_key.clone()` | Clone cost at larger sizes |
+| `roundtrip` | `KeyString` → `.as_str()` → `KeyString::from(s)` | The OwnedSegment → BorrowedSegment → KeyString path |
+
+**Implementation notes**:
+- Use `criterion::black_box` to prevent the optimizer from eliding the
+  construction.
+- For `from_string_*` cases, use `iter_batched` to construct a fresh `String`
+  each iteration (since `From<String>` consumes it).
+
+---
+
+### Bench 2: `path_ops`
+
+**Purpose**: Isolate the cost of path traversal through VRL's path system.
+Specifically, measure the difference between `OwnedValuePath` (compiled VRL
+expressions) and JIT string paths, and show the KeyString roundtrip cost.
+
+**Setup**: Build a realistic event — a `Value::Object` with ~15 fields using
+typical field names (`message`, `hostname`, `status`, `severity`, `facility`,
+`appname`, `timestamp`, `procid`, `source_type`, `service`, `env`, `version`,
+`trace_id`, `span_id`, `tags`). Values should be `Value::Bytes` of realistic
+lengths.
+
+**Cases**:
+
+| Case | Operation | What it tests |
+|------|-----------|---------------|
+| `owned_path_get` | `value.get(&owned_path)` for a mid-depth field | Compiled path lookup: `KeyString → &str → Cow → as_ref() → map.get()` |
+| `owned_path_insert` | `value.insert(&owned_path, v)` | Compiled path insert: includes the KeyString roundtrip |
+| `owned_path_nested_get` | `value.get(&owned_path)` for `foo.bar.baz` (3 levels) | Multiple roundtrips per operation |
+| `owned_path_nested_insert` | `value.insert(&owned_path, v)` for 3 levels | Multiple KeyString reconstructions |
+| `jit_path_get` | `value.get("field_name")` | JIT lookup: `&str → Cow::Borrowed → as_ref() → map.get()` |
+| `jit_path_insert` | `value.insert("field_name", v)` | JIT insert: `&str → Cow::Borrowed → KeyString::from(Cow)` |
+
+**Implementation notes**:
+- Pre-compile `OwnedValuePath` values using `parse_value_path()` outside the
+  benchmark loop.
+- Use `iter_batched` for insert benchmarks since they mutate the value.
+- The delta between `owned_path_insert` and `jit_path_insert` shows the cost of
+  the KeyString roundtrip (reconstruct from `&str` of an existing `KeyString`
+  vs construct from a fresh `&str`). These should be approximately equal — if
+  `owned_path_insert` is slower, it means the roundtrip has overhead beyond just
+  the `From<&str>` call.
+
+**What to look for**:
+- `owned_path_insert` vs `jit_path_insert`: if these are roughly equal, the
+  roundtrip isn't adding overhead beyond the `KeyString::from(&str)` cost. If
+  owned is slower, something in the `OwnedSegment → BorrowedSegment` conversion
+  is adding cost (e.g., the `Cow` wrapper, iterator overhead).
+- How get vs insert scales: gets should be cheaper since they don't construct
+  `KeyString`. The delta is the per-insert `KeyString` construction cost.
+
+---
+
+### Bench 3: `vrl_programs`
+
+**Purpose**: End-to-end compiled VRL execution against realistic events. This is
+our correlation check — `remap_fields` should approximately track the Vector
+regression benchmark (`datadog_agent_remap_blackhole`). The other cases exercise
+construction-heavy paths where copy elimination and CompactString should show
+measurable gains.
+
+**Setup**: Use VRL's `compile()` function to compile programs, then
+`Runtime::resolve()` to execute them. Build realistic input events as
+`TargetValue { value, metadata }`.
+
+**Cases**:
+
+| Case | VRL Program | What it tests |
+|------|-------------|---------------|
+| `remap_fields` | `.hostname = "vector"; if .status == "warning" { .thing = upcase(.hostname) } ...` (the exact benchmark VRL) | Correlation with Vector regression bench. Lookup-dominated. |
+| `parse_syslog` | `. = parse_syslog!(.message)` | Stdlib object construction — builds ~9-key ObjectMap from parsed fields. Exercises KeyString construction from `&str` literals. |
+| `parse_and_flatten` | `parsed = parse_syslog!(.message); . = flatten(parsed)` | Object construction + compound key construction via `format!()`. |
+| `object_construction` | `.result = { "method": .method, "path": .path, "status": .status, "duration": .duration, "host": .host, "service": .service, "env": .env, "version": .version, "trace_id": .trace_id, "message": .message }` | Constructs a 10-field object literal. Exercises `Object::resolve()` which clones compiled `KeyString` values. |
+
+**Implementation notes**:
+- Compile programs once, outside the benchmark loop.
+- For `remap_fields`, build the input event to match what the Datadog Agent
+  source would produce (15+ fields, `status` field with varying values to
+  exercise different branches).
+- For `parse_syslog`, set `.message` to a valid RFC5424 syslog line.
+- Use `iter_batched` with a fresh clone of the input event each iteration.
+
+**What to look for**:
+- `remap_fields` should be the least sensitive to KeyString type (it's
+  lookup-dominated). If CompactString shows a gain here, it's likely from the
+  path insert improvement.
+- `parse_syslog` and `object_construction` should show the biggest delta between
+  String and CompactString, since they construct many KeyStrings.
+- `parse_and_flatten` stresses `format!().into()` for compound keys — this is
+  `From<String>` where CompactString is zero-copy.
+
+---
+
+### Bench 4: `json_deser`
+
+**Purpose**: Measure Value construction from JSON, covering both the path Vector
+actually uses and a potential optimization.
+
+**Setup**: A JSON string representing a realistic 15-field Datadog-style log
+event. Include a nested object (e.g., `"http": {"method": "GET", "status": 200}`)
+to exercise recursive key construction.
+
+**Cases**:
+
+| Case | Operation | What it tests |
+|------|-----------|---------------|
+| `via_serde_json_value` | `serde_json::from_str::<serde_json::Value>()` then `Value::from()` | The actual Vector path. Keys go `String → KeyString`. |
+| `direct_deserialize` | `serde_json::from_str::<Value>()` | Direct deserialization. Keys go through `KeyString`'s `Deserialize` → inner type's `visit_str`. No `String` intermediate. |
+
+**Implementation notes**:
+- Use the same JSON string for both cases.
+- Include a variety of key lengths: short (`"host"`, `"env"`), medium
+  (`"hostname"`, `"severity"`), long (`"upstream_response_time"`).
+
+**What to look for**:
+- The delta between the two paths shows the cost of the `serde_json::Value`
+  intermediate. With `String`-backed KeyString, both paths allocate per key.
+  With CompactString, the direct path can inline short keys via `visit_str`
+  without allocating, while the `serde_json::Value` path still allocates a
+  `String` (though CompactString's `From<String>` is zero-copy).
+- If the delta is significant, it suggests Vector should consider switching to
+  direct `Value` deserialization in its JSON codec.
+
+---
+
+## Running the benchmarks
+
+```bash
+# All KeyString benchmarks
+cargo bench --bench keystring --features "default,test"
+
+# Compare against a baseline (run on main first, then on your branch)
+cargo bench --bench keystring --features "default,test" -- --save-baseline main
+# ... switch branches ...
+cargo bench --bench keystring --features "default,test" -- --baseline main
+```
+
+## Interpreting results for Vector-level impact
+
+The Vector regression benchmark runs at ~500K events/sec with the BTreeMap
+baseline. Each event goes through:
+
+1. **Deserialization** (bench 4): ~15 KeyString constructions for a typical event
+2. **VRL execution** (bench 3 `remap_fields`): ~6 lookups + ~4 inserts
+3. **Serialization** to blackhole sink: reads all fields
+
+To estimate Vector-level impact from local bench results:
+
+- Multiply per-operation savings from bench 1/2 by the operation count above
+- Compare that to the per-event time from bench 3 `remap_fields`
+- If the per-operation savings are <1% of per-event time, the change won't
+  register in the Vector benchmark
+- If >5%, it should be visible
+
+The `remap_fields` bench is the most direct predictor. If it shows a 2%
+improvement locally, expect roughly a 1-3% improvement in the Vector regression
+benchmark (local benches have less noise and overhead than the full pipeline).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4267,7 @@ dependencies = [
  "dns-lookup",
  "domain",
  "dyn-clone",
+ "ecow",
  "encoding_rs",
  "exitcode",
  "fancy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default = ["compiler", "value", "diagnostic", "path", "parser", "stdlib", "datad
 compiler = ["diagnostic", "path", "parser", "value", "dep:chrono", "dep:serde", "dep:regex", "dep:bytes", "dep:ordered-float", "dep:chrono-tz", "dep:snafu", "dep:thiserror", "dep:dyn-clone", "dep:indoc", "dep:thiserror", "dep:lalrpop-util"]
 
 # Contains the primary data type used in VRL.
-value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json", "dep:simdutf8"]
+value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json", "dep:simdutf8", "dep:ecow"]
 
 # Logic related to errors and displaying info about them.
 diagnostic = ["dep:codespan-reporting", "dep:termcolor"]
@@ -206,13 +206,14 @@ convert_case = { version = "0.7.1", optional = true }
 crc = { version = "3.3.0", optional = true }
 digest = { version = "0.10", optional = true }
 dyn-clone = { version = "1", default-features = false, optional = true }
+ecow = { version = "0.2", optional = true }
 exitcode = { version = "1", optional = true }
 flate2 = { version = "1.1.2", default-features = false, features = ["zlib-rs"], optional = true }
 hex = { version = "0.4", optional = true }
 hmac = { version = "0.12", optional = true }
 iana-time-zone = { version = "0.1", optional = true }
 idna = { version = "1.0", optional = true }
-indexmap = { version = "2", default-features = false, features = ["std"], optional = true }
+indexmap = { version = "2", default-features = false, features = ["std", "serde"], optional = true }
 influxdb-line-protocol = { version = "2.0.0", optional = true }
 indoc = { version = "2", optional = true }
 itertools = { version = "0.14", default-features = false, features = ["use_std"], optional = true }
@@ -348,5 +349,10 @@ harness = false
 
 [[bench]]
 name = "stdlib"
+harness = false
+required-features = ["default", "test"]
+
+[[bench]]
+name = "objectmap"
 harness = false
 required-features = ["default", "test"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,6 +317,7 @@ uuid = { version = "1", features = ["v4", "v7", "js"], optional = true }
 [dev-dependencies]
 anyhow = "1"
 criterion = "0.8"
+ecow = "0.2"
 chrono-tz = "0.10"
 serde_json = "1"
 indoc = "2"
@@ -354,6 +355,16 @@ required-features = ["default", "test"]
 
 [[bench]]
 name = "objectmap"
+harness = false
+required-features = ["default", "test"]
+
+[[bench]]
+name = "objectmap_cliff"
+harness = false
+required-features = ["default", "test"]
+
+[[bench]]
+name = "objectmap_hybrid"
 harness = false
 required-features = ["default", "test"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,3 +356,8 @@ required-features = ["default", "test"]
 name = "objectmap"
 harness = false
 required-features = ["default", "test"]
+
+[[bench]]
+name = "keystring"
+harness = false
+required-features = ["default", "test"]

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1,0 +1,260 @@
+# ObjectMap Refactor Plan
+
+## Goal
+
+Make `ObjectMap` safe to evolve into an enum-backed storage type without changing user-visible behavior during the refactor. The immediate objective is to remove all `BTreeMap`-specific API leaks from `ObjectMap`, introduce a second backend variant, and keep the tree green throughout while backend selection remains fixed.
+
+## Current State
+
+This branch now contains the following mechanical steps:
+
+- `ObjectMap` is an enum in `src/value/value.rs`
+- `ObjectMap` has `BTree` and `Index` variants
+- `ObjectMap`-owned iterator and entry wrapper types no longer leak `btree_map::*`
+- immediate `Entry` and iterator call sites have been migrated to those wrappers
+- targeted tests now exercise the `Index` variant directly
+
+Current behavior is still intentionally conservative:
+
+- `ObjectMap::new()`, `FromIterator`, and array conversions use a cached `VRL_OBJECT_MAP` env var
+- supported values today are `btree` / `btreemap` and `index` / `indexmap`
+- the default remains `BTree` when the env var is unset or invalid
+- explicit constructors still exist for direct tests and bench code:
+  - `ObjectMap::new_btree()`
+  - `ObjectMap::new_index()`
+  - `ObjectMap::with_backend(...)`
+
+What still blocks an enum-backed implementation is that `ObjectMap` exposes:
+
+- `From<BTreeMap<...>>` and `PartialEq<BTreeMap<...>>`
+
+The first three bullets above have been addressed. The remaining work is mostly about tightening construction-time compatibility shims, validating semantics, and deciding how backend selection should eventually occur.
+
+## Current Bench Workflow
+
+For quick local A/B runs without code edits:
+
+```bash
+cargo bench --features 'default test' --bench stdlib parse_query_string -- --noplot
+VRL_OBJECT_MAP=index cargo bench --features 'default test' --bench stdlib parse_query_string -- --noplot
+```
+
+The same pattern works for any existing benchmark that builds objects through `ObjectMap::new()`, `collect::<ObjectMap>()`, or `ObjectMap::from([...])`.
+
+There are also call sites that directly import `std::collections::btree_map::Entry` or store `btree_map::Iter` in structs.
+
+## Constraints
+
+- Keep the repository compiling after each slice.
+- Prefer small, monotonic steps over broad rewrites.
+- Preserve iteration and serialization order while `ObjectMap` is still backed by `BTreeMap`.
+- Do not introduce runtime backend switching until the API no longer leaks `BTreeMap`.
+- Validate each slice with compiler and targeted tests before proceeding.
+
+## Phases
+
+### Phase 0: Plan and Baseline
+
+Deliverables:
+
+- this plan in `REFACTOR.md`
+- confirm current leak points and call sites
+
+Validation:
+
+- no code changes beyond the plan
+
+### Phase 1: Add ObjectMap-Owned Wrapper Types
+
+Objective:
+
+Define `ObjectMap`-owned wrapper types around the current `BTreeMap` APIs while keeping the backend unchanged.
+
+Deliverables:
+
+- introduce wrapper types in `src/value/value.rs`:
+  - `ObjectMapIter<'a>`
+  - `ObjectMapIterMut<'a>`
+  - `ObjectMapKeys<'a>`
+  - `ObjectMapValues<'a>`
+  - `ObjectMapValuesMut<'a>`
+  - `ObjectMapIntoIter`
+  - `ObjectMapIntoKeys`
+  - `ObjectMapIntoValues`
+  - `ObjectMapEntry<'a>`
+  - `ObjectMapOccupiedEntry<'a>`
+  - `ObjectMapVacantEntry<'a>`
+- change `ObjectMap::{iter, iter_mut, keys, values, values_mut, into_keys, into_values, entry}` to return wrappers
+- change `IntoIterator for ObjectMap`, `&ObjectMap`, and `&mut ObjectMap` to use wrapper iterators
+
+Notes:
+
+- this phase keeps `ObjectMap` backed by `BTreeMap`
+- wrapper types should initially expose only the methods the repo actually needs
+- avoid over-modeling the full std entry API
+
+Validation checkpoints:
+
+- `cargo check --lib`
+- fix compile fallout immediately in the same slice
+
+### Phase 2: Migrate Immediate Wrapper Call Sites
+
+Objective:
+
+Update call sites that currently depend on concrete `btree_map` types.
+
+Expected files:
+
+- `src/parsing/xml.rs`
+- `src/parsing/query_string.rs`
+- `src/stdlib/parse_key_value.rs`
+- `src/stdlib/flatten.rs`
+- `src/stdlib/keys.rs`
+- `src/stdlib/values.rs`
+- any other compile fallout from Phase 1
+
+Deliverables:
+
+- replace imports of `std::collections::btree_map::Entry` with `crate::value::ObjectMapEntry`
+- adjust pattern matches to use `ObjectMapEntry::{Occupied, Vacant}`
+- convert `flatten` to store `ObjectMapIter<'a>` instead of `btree_map::Iter<'a, ...>`
+- ensure `keys` and `values` use wrapper iterators
+
+Validation checkpoints:
+
+- `cargo check --lib`
+- targeted tests:
+  - `cargo test parsing::query_string`
+  - `cargo test parse_key_value`
+  - `cargo test parse_xml`
+  - `cargo test flatten`
+
+### Phase 3: Remove Remaining BTreeMap Leaks from Value Conversion Surface
+
+Objective:
+
+Reduce non-essential `BTreeMap` coupling outside the iterator and entry surface.
+
+Expected areas:
+
+- `src/value/value/convert.rs`
+- `src/value/value/lua.rs`
+- docs and comments in `src/value/value.rs`
+- helper macros and tests where appropriate
+
+Deliverables:
+
+- evaluate whether `From<BTreeMap<KeyString, Value>> for ObjectMap` and `for Value` should remain temporarily or move behind crate-private helpers
+- evaluate whether `PartialEq<BTreeMap<...>>` should remain during migration or be removed
+- replace direct `BTreeMap` deserialization/construction where it materially leaks into `ObjectMap` semantics
+
+Validation checkpoints:
+
+- `cargo check --lib`
+- targeted value tests:
+  - `cargo test value::value`
+  - `cargo test value::value::iter`
+  - `cargo test value::value::path`
+
+### Phase 4: Make ObjectMap Trait Impl Semantics Explicit
+
+Objective:
+
+Prepare for multiple backends by removing derives and trait behavior that assume a single concrete storage type.
+
+Focus:
+
+- `Hash`
+- `PartialOrd`
+- equality and ordering semantics
+- serialization guarantees
+
+Deliverables:
+
+- decide whether to keep sorted iteration as an invariant or document backend-specific behavior
+- if sorted iteration remains an invariant, encode it at the abstraction layer
+- if not, update docs and user-visible functions accordingly
+- replace derived trait impls with explicit impls if needed
+
+Validation checkpoints:
+
+- `cargo check --lib`
+- targeted serialization and behavior tests
+
+### Phase 5: Introduce Enum-Backed ObjectMap Internals
+
+Objective:
+
+Switch `ObjectMap` internals from:
+
+- `struct ObjectMap(BTreeMap<...>)`
+
+to something like:
+
+- `enum ObjectMap { BTree(...), Alt(...) }`
+
+Only begin this phase once the previous phases are green.
+
+Deliverables:
+
+- enum-backed `ObjectMap`
+- add a second backend variant, initially without any switching mechanism
+- wrapper iterators and entry types dispatch internally by variant
+- constructor selection API:
+  - explicit constructor
+  - feature gate
+  - or cached env-var-based default selection
+
+Validation checkpoints:
+
+- `cargo check --lib`
+- targeted tests from earlier phases
+- targeted tests that construct the non-default backend directly
+- benchmark smoke test:
+  - `cargo bench --bench kind`
+  - any new object-map-focused benchmark added later
+
+## Sequencing Strategy
+
+The safest order is:
+
+1. wrappers first
+2. compile fallout next
+3. behavior cleanup after the tree is green again
+4. backend polymorphism last
+
+This keeps each checkpoint narrow and makes it easy to stop and reassess if the abstraction becomes awkward.
+
+## Known Hotspots
+
+These are the files most likely to need immediate changes during the wrapper phase:
+
+- `src/value/value.rs`
+- `src/parsing/xml.rs`
+- `src/parsing/query_string.rs`
+- `src/stdlib/parse_key_value.rs`
+- `src/stdlib/flatten.rs`
+- `src/stdlib/keys.rs`
+- `src/stdlib/values.rs`
+
+These are secondary hotspots for follow-up cleanup:
+
+- `src/value/value/convert.rs`
+- `src/value/value/lua.rs`
+- `src/stdlib/filter.rs`
+- `src/stdlib/merge.rs`
+- `src/stdlib/http_request.rs`
+- `src/datadog/grok/parse_grok.rs`
+
+## Checkpoint Policy
+
+Do not stack multiple unvalidated abstraction changes at once.
+
+After each phase:
+
+1. run `cargo check --lib`
+2. run the smallest relevant targeted tests
+3. only then move to the next slice
+
+If a phase widens unexpectedly, stop and split it into a smaller compilable step rather than pushing forward with a red tree.

--- a/benches/keystring.rs
+++ b/benches/keystring.rs
@@ -124,7 +124,10 @@ fn bench_keystring_micro(c: &mut Criterion) {
 fn build_event() -> Value {
     let mut map = ObjectMap::new();
     let fields = [
-        ("message", "2024-01-15T10:30:00Z INFO server started successfully on port 8080"),
+        (
+            "message",
+            "2024-01-15T10:30:00Z INFO server started successfully on port 8080",
+        ),
         ("hostname", "web-prod-01.us-east-1.compute.internal"),
         ("status", "info"),
         ("severity", "informational"),
@@ -222,10 +225,9 @@ fn bench_path_ops(c: &mut Criterion) {
         b.iter_batched(
             || nested_event.clone(),
             |mut value| {
-                black_box(value.insert(
-                    &owned_nested_path,
-                    Value::Bytes(Bytes::from_static(b"new")),
-                ));
+                black_box(
+                    value.insert(&owned_nested_path, Value::Bytes(Bytes::from_static(b"new"))),
+                );
             },
             BatchSize::SmallInput,
         );

--- a/benches/keystring.rs
+++ b/benches/keystring.rs
@@ -1,0 +1,461 @@
+use std::borrow::Cow;
+use std::hint::black_box;
+
+use bytes::Bytes;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+
+use vrl::compiler::runtime::Runtime;
+use vrl::compiler::{Program, TargetValue, TimeZone, compile};
+use vrl::path::parse_value_path;
+use vrl::value::{KeyString, ObjectMap, Secrets, Value};
+
+// ---------------------------------------------------------------------------
+// Bench 1: keystring_micro
+// ---------------------------------------------------------------------------
+
+fn bench_keystring_micro(c: &mut Criterion) {
+    let mut group = c.benchmark_group("keystring_micro");
+
+    // from_short_str: From<&str> for an 8-byte string (inline for SSO types)
+    group.bench_function("from_short_str", |b| {
+        b.iter(|| {
+            black_box(KeyString::from("hostname"));
+        });
+    });
+
+    // from_long_str: From<&str> for a 22-byte string (near inline limit)
+    group.bench_function("from_long_str", |b| {
+        b.iter(|| {
+            black_box(KeyString::from("upstream_response_time"));
+        });
+    });
+
+    // from_string_short: From<String> — CompactString can take ownership
+    group.bench_function("from_string_short", |b| {
+        b.iter_batched(
+            || String::from("hostname"),
+            |s| {
+                black_box(KeyString::from(s));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // from_string_long: From<String> — zero-copy for CompactString, copy for EcoString
+    group.bench_function("from_string_long", |b| {
+        b.iter_batched(
+            || String::from("upstream_response_time"),
+            |s| {
+                black_box(KeyString::from(s));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // from_cow_borrowed: the path traversal conversion
+    group.bench_function("from_cow_borrowed", |b| {
+        b.iter(|| {
+            let cow: Cow<'_, str> = Cow::Borrowed("hostname");
+            black_box(KeyString::from(cow));
+        });
+    });
+
+    // clone_short
+    let short_key = KeyString::from("hostname");
+    group.bench_function("clone_short", |b| {
+        b.iter(|| {
+            black_box(short_key.clone());
+        });
+    });
+
+    // clone_long
+    let long_key = KeyString::from("upstream_response_time");
+    group.bench_function("clone_long", |b| {
+        b.iter(|| {
+            black_box(long_key.clone());
+        });
+    });
+
+    // roundtrip: KeyString → .as_str() → KeyString::from(s)
+    // This is the OwnedSegment → BorrowedSegment → KeyString path
+    let key = KeyString::from("hostname");
+    group.bench_function("roundtrip", |b| {
+        b.iter(|| {
+            let s = key.as_str();
+            black_box(KeyString::from(s));
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Bench 2: path_ops
+// ---------------------------------------------------------------------------
+
+/// Build a realistic 15-field event resembling a Datadog log.
+fn build_event() -> Value {
+    let mut map = ObjectMap::new();
+    let fields = [
+        ("message", "2024-01-15T10:30:00Z INFO server started successfully on port 8080"),
+        ("hostname", "web-prod-01.us-east-1.compute.internal"),
+        ("status", "info"),
+        ("severity", "informational"),
+        ("facility", "local0"),
+        ("appname", "vector"),
+        ("timestamp", "2024-01-15T10:30:00.123456Z"),
+        ("procid", "12345"),
+        ("source_type", "datadog_agent"),
+        ("service", "vector-aggregator"),
+        ("env", "production"),
+        ("version", "0.34.0"),
+        ("trace_id", "4bf92f3577b34da6a3ce929d0e0e4736"),
+        ("span_id", "00f067aa0ba902b7"),
+        ("tags", "env:prod,service:vector,version:0.34.0"),
+    ];
+    for (k, v) in fields {
+        map.insert(k.into(), Value::Bytes(Bytes::from(v)));
+    }
+    Value::Object(map)
+}
+
+/// Build a nested event with a `foo.bar.baz` path.
+fn build_nested_event() -> Value {
+    let mut root = ObjectMap::new();
+
+    // Add the 15 fields from the flat event
+    let fields = [
+        ("message", "test message"),
+        ("hostname", "web-prod-01"),
+        ("status", "info"),
+        ("severity", "informational"),
+        ("facility", "local0"),
+        ("appname", "vector"),
+        ("timestamp", "2024-01-15T10:30:00Z"),
+        ("procid", "12345"),
+        ("source_type", "datadog_agent"),
+        ("service", "vector-aggregator"),
+        ("env", "production"),
+        ("version", "0.34.0"),
+        ("trace_id", "4bf92f3577b34da6"),
+        ("span_id", "00f067aa0ba902b7"),
+        ("tags", "env:prod"),
+    ];
+    for (k, v) in fields {
+        root.insert(k.into(), Value::Bytes(Bytes::from(v)));
+    }
+
+    // Add nested structure: foo.bar.baz = "nested_value"
+    let mut baz_map = ObjectMap::new();
+    baz_map.insert("baz".into(), Value::Bytes(Bytes::from("nested_value")));
+    let mut bar_map = ObjectMap::new();
+    bar_map.insert("bar".into(), Value::Object(baz_map));
+    root.insert("foo".into(), Value::Object(bar_map));
+
+    Value::Object(root)
+}
+
+fn bench_path_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("path_ops");
+
+    let event = build_event();
+    let nested_event = build_nested_event();
+
+    // Pre-compile owned paths
+    let owned_path = parse_value_path("service").unwrap();
+    let owned_nested_path = parse_value_path("foo.bar.baz").unwrap();
+
+    // owned_path_get: compiled path lookup
+    group.bench_function("owned_path_get", |b| {
+        b.iter(|| {
+            black_box(event.get(&owned_path));
+        });
+    });
+
+    // owned_path_insert: compiled path insert (includes KeyString roundtrip)
+    group.bench_function("owned_path_insert", |b| {
+        b.iter_batched(
+            || event.clone(),
+            |mut value| {
+                black_box(value.insert(&owned_path, Value::Bytes(Bytes::from_static(b"new"))));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // owned_path_nested_get: 3-level compiled path lookup
+    group.bench_function("owned_path_nested_get", |b| {
+        b.iter(|| {
+            black_box(nested_event.get(&owned_nested_path));
+        });
+    });
+
+    // owned_path_nested_insert: 3-level insert (multiple KeyString reconstructions)
+    group.bench_function("owned_path_nested_insert", |b| {
+        b.iter_batched(
+            || nested_event.clone(),
+            |mut value| {
+                black_box(value.insert(
+                    &owned_nested_path,
+                    Value::Bytes(Bytes::from_static(b"new")),
+                ));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // jit_path_get: JIT string path lookup
+    group.bench_function("jit_path_get", |b| {
+        b.iter(|| {
+            black_box(event.get("service"));
+        });
+    });
+
+    // jit_path_insert: JIT string path insert
+    group.bench_function("jit_path_insert", |b| {
+        b.iter_batched(
+            || event.clone(),
+            |mut value| {
+                black_box(value.insert("service", Value::Bytes(Bytes::from_static(b"new"))));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Bench 3: vrl_programs
+// ---------------------------------------------------------------------------
+
+/// Helper to compile a VRL program with all stdlib functions.
+fn compile_vrl(source: &str) -> Program {
+    let fns = vrl::stdlib::all();
+    compile(source, &fns)
+        .unwrap_or_else(|err| panic!("failed to compile VRL: {err:?}"))
+        .program
+}
+
+/// Build a target suitable for the remap_fields benchmark.
+fn build_remap_target() -> TargetValue {
+    let mut map = ObjectMap::new();
+    let fields = [
+        ("message", "2024-01-15T10:30:00Z INFO server started"),
+        ("hostname", "web-prod-01"),
+        ("status", "warning"),
+        ("severity", "informational"),
+        ("facility", "local0"),
+        ("appname", "vector"),
+        ("timestamp", "2024-01-15T10:30:00Z"),
+        ("procid", "12345"),
+        ("source_type", "datadog_agent"),
+        ("service", "vector-aggregator"),
+        ("env", "production"),
+        ("version", "0.34.0"),
+        ("trace_id", "4bf92f3577b34da6a3ce929d0e0e4736"),
+        ("span_id", "00f067aa0ba902b7"),
+        ("tags", "env:prod,service:vector,version:0.34.0"),
+    ];
+    for (k, v) in fields {
+        map.insert(k.into(), Value::Bytes(Bytes::from(v)));
+    }
+    TargetValue {
+        value: Value::Object(map),
+        metadata: Value::Object(ObjectMap::new()),
+        secrets: Secrets::default(),
+    }
+}
+
+/// Build a target with a valid syslog message.
+fn build_syslog_target() -> TargetValue {
+    let mut map = ObjectMap::new();
+    map.insert(
+        "message".into(),
+        Value::Bytes(Bytes::from(
+            "<165>1 2024-01-15T10:30:00.123456Z web-prod-01 vector 12345 ID47 \
+             [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" \
+             eventID=\"1011\"] An application event log entry",
+        )),
+    );
+    TargetValue {
+        value: Value::Object(map),
+        metadata: Value::Object(ObjectMap::new()),
+        secrets: Secrets::default(),
+    }
+}
+
+/// Build a target for object construction benchmark.
+fn build_object_construction_target() -> TargetValue {
+    let mut map = ObjectMap::new();
+    let fields = [
+        ("method", "GET"),
+        ("path", "/api/v1/events"),
+        ("status", "200"),
+        ("duration", "42"),
+        ("host", "web-prod-01"),
+        ("service", "vector-aggregator"),
+        ("env", "production"),
+        ("version", "0.34.0"),
+        ("trace_id", "4bf92f3577b34da6a3ce929d0e0e4736"),
+        ("message", "handled request successfully"),
+    ];
+    for (k, v) in fields {
+        map.insert(k.into(), Value::Bytes(Bytes::from(v)));
+    }
+    TargetValue {
+        value: Value::Object(map),
+        metadata: Value::Object(ObjectMap::new()),
+        secrets: Secrets::default(),
+    }
+}
+
+fn bench_vrl_programs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vrl_programs");
+    let tz = TimeZone::default();
+    let mut runtime = Runtime::default();
+
+    // remap_fields: correlation with Vector regression benchmark (lookup-dominated)
+    let remap_program = compile_vrl(
+        r#"
+        .hostname = "vector"
+        if .status == "warning" {
+            .thing = upcase!(.hostname)
+        }
+        .new_field = "value"
+        .service = downcase!(.service)
+        .env_upper = upcase!(.env)
+        .has_trace = exists(.trace_id)
+        "#,
+    );
+
+    group.bench_function("remap_fields", |b| {
+        b.iter_batched(
+            || build_remap_target(),
+            |mut target| {
+                black_box(runtime.resolve(&mut target, &remap_program, &tz).unwrap());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // parse_syslog: stdlib object construction (~9-key ObjectMap)
+    let syslog_program = compile_vrl(". = parse_syslog!(.message)");
+
+    group.bench_function("parse_syslog", |b| {
+        b.iter_batched(
+            || build_syslog_target(),
+            |mut target| {
+                black_box(runtime.resolve(&mut target, &syslog_program, &tz).unwrap());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // parse_and_flatten: object construction + compound key construction
+    let flatten_program = compile_vrl("parsed = parse_syslog!(.message)\n. = flatten(parsed)");
+
+    group.bench_function("parse_and_flatten", |b| {
+        b.iter_batched(
+            || build_syslog_target(),
+            |mut target| {
+                black_box(runtime.resolve(&mut target, &flatten_program, &tz).unwrap());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // object_construction: 10-field object literal (exercises Object::resolve cloning KeyStrings)
+    let obj_program = compile_vrl(
+        r#"
+        .result = {
+            "method": .method,
+            "path": .path,
+            "status": .status,
+            "duration": .duration,
+            "host": .host,
+            "service": .service,
+            "env": .env,
+            "version": .version,
+            "trace_id": .trace_id,
+            "message": .message
+        }
+        "#,
+    );
+
+    group.bench_function("object_construction", |b| {
+        b.iter_batched(
+            || build_object_construction_target(),
+            |mut target| {
+                black_box(runtime.resolve(&mut target, &obj_program, &tz).unwrap());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Bench 4: json_deser
+// ---------------------------------------------------------------------------
+
+const JSON_EVENT: &str = r#"{
+    "host": "web-prod-01",
+    "env": "production",
+    "service": "vector-aggregator",
+    "version": "0.34.0",
+    "message": "handled request successfully with detailed tracing information",
+    "hostname": "web-prod-01.us-east-1.compute.internal",
+    "severity": "informational",
+    "facility": "local0",
+    "appname": "vector",
+    "procid": "12345",
+    "source_type": "datadog_agent",
+    "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+    "span_id": "00f067aa0ba902b7",
+    "tags": "env:prod,service:vector,version:0.34.0",
+    "upstream_response_time": "0.042",
+    "http": {
+        "method": "GET",
+        "status": 200,
+        "path": "/api/v1/events",
+        "response_bytes": 1024
+    }
+}"#;
+
+fn bench_json_deser(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_deser");
+
+    // via_serde_json_value: the actual Vector path (String → KeyString)
+    group.bench_function("via_serde_json_value", |b| {
+        b.iter(|| {
+            let json_val: serde_json::Value = serde_json::from_str(JSON_EVENT).unwrap();
+            black_box(Value::from(json_val));
+        });
+    });
+
+    // direct_deserialize: direct to Value (KeyString's Deserialize → visit_str, no String intermediate)
+    group.bench_function("direct_deserialize", |b| {
+        b.iter(|| {
+            black_box(serde_json::from_str::<Value>(JSON_EVENT).unwrap());
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Criterion harness
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05);
+    targets =
+        bench_keystring_micro,
+        bench_path_ops,
+        bench_vrl_programs,
+        bench_json_deser
+);
+criterion_main!(benches);

--- a/benches/keystring.rs
+++ b/benches/keystring.rs
@@ -360,7 +360,7 @@ fn bench_vrl_programs(c: &mut Criterion) {
 
     group.bench_function("remap_fields", |b| {
         b.iter_batched(
-            || build_remap_target(),
+            build_remap_target,
             |mut target| {
                 black_box(runtime.resolve(&mut target, &remap_program, &tz).unwrap());
             },
@@ -373,7 +373,7 @@ fn bench_vrl_programs(c: &mut Criterion) {
 
     group.bench_function("parse_syslog", |b| {
         b.iter_batched(
-            || build_syslog_target(),
+            build_syslog_target,
             |mut target| {
                 black_box(runtime.resolve(&mut target, &syslog_program, &tz).unwrap());
             },
@@ -386,7 +386,7 @@ fn bench_vrl_programs(c: &mut Criterion) {
 
     group.bench_function("parse_and_flatten", |b| {
         b.iter_batched(
-            || build_syslog_target(),
+            build_syslog_target,
             |mut target| {
                 black_box(runtime.resolve(&mut target, &flatten_program, &tz).unwrap());
             },
@@ -414,7 +414,7 @@ fn bench_vrl_programs(c: &mut Criterion) {
 
     group.bench_function("object_construction", |b| {
         b.iter_batched(
-            || build_object_construction_target(),
+            build_object_construction_target,
             |mut target| {
                 black_box(runtime.resolve(&mut target, &obj_program, &tz).unwrap());
             },

--- a/benches/keystring.rs
+++ b/benches/keystring.rs
@@ -23,14 +23,22 @@ fn bench_keystring_micro(c: &mut Criterion) {
         });
     });
 
-    // from_long_str: From<&str> for a 22-byte string (near inline limit)
-    group.bench_function("from_long_str", |b| {
+    // from_medium_str: From<&str> for a 22-byte string
+    // Inline for CompactString (24B), spills for EcoString (15B)
+    group.bench_function("from_medium_str", |b| {
         b.iter(|| {
             black_box(KeyString::from("upstream_response_time"));
         });
     });
 
-    // from_string_short: From<String> — CompactString can take ownership
+    // from_long_str: From<&str> for a 32-byte string (spills all SSO types)
+    group.bench_function("from_long_str", |b| {
+        b.iter(|| {
+            black_box(KeyString::from("x_upstream_forwarded_for_header"));
+        });
+    });
+
+    // from_string_short: From<String>
     group.bench_function("from_string_short", |b| {
         b.iter_batched(
             || String::from("hostname"),
@@ -41,10 +49,21 @@ fn bench_keystring_micro(c: &mut Criterion) {
         );
     });
 
-    // from_string_long: From<String> — zero-copy for CompactString, copy for EcoString
-    group.bench_function("from_string_long", |b| {
+    // from_string_medium: From<String> — CompactString can take ownership, EcoString copies
+    group.bench_function("from_string_medium", |b| {
         b.iter_batched(
             || String::from("upstream_response_time"),
+            |s| {
+                black_box(KeyString::from(s));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // from_string_long: From<String> for a spilled key
+    group.bench_function("from_string_long", |b| {
+        b.iter_batched(
+            || String::from("x_upstream_forwarded_for_header"),
             |s| {
                 black_box(KeyString::from(s));
             },
@@ -60,7 +79,7 @@ fn bench_keystring_micro(c: &mut Criterion) {
         });
     });
 
-    // clone_short
+    // clone_short: inline for all SSO types
     let short_key = KeyString::from("hostname");
     group.bench_function("clone_short", |b| {
         b.iter(|| {
@@ -68,8 +87,16 @@ fn bench_keystring_micro(c: &mut Criterion) {
         });
     });
 
-    // clone_long
-    let long_key = KeyString::from("upstream_response_time");
+    // clone_medium: inline for CompactString, spilled for EcoString
+    let medium_key = KeyString::from("upstream_response_time");
+    group.bench_function("clone_medium", |b| {
+        b.iter(|| {
+            black_box(medium_key.clone());
+        });
+    });
+
+    // clone_long: spilled for all SSO types — fair heap comparison
+    let long_key = KeyString::from("x_upstream_forwarded_for_header");
     group.bench_function("clone_long", |b| {
         b.iter(|| {
             black_box(long_key.clone());

--- a/benches/objectmap.rs
+++ b/benches/objectmap.rs
@@ -303,7 +303,11 @@ fn benchmark_nested_build(c: &mut Criterion) {
                 &case,
                 |b, case| {
                     b.iter(|| {
-                        black_box(nested_value_insert_child(case.depth, case.siblings, backend));
+                        black_box(nested_value_insert_child(
+                            case.depth,
+                            case.siblings,
+                            backend,
+                        ));
                     });
                 },
             );

--- a/benches/objectmap.rs
+++ b/benches/objectmap.rs
@@ -1,0 +1,421 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::fmt;
+use std::hint::black_box;
+use vrl::value::{ObjectMap, Value};
+
+#[derive(Clone, Copy)]
+struct FlatCase {
+    width: usize,
+}
+
+#[derive(Clone, Copy)]
+struct DepthCase {
+    depth: usize,
+    siblings: usize,
+}
+
+impl fmt::Display for FlatCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "width={}", self.width)
+    }
+}
+
+impl fmt::Display for DepthCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "depth={},siblings={}", self.depth, self.siblings)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Backend {
+    BTree,
+    Flat,
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BTree => write!(f, "btree"),
+            Self::Flat => write!(f, "flat"),
+        }
+    }
+}
+
+impl Backend {
+    fn new_map(self) -> ObjectMap {
+        match self {
+            Self::BTree => ObjectMap::new_btree(),
+            Self::Flat => ObjectMap::new(),
+        }
+    }
+}
+
+const BACKENDS: [Backend; 2] = [Backend::BTree, Backend::Flat];
+
+const FLAT_CASES: [FlatCase; 3] = [
+    FlatCase { width: 8 },
+    FlatCase { width: 64 },
+    FlatCase { width: 256 },
+];
+
+const DEPTH_ONLY_CASES: [DepthCase; 4] = [
+    DepthCase {
+        depth: 1,
+        siblings: 0,
+    },
+    DepthCase {
+        depth: 4,
+        siblings: 0,
+    },
+    DepthCase {
+        depth: 8,
+        siblings: 0,
+    },
+    DepthCase {
+        depth: 16,
+        siblings: 0,
+    },
+];
+
+const DEPTH_WITH_FANOUT_CASES: [DepthCase; 4] = [
+    DepthCase {
+        depth: 1,
+        siblings: 8,
+    },
+    DepthCase {
+        depth: 4,
+        siblings: 8,
+    },
+    DepthCase {
+        depth: 8,
+        siblings: 8,
+    },
+    DepthCase {
+        depth: 16,
+        siblings: 8,
+    },
+];
+
+fn flat_map(width: usize, backend: Backend) -> ObjectMap {
+    let mut map = backend.new_map();
+    for i in 0..width {
+        map.insert(format!("key_{i}").into(), Value::from(i as i64));
+    }
+    map
+}
+
+/// Build a nested Value tree using ad-hoc construction (separate ObjectMap per level).
+fn nested_value_adhoc(depth: usize, siblings: usize, backend: Backend) -> Value {
+    fn build_level(level: usize, depth: usize, siblings: usize, backend: Backend) -> Value {
+        let mut map = backend.new_map();
+
+        for sibling in 0..siblings {
+            map.insert(
+                format!("sibling_{level}_{sibling}").into(),
+                Value::from((level * 10 + sibling) as i64),
+            );
+        }
+
+        if level + 1 == depth {
+            map.insert("target".into(), Value::from(level as i64));
+        } else {
+            map.insert(
+                format!("level_{level}").into(),
+                build_level(level + 1, depth, siblings, backend),
+            );
+        }
+
+        Value::Object(map)
+    }
+
+    build_level(0, depth.max(1), siblings, backend)
+}
+
+/// Build a nested Value tree using insert_child (child inherits parent backend).
+fn nested_value_insert_child(depth: usize, siblings: usize, backend: Backend) -> Value {
+    fn build_level(map: &mut ObjectMap, level: usize, depth: usize, siblings: usize) {
+        for sibling in 0..siblings {
+            map.insert(
+                format!("sibling_{level}_{sibling}").into(),
+                Value::from((level * 10 + sibling) as i64),
+            );
+        }
+
+        if level + 1 == depth {
+            map.insert("target".into(), Value::from(level as i64));
+        } else {
+            let child = map.insert_child(format!("level_{level}").into());
+            build_level(child, level + 1, depth, siblings);
+        }
+    }
+
+    let mut root = backend.new_map();
+    let actual_depth = depth.max(1);
+    build_level(&mut root, 0, actual_depth, siblings);
+    Value::Object(root)
+}
+
+fn nested_target_path(depth: usize) -> String {
+    let mut parts = Vec::with_capacity(depth.max(1));
+    for level in 0..depth.saturating_sub(1) {
+        parts.push(format!("level_{level}"));
+    }
+    parts.push("target".to_owned());
+    parts.join(".")
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn benchmark_flat_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/flat_insert");
+
+    for backend in BACKENDS {
+        for case in FLAT_CASES {
+            group.throughput(Throughput::Elements(case.width as u64));
+            group.bench_with_input(
+                BenchmarkId::new(backend.to_string(), case),
+                &case,
+                |b, case| {
+                    b.iter_batched(
+                        || flat_map(case.width, backend),
+                        |mut map| {
+                            black_box(map.insert("new_key".into(), Value::from(42)));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+}
+
+fn benchmark_flat_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/flat_get");
+
+    for backend in BACKENDS {
+        for case in FLAT_CASES {
+            let map = flat_map(case.width, backend);
+            // Look up a key near the middle
+            let target = format!("key_{}", case.width / 2);
+            group.bench_with_input(
+                BenchmarkId::new(backend.to_string(), case),
+                &(map, target),
+                |b, (map, target)| {
+                    b.iter(|| {
+                        black_box(map.get(target.as_str()));
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn benchmark_nested_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/nested_get");
+
+    for backend in BACKENDS {
+        for case in DEPTH_ONLY_CASES {
+            let value = nested_value_adhoc(case.depth, case.siblings, backend);
+            let path = nested_target_path(case.depth);
+            group.bench_with_input(
+                BenchmarkId::new(backend.to_string(), case),
+                &(value, path),
+                |b, (value, path)| {
+                    b.iter(|| {
+                        black_box(value.get(path.as_str()));
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn benchmark_nested_get_with_fanout(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/nested_get_with_fanout");
+
+    for backend in BACKENDS {
+        for case in DEPTH_WITH_FANOUT_CASES {
+            let value = nested_value_adhoc(case.depth, case.siblings, backend);
+            let path = nested_target_path(case.depth);
+            group.bench_with_input(
+                BenchmarkId::new(backend.to_string(), case),
+                &(value, path),
+                |b, (value, path)| {
+                    b.iter(|| {
+                        black_box(value.get(path.as_str()));
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn benchmark_nested_insert_with_fanout(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/nested_insert_with_fanout");
+
+    for backend in BACKENDS {
+        for case in DEPTH_WITH_FANOUT_CASES {
+            let base = nested_value_adhoc(case.depth, case.siblings, backend);
+            let path = format!("{}.write_leaf", nested_target_path(case.depth));
+            group.bench_with_input(
+                BenchmarkId::new(backend.to_string(), case),
+                &(base, path),
+                |b, (base, path)| {
+                    b.iter_batched(
+                        || base.clone(),
+                        |mut value| {
+                            black_box(value.insert(path.as_str(), Value::from(99)));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+}
+
+/// Benchmarks construction of a nested tree.
+/// Compares ad-hoc construction (each level creates a standalone ObjectMap)
+/// vs insert_child (child allocated through parent API).
+fn benchmark_nested_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/nested_build");
+
+    for backend in BACKENDS {
+        for case in DEPTH_WITH_FANOUT_CASES {
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/adhoc", backend), case),
+                &case,
+                |b, case| {
+                    b.iter(|| {
+                        black_box(nested_value_adhoc(case.depth, case.siblings, backend));
+                    });
+                },
+            );
+        }
+    }
+
+    for backend in BACKENDS {
+        for case in DEPTH_WITH_FANOUT_CASES {
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/insert_child", backend), case),
+                &case,
+                |b, case| {
+                    b.iter(|| {
+                        black_box(nested_value_insert_child(case.depth, case.siblings, backend));
+                    });
+                },
+            );
+        }
+    }
+}
+
+/// Benchmarks full round-trip: build a nested tree, then read from it.
+/// Compares the two construction methods while measuring the same read path.
+fn benchmark_build_then_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/build_then_read");
+
+    for backend in BACKENDS {
+        for case in DEPTH_WITH_FANOUT_CASES {
+            let path = nested_target_path(case.depth);
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/adhoc", backend), case),
+                &(case, path),
+                |b, (case, path)| {
+                    b.iter(|| {
+                        let value = nested_value_adhoc(case.depth, case.siblings, backend);
+                        black_box(value.get(path.as_str()));
+                    });
+                },
+            );
+        }
+    }
+
+    for backend in BACKENDS {
+        for case in DEPTH_WITH_FANOUT_CASES {
+            let path = nested_target_path(case.depth);
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/insert_child", backend), case),
+                &(case, path),
+                |b, (case, path)| {
+                    b.iter(|| {
+                        let value = nested_value_insert_child(case.depth, case.siblings, backend);
+                        black_box(value.get(path.as_str()));
+                    });
+                },
+            );
+        }
+    }
+}
+
+/// Simulates Vector's fan-out pattern: clone an event, then mutate the clone.
+/// This is where clone-on-write would show its benefit.
+fn benchmark_clone_then_mutate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap/clone_then_mutate");
+
+    for backend in BACKENDS {
+        for case in FLAT_CASES {
+            let map = flat_map(case.width, backend);
+            let event = Value::Object(map);
+
+            // Clone only
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/clone_only", backend), case),
+                &event,
+                |b, event| {
+                    b.iter(|| {
+                        black_box(event.clone());
+                    });
+                },
+            );
+
+            // Clone then insert 3 fields (simulates transform modifying a cloned event)
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/clone_insert_3", backend), case),
+                &event,
+                |b, event| {
+                    b.iter(|| {
+                        let mut cloned = event.clone();
+                        cloned.insert("_new_field_1", Value::from(1));
+                        cloned.insert("_new_field_2", Value::from(2));
+                        cloned.insert("_new_field_3", Value::from(3));
+                        black_box(cloned);
+                    });
+                },
+            );
+
+            // Clone then read 3 fields (simulates sink reading a cloned event)
+            let target = format!("key_{}", case.width / 2);
+            group.bench_with_input(
+                BenchmarkId::new(format!("{}/clone_read_3", backend), case),
+                &(event, target),
+                |b, (event, target)| {
+                    b.iter(|| {
+                        let cloned = event.clone();
+                        black_box(cloned.get(target.as_str()));
+                        black_box(cloned.get("key_0"));
+                        black_box(cloned.get("key_1"));
+                    });
+                },
+            );
+        }
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets =
+        benchmark_flat_insert,
+        benchmark_flat_get,
+        benchmark_nested_get,
+        benchmark_nested_get_with_fanout,
+        benchmark_nested_insert_with_fanout,
+        benchmark_nested_build,
+        benchmark_build_then_read,
+        benchmark_clone_then_mutate
+);
+criterion_main!(benches);

--- a/benches/objectmap_cliff.rs
+++ b/benches/objectmap_cliff.rs
@@ -1,0 +1,344 @@
+//! Microbenchmarks aimed at finding the map-width at which the Flat (EcoVec)
+//! `ObjectMap` backend begins to perform worse than the BTree backend.
+//!
+//! Primary axis: map width (number of entries in the map).
+//! Secondary axes:
+//!   - key length / shape (short identifier vs realistic dotted field name)
+//!   - operation kind (hit lookup, miss lookup, update-insert, bulk build,
+//!     and a mixed "realistic event" sequence that simulates a small VRL
+//!     program)
+//!
+//! Access pattern is held roughly constant per bench (we hit a key near the
+//! middle of the keyspace or a predictable pattern of keys) so runs are
+//! comparable across widths.
+//!
+//! Run with:
+//!   cargo bench --bench objectmap_cliff --features "default,test"
+//!
+//! NOTE: `ObjectMap::new()` selects a backend via the `VRL_OBJECT_MAP` env
+//! var, defaulting to Flat. This bench forces `Flat` by setting that env
+//! before any `ObjectMap` is constructed. `ObjectMap::new_btree()` is
+//! unaffected.
+
+use std::fmt;
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use vrl::value::{KeyString, ObjectMap, Value};
+
+// ---------------------------------------------------------------------------
+// Axes
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum Backend {
+    BTree,
+    Flat,
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BTree => write!(f, "btree"),
+            Self::Flat => write!(f, "flat"),
+        }
+    }
+}
+
+impl Backend {
+    fn new_map(self) -> ObjectMap {
+        match self {
+            Self::BTree => ObjectMap::new_btree(),
+            // `new()` honors VRL_OBJECT_MAP; we set it to "flat" in `main()`.
+            Self::Flat => ObjectMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum KeyStyle {
+    /// Short identifier-like keys ("k_0042"). Typical for synthetic tests
+    /// and some well-behaved schemas. ~6-8 bytes.
+    Short,
+    /// Realistic dotted field names mixed with numeric disambiguation
+    /// ("http.request.header_0042"). ~24-28 bytes. Realistic for log event
+    /// metadata and flattened objects.
+    Realistic,
+}
+
+impl fmt::Display for KeyStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Short => write!(f, "short_key"),
+            Self::Realistic => write!(f, "realistic_key"),
+        }
+    }
+}
+
+impl KeyStyle {
+    fn make(self, i: usize) -> String {
+        match self {
+            Self::Short => format!("k_{i:04}"),
+            Self::Realistic => format!("http.request.header_{i:04}"),
+        }
+    }
+}
+
+const BACKENDS: [Backend; 2] = [Backend::BTree, Backend::Flat];
+const KEY_STYLES: [KeyStyle; 2] = [KeyStyle::Short, KeyStyle::Realistic];
+/// Width sweep chosen to span small (where Flat should win) through large
+/// (where BTree's O(log n) should dominate). Exponential, but dense enough
+/// around the likely crossover (32-256) to read the cliff clearly.
+const WIDTHS: [usize; 9] = [4, 8, 16, 32, 64, 128, 256, 512, 1024];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_map(width: usize, style: KeyStyle, backend: Backend) -> ObjectMap {
+    let mut map = backend.new_map();
+    for i in 0..width {
+        map.insert(KeyString::from(style.make(i)), Value::from(i as i64));
+    }
+    map
+}
+
+/// Precompute keys the bench will exercise so `format!` is not on the hot path.
+struct ReadKeys {
+    /// The key right around the middle of the map (typical "average" hit).
+    mid: KeyString,
+    /// A key guaranteed to miss.
+    miss: KeyString,
+    /// Six realistic access keys distributed across the keyspace. Models a
+    /// small VRL program's read pattern.
+    mixed: [KeyString; 6],
+}
+
+fn read_keys(width: usize, style: KeyStyle) -> ReadKeys {
+    // Miss key shares the style so string-comparison cost is representative.
+    let miss_name = match style {
+        KeyStyle::Short => "k_MISSING".to_owned(),
+        KeyStyle::Realistic => "http.request.header_MISSING".to_owned(),
+    };
+    let pick = |frac_num: usize, frac_den: usize| {
+        // Clamp to [0, width-1].
+        let idx = (width.saturating_sub(1) * frac_num) / frac_den.max(1);
+        KeyString::from(style.make(idx))
+    };
+    ReadKeys {
+        mid: pick(1, 2),
+        miss: KeyString::from(miss_name),
+        mixed: [
+            pick(0, 1), // first
+            pick(1, 8), // near front
+            pick(3, 8),
+            pick(1, 2), // middle
+            pick(5, 8),
+            pick(7, 8), // near end
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+/// Single `get` for a key that exists near the middle of the map.
+/// This is the core read cliff: linear scan (Flat) vs log-n descent (BTree).
+fn bench_get_hit_mid(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_cliff/get_hit_mid");
+
+    for style in KEY_STYLES {
+        for backend in BACKENDS {
+            for &width in &WIDTHS {
+                let map = build_map(width, style, backend);
+                let keys = read_keys(width, style);
+                let id = format!("{backend}/{style}/width={width:04}");
+                group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                    b.iter(|| black_box(map.get(keys.mid.as_str())));
+                });
+            }
+        }
+    }
+}
+
+/// Single `get` for a key that does NOT exist. This is Flat's worst-case:
+/// the full O(n) scan runs every time.
+fn bench_get_miss(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_cliff/get_miss");
+
+    for style in KEY_STYLES {
+        for backend in BACKENDS {
+            for &width in &WIDTHS {
+                let map = build_map(width, style, backend);
+                let keys = read_keys(width, style);
+                let id = format!("{backend}/{style}/width={width:04}");
+                group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                    b.iter(|| black_box(map.get(keys.miss.as_str())));
+                });
+            }
+        }
+    }
+}
+
+/// Re-insert an existing key (in-place update). The insert path does a key
+/// lookup and then replaces the value in place. Uses a persistent map so the
+/// measurement excludes clone/drop cost (which would otherwise dominate
+/// BTree's numbers and make the comparison unfair). The map's key set is
+/// unchanged across iterations — only the value at `mid` is overwritten.
+fn bench_insert_update(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_cliff/insert_update");
+
+    for style in KEY_STYLES {
+        for backend in BACKENDS {
+            for &width in &WIDTHS {
+                let mut map = build_map(width, style, backend);
+                let keys = read_keys(width, style);
+                let id = format!("{backend}/{style}/width={width:04}");
+                group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                    let mut counter: i64 = 0;
+                    b.iter(|| {
+                        counter = counter.wrapping_add(1);
+                        black_box(map.insert(keys.mid.clone(), Value::from(counter)));
+                    });
+                });
+            }
+        }
+    }
+}
+
+/// Build a map of `width` entries from scratch. Captures the full-build cost,
+/// dominated by per-insert dedup scan for Flat (O(n^2)) vs rebalancing for
+/// BTree (O(n log n)).
+fn bench_build_from_scratch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_cliff/build");
+    // Build cost scales with width; let criterion sample fewer big iterations.
+    group.sample_size(30);
+
+    for style in KEY_STYLES {
+        for backend in BACKENDS {
+            for &width in &WIDTHS {
+                // Precompute key strings to keep the bench focused on the map.
+                let keys: Vec<KeyString> =
+                    (0..width).map(|i| KeyString::from(style.make(i))).collect();
+                let id = format!("{backend}/{style}/width={width:04}");
+                group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                    b.iter(|| {
+                        let mut map = backend.new_map();
+                        for (i, k) in keys.iter().enumerate() {
+                            map.insert(k.clone(), Value::from(i as i64));
+                        }
+                        black_box(map);
+                    });
+                });
+            }
+        }
+    }
+}
+
+/// Semi-realistic "one VRL program run against an event" sequence. Mirrors
+/// what Vector's regression bench shows (~6 lookups + ~2 inserts per event),
+/// applied to events of varying width (number of fields).
+///
+/// Per iteration, starting from a pre-built `base` map:
+///   - clone the map (events are copy-on-write in Vector's hot path)
+///   - 5 hits spread across the keyspace
+///   - 1 miss
+///   - 1 update (in-place insert of an existing key)
+///   - 1 new insert (append)
+///   - drop the clone
+///
+/// The clone is INSIDE the measured closure, so we capture BTree's O(n)
+/// deep-copy cost and Flat's O(1) refcount bump (with the first mutation
+/// triggering EcoVec's CoW). This matches how events actually flow through
+/// a VRL pipeline.
+fn bench_realistic_event(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_cliff/realistic_event");
+
+    // Realistic keys only; short identifier benches are less representative
+    // of real event schemas and this bench already produces many combinations.
+    let style = KeyStyle::Realistic;
+
+    for backend in BACKENDS {
+        for &width in &WIDTHS {
+            let base = build_map(width, style, backend);
+            let keys = read_keys(width, style);
+            let new_key = KeyString::from("http.request.header_NEW".to_owned());
+            let id = format!("{backend}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    let mut map = base.clone();
+                    for k in &keys.mixed[..5] {
+                        black_box(map.get(k.as_str()));
+                    }
+                    black_box(map.get(keys.miss.as_str()));
+                    black_box(map.insert(keys.mid.clone(), Value::from(1i64)));
+                    black_box(map.insert(new_key.clone(), Value::from(2i64)));
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+/// Same sequence as `realistic_event` but WITHOUT any mutation — pure
+/// read-only traversal of a cloned event. Captures the case where a VRL
+/// program is a pure filter/projection (no `.x = y`). For Flat this avoids
+/// triggering EcoVec's CoW, keeping the clone at O(1).
+fn bench_realistic_event_readonly(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_cliff/realistic_event_readonly");
+
+    let style = KeyStyle::Realistic;
+
+    for backend in BACKENDS {
+        for &width in &WIDTHS {
+            let base = build_map(width, style, backend);
+            let keys = read_keys(width, style);
+            let id = format!("{backend}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    let map = base.clone();
+                    for k in &keys.mixed {
+                        black_box(map.get(k.as_str()));
+                    }
+                    black_box(map.get(keys.miss.as_str()));
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+fn configured() -> Criterion {
+    // Keep total runtime reasonable: ~144 benches here (5 * 2 * 2 * 9 - 18 for
+    // realistic-only). Default criterion settings would run ~20+ minutes.
+    Criterion::default()
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(50)
+}
+
+fn force_flat_backend() {
+    // Fix backend choice so bench results are meaningful regardless of the
+    // user's shell env.
+    // SAFETY: benches run single-threaded before any ObjectMap is constructed.
+    unsafe { std::env::set_var("VRL_OBJECT_MAP", "flat") };
+}
+
+criterion_group!(
+    name = benches;
+    config = { force_flat_backend(); configured() };
+    targets =
+        bench_get_hit_mid,
+        bench_get_miss,
+        bench_insert_update,
+        bench_build_from_scratch,
+        bench_realistic_event,
+        bench_realistic_event_readonly,
+);
+criterion_main!(benches);

--- a/benches/objectmap_hybrid.rs
+++ b/benches/objectmap_hybrid.rs
@@ -1,0 +1,648 @@
+//! Hybrid ObjectMap design experiments.
+//!
+//! The `objectmap_cliff` benchmark showed that the Flat backend's linear-scan
+//! lookup cost produces large isolated-op cliffs, but the O(1) `EcoVec`-clone
+//! property keeps it competitive in realistic flows. This bench explores
+//! hybrid designs that attempt to keep the cheap-clone property while
+//! closing the lookup gap:
+//!
+//!   * `btree`            — baseline BTreeMap<KeyString, Value>
+//!   * `flat`             — unsorted EcoVec with linear-scan lookup (current
+//!                          Flat backend)
+//!   * `sorted`           — sorted EcoVec with binary-search lookup (proposed)
+//!   * `threshold(N)`     — sorted EcoVec up to N entries, then BTree (also
+//!                          proposed, but harder to justify unless `sorted`
+//!                          loses to BTree somewhere)
+//!
+//! These are implemented inline in the bench so we can iterate without
+//! churning the library. Results tell us whether a hybrid design is worth
+//! productionizing and where to put the threshold.
+//!
+//! Run with:
+//!   cargo bench --bench objectmap_hybrid --features "default,test"
+
+use std::fmt;
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ecow::EcoVec;
+use vrl::value::{KeyString, Value};
+
+// ---------------------------------------------------------------------------
+// Candidate map representations
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+#[allow(dead_code)] // Threshold variants retained for historical reference.
+enum HybridMap {
+    BTree(std::collections::BTreeMap<KeyString, Value>),
+    /// Unsorted; insertion-order `push`; linear-scan lookup. Matches the
+    /// current `Flat` backend semantics.
+    FlatEco(EcoVec<(KeyString, Value)>),
+    /// Always-sorted-by-key; binary-search lookup.
+    SortedEco(EcoVec<(KeyString, Value)>),
+    /// Starts as SortedEco; promotes to BTree once `len >= threshold` on
+    /// insert. Demotion is never attempted (the typical pipeline doesn't
+    /// shrink back).
+    Threshold(ThresholdMap),
+    /// Like FlatEco, but remembers whether entries are sorted. `get` sorts
+    /// the vec on first call after mutations; subsequent gets binary-search.
+    /// Size: EcoVec (16B) + bool + padding = 24B — same as the BTreeMap
+    /// variant, so adding this to the real ObjectMap enum would not grow it.
+    LazySorted(LazySorted),
+}
+
+#[derive(Clone)]
+struct LazySorted {
+    entries: EcoVec<(KeyString, Value)>,
+    /// Invariant: when `true`, `entries` is sorted by key and contains no
+    /// duplicate keys. When `false`, entries is in insertion order and may
+    /// contain duplicates (newer key-value overrides older).
+    sorted: bool,
+}
+
+#[derive(Clone)]
+#[allow(dead_code)]
+struct ThresholdMap {
+    threshold: usize,
+    inner: ThresholdInner,
+}
+
+#[derive(Clone)]
+#[allow(dead_code)]
+enum ThresholdInner {
+    Small(EcoVec<(KeyString, Value)>),
+    Large(std::collections::BTreeMap<KeyString, Value>),
+}
+
+impl HybridMap {
+    fn new_btree() -> Self {
+        Self::BTree(std::collections::BTreeMap::new())
+    }
+    fn new_flat() -> Self {
+        Self::FlatEco(EcoVec::new())
+    }
+    fn new_sorted() -> Self {
+        Self::SortedEco(EcoVec::new())
+    }
+    #[allow(dead_code)]
+    fn new_threshold(threshold: usize) -> Self {
+        Self::Threshold(ThresholdMap {
+            threshold,
+            inner: ThresholdInner::Small(EcoVec::new()),
+        })
+    }
+    fn new_lazy_sorted() -> Self {
+        Self::LazySorted(LazySorted {
+            entries: EcoVec::new(),
+            sorted: true, // vacuously
+        })
+    }
+
+    /// Mutable-self get: required by the `LazySorted` variant (first lookup
+    /// after mutation triggers a sort). All other variants ignore `&mut`.
+    /// This is a bench-level concession — a production `LazySorted` would
+    /// need interior mutability (e.g. an `UnsafeCell<bool>` + `UnsafeCell`
+    /// or a dedicated `get_mut` API).
+    fn get(&mut self, key: &str) -> Option<&Value> {
+        match self {
+            Self::BTree(m) => m.get(key),
+            Self::FlatEco(v) => v.iter().find(|(k, _)| k.as_str() == key).map(|(_, v)| v),
+            Self::SortedEco(v) => match v.binary_search_by(|(ek, _)| ek.as_str().cmp(key)) {
+                Ok(idx) => Some(&v[idx].1),
+                Err(_) => None,
+            },
+            Self::Threshold(t) => match &t.inner {
+                ThresholdInner::Small(v) => {
+                    match v.binary_search_by(|(ek, _)| ek.as_str().cmp(key)) {
+                        Ok(idx) => Some(&v[idx].1),
+                        Err(_) => None,
+                    }
+                }
+                ThresholdInner::Large(m) => m.get(key),
+            },
+            Self::LazySorted(ls) => {
+                if !ls.sorted {
+                    // Sort with dedup: inserts are pure appends, so there
+                    // may be multiple entries per key. Stable sort keeps
+                    // insertion order within duplicates; we then collapse
+                    // adjacent dupes keeping the LAST (i.e. most recent)
+                    // value per key.
+                    let slice = ls.entries.make_mut();
+                    slice.sort_by(|a, b| a.0.cmp(&b.0));
+                    // Collapse adjacent duplicates keeping the last. Walk
+                    // in reverse; move each unique key to the front.
+                    let mut write = 0usize;
+                    let mut i = 0usize;
+                    while i < slice.len() {
+                        // Find end of the run of equal keys starting at i.
+                        let mut j = i + 1;
+                        while j < slice.len() && slice[j].0 == slice[i].0 {
+                            j += 1;
+                        }
+                        // The last element of the run (index j-1) is the
+                        // most recent insertion for this key (stable sort).
+                        if write != j - 1 {
+                            slice.swap(write, j - 1);
+                        }
+                        write += 1;
+                        i = j;
+                    }
+                    // Truncate the tail.
+                    let new_len = write;
+                    // EcoVec doesn't expose truncate directly on make_mut's
+                    // slice, but the EcoVec itself does via `truncate`.
+                    ls.entries.truncate(new_len);
+                    ls.sorted = true;
+                }
+                match ls.entries.binary_search_by(|(ek, _)| ek.as_str().cmp(key)) {
+                    Ok(idx) => Some(&ls.entries[idx].1),
+                    Err(_) => None,
+                }
+            }
+        }
+    }
+
+    fn insert(&mut self, key: KeyString, value: Value) -> Option<Value> {
+        match self {
+            Self::BTree(m) => m.insert(key, value),
+            Self::FlatEco(v) => {
+                if let Some(pos) = v.iter().position(|(k, _)| *k == key) {
+                    Some(std::mem::replace(&mut v.make_mut()[pos].1, value))
+                } else {
+                    v.push((key, value));
+                    None
+                }
+            }
+            Self::SortedEco(v) => {
+                match v.binary_search_by(|(ek, _)| ek.as_str().cmp(key.as_str())) {
+                    Ok(idx) => Some(std::mem::replace(&mut v.make_mut()[idx].1, value)),
+                    Err(idx) => {
+                        v.insert(idx, (key, value));
+                        None
+                    }
+                }
+            }
+            Self::Threshold(t) => {
+                let threshold = t.threshold;
+                // Promote if we'd be inserting the `threshold`-th entry (as a
+                // new key). Cheap check: only promote on Err from binary_search
+                // when len == threshold.
+                match &mut t.inner {
+                    ThresholdInner::Small(v) => {
+                        match v.binary_search_by(|(ek, _)| ek.as_str().cmp(key.as_str())) {
+                            Ok(idx) => Some(std::mem::replace(&mut v.make_mut()[idx].1, value)),
+                            Err(idx) => {
+                                if v.len() >= threshold {
+                                    // Promote: move entries into a BTreeMap.
+                                    let old = std::mem::replace(v, EcoVec::new());
+                                    let mut m = std::collections::BTreeMap::new();
+                                    for (k, val) in old {
+                                        m.insert(k, val);
+                                    }
+                                    m.insert(key, value);
+                                    t.inner = ThresholdInner::Large(m);
+                                    None
+                                } else {
+                                    v.insert(idx, (key, value));
+                                    None
+                                }
+                            }
+                        }
+                    }
+                    ThresholdInner::Large(m) => m.insert(key, value),
+                }
+            }
+            Self::LazySorted(ls) => {
+                // Two-path insert:
+                //   Sorted state → binary_search; update in place if found,
+                //   push+mark-unsorted if not (stays sorted only if the new
+                //   key happens to sort at the end).
+                //   Unsorted state → pure append. No dedup; the next `get`
+                //   will sort+dedup. This gives O(1) inserts during bulk
+                //   builds (the worst case for `sorted`) at the cost of
+                //   potentially keeping duplicate entries around until the
+                //   next read triggers cleanup.
+                if ls.sorted {
+                    match ls
+                        .entries
+                        .binary_search_by(|(ek, _)| ek.as_str().cmp(key.as_str()))
+                    {
+                        Ok(idx) => {
+                            Some(std::mem::replace(&mut ls.entries.make_mut()[idx].1, value))
+                        }
+                        Err(idx) => {
+                            if idx == ls.entries.len() {
+                                ls.entries.push((key, value));
+                                // sorted remains true
+                            } else {
+                                ls.entries.push((key, value));
+                                ls.sorted = false;
+                            }
+                            None
+                        }
+                    }
+                } else {
+                    // Append without dedup. Duplicates will be collapsed
+                    // on next read.
+                    ls.entries.push((key, value));
+                    // We don't know if the prior inserts produced a
+                    // duplicate; return None. Update semantics are still
+                    // correct because sort+dedup keeps the last value per
+                    // key, and the caller of insert-returning-Option almost
+                    // never actually uses the returned prior value.
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Variant {
+    BTree,
+    Flat,
+    Sorted,
+    Lazy,
+}
+
+impl Variant {
+    fn make(self) -> HybridMap {
+        match self {
+            Self::BTree => HybridMap::new_btree(),
+            Self::Flat => HybridMap::new_flat(),
+            Self::Sorted => HybridMap::new_sorted(),
+            Self::Lazy => HybridMap::new_lazy_sorted(),
+        }
+    }
+}
+
+impl fmt::Display for Variant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BTree => write!(f, "btree"),
+            Self::Flat => write!(f, "flat"),
+            Self::Sorted => write!(f, "sorted"),
+            Self::Lazy => write!(f, "lazy"),
+        }
+    }
+}
+
+const VARIANTS: [Variant; 4] = [
+    Variant::BTree,
+    Variant::Flat,
+    Variant::Sorted,
+    Variant::Lazy,
+];
+
+/// Widths chosen to span below and above the predicted threshold crossovers.
+const WIDTHS: [usize; 9] = [4, 8, 16, 32, 64, 128, 256, 512, 1024];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn key(i: usize) -> KeyString {
+    KeyString::from(format!("http.request.header_{i:04}"))
+}
+
+fn miss_key() -> KeyString {
+    KeyString::from("http.request.header_MISSING")
+}
+
+fn new_key() -> KeyString {
+    KeyString::from("http.request.header_NEW")
+}
+
+fn build(variant: Variant, width: usize) -> HybridMap {
+    let mut map = variant.make();
+    for i in 0..width {
+        map.insert(key(i), Value::from(i as i64));
+    }
+    map
+}
+
+struct ReadKeys {
+    mid: KeyString,
+    miss: KeyString,
+    mixed: [KeyString; 6],
+}
+
+fn read_keys(width: usize) -> ReadKeys {
+    let pick = |num: usize, den: usize| key((width.saturating_sub(1) * num) / den.max(1));
+    ReadKeys {
+        mid: pick(1, 2),
+        miss: miss_key(),
+        mixed: [
+            pick(0, 1),
+            pick(1, 8),
+            pick(3, 8),
+            pick(1, 2),
+            pick(5, 8),
+            pick(7, 8),
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_get_hit_mid(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/get_hit_mid");
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            // For LazySorted, trigger a priming lookup so the map is sorted
+            // before the timed loop. This captures the *steady-state* get
+            // cost (all variants already-ready). `build_then_first_read`
+            // below covers the cold-sort case.
+            let mut map = build(variant, width);
+            let keys = read_keys(width);
+            let _ = map.get(keys.mid.as_str());
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    black_box(map.get(keys.mid.as_str()));
+                });
+            });
+        }
+    }
+}
+
+fn bench_get_miss(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/get_miss");
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let mut map = build(variant, width);
+            let keys = read_keys(width);
+            let _ = map.get(keys.miss.as_str());
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    black_box(map.get(keys.miss.as_str()));
+                });
+            });
+        }
+    }
+}
+
+fn bench_insert_update(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/insert_update");
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let mut map = build(variant, width);
+            let keys = read_keys(width);
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                let mut counter: i64 = 0;
+                b.iter(|| {
+                    counter = counter.wrapping_add(1);
+                    black_box(map.insert(keys.mid.clone(), Value::from(counter)));
+                });
+            });
+        }
+    }
+}
+
+fn bench_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/build");
+    group.sample_size(30);
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let keys: Vec<KeyString> = (0..width).map(key).collect();
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    let mut map = variant.make();
+                    for (i, k) in keys.iter().enumerate() {
+                        map.insert(k.clone(), Value::from(i as i64));
+                    }
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+/// Same as `bench_build` but with keys inserted in a scrambled (non-sorted)
+/// order. For the `sorted` variant each insertion now requires shifting the
+/// tail, so this is the worst case for vector-based sorted maps. BTree is
+/// insertion-order-agnostic.
+fn bench_build_shuffled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/build_shuffled");
+    group.sample_size(30);
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            // Cheap deterministic scramble: reverse and interleave halves.
+            // Produces a permutation that puts every insertion near the
+            // middle, maximizing shift cost for sorted vectors.
+            let mut keys: Vec<KeyString> = (0..width).map(key).collect();
+            let half = keys.len() / 2;
+            let (a, b) = keys.split_at(half);
+            let scrambled: Vec<KeyString> = a
+                .iter()
+                .zip(b.iter().rev())
+                .flat_map(|(x, y)| [x.clone(), y.clone()])
+                .chain(if keys.len() % 2 == 1 {
+                    Some(keys.last().unwrap().clone())
+                } else {
+                    None
+                })
+                .collect();
+            keys = scrambled;
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    let mut map = variant.make();
+                    for (i, k) in keys.iter().enumerate() {
+                        map.insert(k.clone(), Value::from(i as i64));
+                    }
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+fn bench_realistic_event(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/realistic_event");
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let mut base = build(variant, width);
+            // Prime the sort for LazySorted so the base is already sorted
+            // (simulates a long-lived source event whose sort state
+            // amortizes across many fan-out clones).
+            let keys = read_keys(width);
+            let _ = base.get(keys.mid.as_str());
+            let new_k = new_key();
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    let mut map = base.clone();
+                    for k in &keys.mixed[..5] {
+                        black_box(map.get(k.as_str()));
+                    }
+                    black_box(map.get(keys.miss.as_str()));
+                    black_box(map.insert(keys.mid.clone(), Value::from(1i64)));
+                    black_box(map.insert(new_k.clone(), Value::from(2i64)));
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+fn bench_realistic_event_readonly(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/realistic_event_readonly");
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let mut base = build(variant, width);
+            let keys = read_keys(width);
+            let _ = base.get(keys.mid.as_str());
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b| {
+                b.iter(|| {
+                    let mut map = base.clone();
+                    for k in &keys.mixed {
+                        black_box(map.get(k.as_str()));
+                    }
+                    black_box(map.get(keys.miss.as_str()));
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+/// Cold-path benchmark for LazySorted: build a map of N entries (shuffled
+/// insertion order, so Sorted pays its O(N^2) shift cost) and then perform
+/// a single lookup. For LazySorted, the first lookup is where the O(N log N)
+/// sort happens — this bench captures the amortized "build + activation"
+/// cost that steady-state get benches miss.
+fn bench_build_then_first_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/build_then_first_read");
+    group.sample_size(30);
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let mut keys: Vec<KeyString> = (0..width).map(key).collect();
+            let half = keys.len() / 2;
+            let (a, b) = keys.split_at(half);
+            let scrambled: Vec<KeyString> = a
+                .iter()
+                .zip(b.iter().rev())
+                .flat_map(|(x, y)| [x.clone(), y.clone()])
+                .chain(if keys.len() % 2 == 1 {
+                    Some(keys.last().unwrap().clone())
+                } else {
+                    None
+                })
+                .collect();
+            keys = scrambled;
+            let read_keys_ = read_keys(width);
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b_| {
+                b_.iter(|| {
+                    let mut map = variant.make();
+                    for (i, k) in keys.iter().enumerate() {
+                        map.insert(k.clone(), Value::from(i as i64));
+                    }
+                    // Single lookup — for LazySorted this triggers the
+                    // internal sort.
+                    black_box(map.get(read_keys_.mid.as_str()));
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+/// Build a map of N entries in shuffled order, then do 10 lookups. This
+/// amortizes LazySorted's sort cost across multiple reads (the typical
+/// pattern for a source event that the pipeline reads many fields from).
+fn bench_build_then_many_reads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("objectmap_hybrid/build_then_many_reads");
+    group.sample_size(30);
+    for variant in VARIANTS {
+        for &width in &WIDTHS {
+            let mut keys: Vec<KeyString> = (0..width).map(key).collect();
+            let half = keys.len() / 2;
+            let (a, b) = keys.split_at(half);
+            let scrambled: Vec<KeyString> = a
+                .iter()
+                .zip(b.iter().rev())
+                .flat_map(|(x, y)| [x.clone(), y.clone()])
+                .chain(if keys.len() % 2 == 1 {
+                    Some(keys.last().unwrap().clone())
+                } else {
+                    None
+                })
+                .collect();
+            keys = scrambled;
+            let read_keys_ = read_keys(width);
+            let id = format!("{variant}/width={width:04}");
+            group.bench_function(BenchmarkId::from_parameter(&id), |b_| {
+                b_.iter(|| {
+                    let mut map = variant.make();
+                    for (i, k) in keys.iter().enumerate() {
+                        map.insert(k.clone(), Value::from(i as i64));
+                    }
+                    for k in &read_keys_.mixed {
+                        black_box(map.get(k.as_str()));
+                    }
+                    black_box(map.get(read_keys_.miss.as_str()));
+                    black_box(map.get(read_keys_.mid.as_str()));
+                    black_box(map.get(read_keys_.mid.as_str()));
+                    black_box(map.get(read_keys_.mid.as_str()));
+                    black_box(map);
+                });
+            });
+        }
+    }
+}
+
+/// Prints the size (and memory layout) of each candidate type. Called
+/// before the bench suite runs so the numbers are visible in bench output.
+fn print_sizes() {
+    use std::mem::size_of;
+    eprintln!("---- type sizes ----");
+    eprintln!(
+        "ObjectMap (real):        {} bytes",
+        size_of::<vrl::value::ObjectMap>()
+    );
+    eprintln!("HybridMap (this bench):  {} bytes", size_of::<HybridMap>());
+    eprintln!(
+        "EcoVec<(K,V)>:           {} bytes",
+        size_of::<EcoVec<(KeyString, Value)>>()
+    );
+    eprintln!("LazySorted struct:       {} bytes", size_of::<LazySorted>());
+    eprintln!(
+        "BTreeMap<K,V>:           {} bytes",
+        size_of::<std::collections::BTreeMap<KeyString, Value>>()
+    );
+    eprintln!("---------------------");
+}
+
+fn configured() -> Criterion {
+    print_sizes();
+    Criterion::default()
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(50)
+}
+
+criterion_group!(
+    name = benches;
+    config = configured();
+    targets =
+        bench_get_hit_mid,
+        bench_get_miss,
+        bench_insert_update,
+        bench_build,
+        bench_build_shuffled,
+        bench_build_then_first_read,
+        bench_build_then_many_reads,
+        bench_realistic_event,
+        bench_realistic_event_readonly,
+);
+criterion_main!(benches);

--- a/benches/objectmap_hybrid.rs
+++ b/benches/objectmap_hybrid.rs
@@ -6,13 +6,11 @@
 //! hybrid designs that attempt to keep the cheap-clone property while
 //! closing the lookup gap:
 //!
-//!   * `btree`            — baseline BTreeMap<KeyString, Value>
-//!   * `flat`             — unsorted EcoVec with linear-scan lookup (current
-//!                          Flat backend)
-//!   * `sorted`           — sorted EcoVec with binary-search lookup (proposed)
-//!   * `threshold(N)`     — sorted EcoVec up to N entries, then BTree (also
-//!                          proposed, but harder to justify unless `sorted`
-//!                          loses to BTree somewhere)
+//! * `btree` — baseline BTreeMap<KeyString, Value>
+//! * `flat` — unsorted EcoVec with linear-scan lookup (current Flat backend)
+//! * `sorted` — sorted EcoVec with binary-search lookup (proposed)
+//! * `threshold(N)` — sorted EcoVec up to N entries, then BTree (also proposed,
+//!   but harder to justify unless `sorted` loses to BTree somewhere)
 //!
 //! These are implemented inline in the bench so we can iterate without
 //! churning the library. Results tell us whether a hybrid design is worth
@@ -603,6 +601,7 @@ fn bench_build_then_many_reads(c: &mut Criterion) {
 
 /// Prints the size (and memory layout) of each candidate type. Called
 /// before the bench suite runs so the numbers are visible in bench output.
+#[allow(clippy::print_stderr)]
 fn print_sizes() {
     use std::mem::size_of;
     eprintln!("---- type sizes ----");

--- a/examples/check_sizes.rs
+++ b/examples/check_sizes.rs
@@ -1,11 +1,23 @@
 use std::mem;
-use vrl::value::{ObjectMap, Value, KeyString};
+use vrl::value::{KeyString, ObjectMap, Value};
 
 fn main() {
     println!("ObjectMap:    {} bytes", mem::size_of::<ObjectMap>());
     println!("Value:        {} bytes", mem::size_of::<Value>());
-    println!("Vec<(K,V)>:   {} bytes", mem::size_of::<Vec<(KeyString, Value)>>());
-    println!("BTreeMap:     {} bytes", mem::size_of::<std::collections::BTreeMap<KeyString, Value>>());
-    println!("HashMap:      {} bytes", mem::size_of::<std::collections::HashMap<KeyString, Value>>());
-    println!("IndexMap:     {} bytes", mem::size_of::<indexmap::IndexMap<KeyString, Value>>());
+    println!(
+        "Vec<(K,V)>:   {} bytes",
+        mem::size_of::<Vec<(KeyString, Value)>>()
+    );
+    println!(
+        "BTreeMap:     {} bytes",
+        mem::size_of::<std::collections::BTreeMap<KeyString, Value>>()
+    );
+    println!(
+        "HashMap:      {} bytes",
+        mem::size_of::<std::collections::HashMap<KeyString, Value>>()
+    );
+    println!(
+        "IndexMap:     {} bytes",
+        mem::size_of::<indexmap::IndexMap<KeyString, Value>>()
+    );
 }

--- a/examples/check_sizes.rs
+++ b/examples/check_sizes.rs
@@ -1,0 +1,11 @@
+use std::mem;
+use vrl::value::{ObjectMap, Value, KeyString};
+
+fn main() {
+    println!("ObjectMap:    {} bytes", mem::size_of::<ObjectMap>());
+    println!("Value:        {} bytes", mem::size_of::<Value>());
+    println!("Vec<(K,V)>:   {} bytes", mem::size_of::<Vec<(KeyString, Value)>>());
+    println!("BTreeMap:     {} bytes", mem::size_of::<std::collections::BTreeMap<KeyString, Value>>());
+    println!("HashMap:      {} bytes", mem::size_of::<std::collections::HashMap<KeyString, Value>>());
+    println!("IndexMap:     {} bytes", mem::size_of::<indexmap::IndexMap<KeyString, Value>>());
+}

--- a/examples/check_sizes.rs
+++ b/examples/check_sizes.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stdout)]
+
 use std::mem;
 use vrl::value::{KeyString, ObjectMap, Value};
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeMap;
 use vrl::{
     compiler::{Context, TargetValue, TimeZone, state::RuntimeState},
     value,
-    value::{Secrets, Value},
+    value::{ObjectMap, Secrets, Value},
 };
 
 fn main() {
@@ -21,7 +20,7 @@ fn main() {
         // the value starts as just an object with a single field "x" set to 1
         value: value!({x: 1}),
         // the metadata is empty
-        metadata: Value::Object(BTreeMap::new()),
+        metadata: Value::Object(ObjectMap::new()),
         // and there are no secrets associated with the target
         secrets: Secrets::default(),
     };

--- a/lib/fuzz/src/main.rs
+++ b/lib/fuzz/src/main.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate afl;
 
-use std::collections::BTreeMap;
-
 use vrl::compiler::state::RuntimeState;
 use vrl::compiler::{CompileConfig, TargetValue};
 use vrl::prelude::state::ExternalEnv;
@@ -36,7 +34,7 @@ fn fuzz(src: &str) {
     if let Ok(result) = vrl::compiler::compile_with_external(src, &fns, &external, config) {
         let mut target = TargetValue {
             value: value!({}),
-            metadata: Value::Object(BTreeMap::new()),
+            metadata: Value::Object(ObjectMap::new()),
             secrets: Secrets::default(),
         };
 

--- a/objectmap-optimization-proposal.md
+++ b/objectmap-optimization-proposal.md
@@ -1,0 +1,85 @@
+# Proposal: Optimized ObjectMap Representation
+
+## Summary
+
+We propose replacing the `ObjectMap` type alias (`type ObjectMap = BTreeMap<KeyString, Value>`) with a proper newtype struct, enabling aggressive internal optimization while preserving the existing API. The goal is to reduce pointer indirections and improve cache locality for the core data structure underlying Vector's `LogEvent`.
+
+## Motivation
+
+In Vector, every log event is ultimately stored as a VRL `Value::Object(ObjectMap)`. The current representation — a `BTreeMap<KeyString, Value>` — has several performance characteristics that are suboptimal for the actual workload:
+
+- **Poor cache locality**: BTreeMap nodes are heap-allocated and pointer-linked. For typical log events (5-20 flat fields), tree traversal adds overhead compared to a flat, contiguous layout.
+- **Deep pointer chains**: Accessing a string field in a LogEvent requires 5-6 pointer indirections: `LogEvent -> Arc<Inner> -> Value::Object(BTreeMap) -> BTreeMap node -> Value::Bytes(Bytes) -> heap data`.
+- **Copy-on-write cost**: Vector wraps events in `Arc<Inner>` for cheap cloning. The first mutation after a clone copies the *entire* Value tree, including all BTreeMap nodes.
+
+The path-based CRUD operations (`insert`, `get`, `remove` with nested paths) are implemented on `Value` in VRL, making VRL the right place to optimize — doing it downstream in Vector would leave the hottest code path (the remap transform) untouched.
+
+## Current State
+
+- `ObjectMap` is a bare type alias for `BTreeMap<KeyString, Value>` (defined in `src/value/value.rs`)
+- `KeyString` is a newtype around `String`, explicitly documented as opaque with the comment: *"the underlying type is opaque and may change for efficiency"*
+- The `ValueCollection` trait in `src/value/value/crud/mod.rs` already provides an abstraction over ObjectMap's CRUD operations (`get_value`, `insert_value`, `remove_value`, etc.)
+- VRL has existing quickcheck property tests on Value operations
+
+## Proposed Approach
+
+### Phase 1: Newtype + Test Oracle
+
+1. **Replace the type alias with a proper struct**: `pub struct ObjectMap(BTreeMap<KeyString, Value>)`. Implement the same traits (`IntoIterator`, `FromIterator`, `Index`, `Serialize`/`Deserialize`, etc.) so all existing code compiles.
+2. **Build a comprehensive differential test harness**: The oracle is the current BTreeMap implementation. Generate random sequences of operations (insert, get, remove, iterate, serialize) and assert both implementations produce identical results. Extend the existing quickcheck infrastructure.
+3. **Add benchmarks** for the actual hot operations: insert-then-serialize, bulk field iteration, nested path insert/get, clone-then-mutate.
+
+### Phase 2: Optimize Internals
+
+With the test harness in place, explore alternative internal representations:
+
+- **Sorted `Vec<(KeyString, Value)>`**: Identical semantics to BTreeMap for small-to-medium maps, dramatically better cache locality. Binary search gives O(log n) lookup.
+- **Small-map optimization**: Inline storage for maps below a threshold (e.g., 8-16 entries), avoiding heap allocation entirely for typical log events.
+- **Arena-backed storage**: Store keys and values in a contiguous byte buffer with an index for O(log n) lookup. Reduces per-entry allocation overhead.
+
+### Phase 3: Downstream Validation
+
+- Bump VRL dependency in Vector
+- Run Vector's full test suite and benchmarks
+- Validate with real-world pipeline configurations
+
+## Constraints
+
+- **Sorted iteration order must be preserved.** BTreeMap's sorted key order is depended on by JSON serialization, VRL tests, and deterministic output.
+- **Path-based CRUD semantics must be identical.** `insert(["a", "b", "c"], v)` must auto-create intermediate objects. `remove` with pruning must clean up empty parents.
+- **Serde compatibility.** Serializes as JSON object, deserializes from JSON object.
+- **VRL has consumers beyond Vector.** Any code that relies on ObjectMap being a BTreeMap (e.g., calling BTreeMap-specific methods not exposed through traits) will need updating.
+
+## API Surface to Preserve
+
+Based on analysis of actual usage across Vector (~320 direct ObjectMap references in 57 files) and VRL internals, the exercised API is:
+
+| Operation | Notes |
+|-----------|-------|
+| `new()`, `default()` | Construction |
+| `insert(key, value)` | Returns previous value |
+| `get(key)` / `get_mut(key)` | Key lookup |
+| `remove(key)` | Key removal |
+| `contains_key(key)` | Existence check |
+| `keys()` / `values()` / `iter()` / `iter_mut()` | Iteration |
+| `len()` / `is_empty()` | Size queries |
+| `into_iter()` / `from_iter()` | Conversion |
+| `entry(key)` | Entry API (used in some places) |
+| `extend(iter)` | Bulk insertion |
+| `Serialize` / `Deserialize` | Serde support |
+| `ValueCollection` trait methods | VRL CRUD dispatch |
+
+## Risks
+
+1. **Entry API complexity**: BTreeMap's `entry()` returns a specific `Entry` enum. A custom struct needs its own Entry type. This is mechanical but touches call sites.
+2. **KeyString co-optimization**: KeyString (currently heap-allocated `String`) could benefit from small-string optimization or interning, but changing both types simultaneously increases risk. Recommend sequencing ObjectMap first.
+3. **Nested map performance**: Nested objects create nested ObjectMaps. A flat representation only helps at each level individually — truly flat event storage (single allocation for the whole event) would require deeper changes to `Value` itself.
+4. **BTreeMap method leakage**: Any code calling BTreeMap-specific methods (e.g., `range()`, `split_off()`) through the current type alias would break. Needs an audit of all usage sites.
+
+## Expected Impact
+
+The primary beneficiaries in Vector are:
+- **Remap transform**: Executes VRL programs that call `insert`/`get`/`remove` per event — the single hottest path for field access
+- **Sink serialization**: Every sink serializes events, iterating all fields
+- **Reduce transform**: Iterates all fields of every event during aggregation
+- **Event creation in sources**: Sequential field insertion when constructing events from raw data

--- a/release/src/changelog.rs
+++ b/release/src/changelog.rs
@@ -256,6 +256,7 @@ impl Changelog {
                 "--diff-filter=A",
                 "--merge-base",
                 "origin/main",
+                "--",
                 "changelog.d",
             ])
             .current_dir(&self.repo_root)
@@ -465,6 +466,21 @@ mod tests {
 
     // --- check_fragments ---
 
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
     fn setup_git_check_repo(fragments: &[(&str, &str)]) -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path();
@@ -475,48 +491,27 @@ mod tests {
             vec!["init", "-b", "base"],
             vec!["config", "user.email", "test@test.com"],
             vec!["config", "user.name", "Test"],
+            vec!["config", "commit.gpgsign", "false"],
+            vec!["config", "core.fsmonitor", "false"],
+            vec!["config", "core.untrackedCache", "false"],
         ] {
-            std::process::Command::new("git")
-                .args(&cmd)
-                .current_dir(repo)
-                .output()
-                .unwrap();
+            run_git(repo, &cmd);
         }
 
         let changelog_dir = repo.join("changelog.d");
         fs::create_dir(&changelog_dir).unwrap();
         fs::write(changelog_dir.join("README.md"), "# Changelog fragments").unwrap();
 
-        std::process::Command::new("git")
-            .args(["add", "-A"])
-            .current_dir(repo)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["commit", "-m", "initial"])
-            .current_dir(repo)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
-            .current_dir(repo)
-            .output()
-            .unwrap();
+        run_git(repo, &["add", "-A"]);
+        run_git(repo, &["commit", "-m", "initial"]);
+        run_git(repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
 
         for (name, content) in fragments {
             fs::write(changelog_dir.join(name), content).unwrap();
         }
 
-        std::process::Command::new("git")
-            .args(["add", "-A"])
-            .current_dir(repo)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["commit", "-m", "add fragments"])
-            .current_dir(repo)
-            .output()
-            .unwrap();
+        run_git(repo, &["add", "-A"]);
+        run_git(repo, &["commit", "-m", "add fragments"]);
 
         dir
     }

--- a/scripts/fix-objectmap-leaks.sh
+++ b/scripts/fix-objectmap-leaks.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+#
+# fix-objectmap-leaks.sh
+#
+# Replaces direct BTreeMap usage with ObjectMap wherever the BTreeMap
+# represents a KeyString -> Value map (i.e., is used as an ObjectMap).
+#
+# Safe to re-run after rebasing. Idempotent — already-fixed sites won't match.
+#
+# Requirements: comby (https://comby.dev)
+#
+# Usage:
+#   ./scripts/fix-objectmap-leaks.sh          # dry-run (default)
+#   ./scripts/fix-objectmap-leaks.sh --apply  # apply changes in-place
+#
+set -euo pipefail
+
+APPLY=""
+if [[ "${1:-}" == "--apply" ]]; then
+  APPLY="-in-place"
+  echo "==> Applying changes in-place"
+else
+  echo "==> Dry run (pass --apply to modify files)"
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+run_comby() {
+  local match="$1"
+  local rewrite="$2"
+  local extensions="${3:-.rs}"
+
+  if [[ -n "$APPLY" ]]; then
+    comby "$match" "$rewrite" "$extensions" -in-place -matcher .rs 2>/dev/null
+  else
+    comby "$match" "$rewrite" "$extensions" -diff -matcher .rs 2>/dev/null
+  fi
+}
+
+echo ""
+echo "--- Group A: Comby patterns (context-safe replacements) ---"
+echo ""
+
+echo "[1] Value::Object(BTreeMap::new())"
+run_comby \
+  'Value::Object(BTreeMap::new())' \
+  'Value::Object(ObjectMap::new())'
+
+echo "[2] Value::Object(BTreeMap::default())"
+run_comby \
+  'Value::Object(BTreeMap::default())' \
+  'Value::Object(ObjectMap::default())'
+
+echo "[3] Value::Object(std::collections::BTreeMap::new())"
+run_comby \
+  'Value::Object(std::collections::BTreeMap::new())' \
+  'Value::Object(ObjectMap::new())'
+
+echo "[4] Value::from(BTreeMap::new())"
+run_comby \
+  'Value::from(BTreeMap::new())' \
+  'Value::from(ObjectMap::new())'
+
+echo "[5] Value::from(BTreeMap::default())"
+run_comby \
+  'Value::from(BTreeMap::default())' \
+  'Value::from(ObjectMap::default())'
+
+echo "[6] Value::Object(BTreeMap::from(...))"
+# Run twice: comby treats matched holes as opaque, so nested
+# occurrences inside :[args] aren't rewritten on the first pass.
+run_comby \
+  'Value::Object(BTreeMap::from(:[args]))' \
+  'Value::Object(ObjectMap::from(:[args]))'
+run_comby \
+  'Value::Object(BTreeMap::from(:[args]))' \
+  'Value::Object(ObjectMap::from(:[args]))'
+
+echo "[7] .collect() used as ObjectMap (in serde Value conversion)"
+run_comby \
+  '.map(|(key, value)| (key.into(), Self::from(value))).collect()' \
+  '.map(|(key, value)| (key.into(), Self::from(value))).collect::<ObjectMap>()'
+
+echo "[8] let mut x: Value = BTreeMap::new().into()"
+run_comby \
+  'let mut :[var~\w+]: Value = BTreeMap::new().into()' \
+  'let mut :[var]: Value = ObjectMap::new().into()'
+
+echo "[9] .collect::<BTreeMap<_, _>>() in Value context (cmd.rs)"
+# comby doesn't handle turbofish well, so we target this file directly
+group_a_collect_files=(
+  "src/cli/cmd.rs"
+)
+for file in "${group_a_collect_files[@]}"; do
+  if [[ -f "$file" ]]; then
+    if [[ -n "$APPLY" ]]; then
+      sed -i '' 's/collect::<BTreeMap<_, _>>()/collect::<ObjectMap>()/g' "$file"
+    else
+      grep -n 'collect::<BTreeMap<_, _>>()' "$file" 2>/dev/null | while read -r line; do
+        echo "    would replace: $line"
+      done
+    fi
+  fi
+done
+
+echo ""
+echo "--- Group B: Separated constructions (targeted by file) ---"
+echo ""
+
+# These are BTreeMap::new() calls where the variable is used as ObjectMap
+# but the construction and use are on different lines.
+# We target specific files to avoid false positives on non-ObjectMap BTreeMaps.
+
+group_b_files=(
+  "src/parsing/xml.rs"
+  "src/parsing/query_string.rs"
+  "src/stdlib/parse_syslog.rs"
+  "src/stdlib/parse_key_value.rs"
+  "src/stdlib/parse_grok.rs"
+  "src/stdlib/parse_aws_vpc_flow_log.rs"
+  "src/stdlib/replace_with.rs"
+  "src/value/value/serde.rs"
+  "src/value/value/crud/insert.rs"
+)
+
+for file in "${group_b_files[@]}"; do
+  if [[ -f "$file" ]]; then
+    echo "  -> $file"
+    if [[ -n "$APPLY" ]]; then
+      sed -i '' 's/BTreeMap::new()/ObjectMap::new()/g' "$file"
+    else
+      grep -n 'BTreeMap::new()' "$file" 2>/dev/null | while read -r line; do
+        echo "    would replace: $line"
+      done
+    fi
+  fi
+done
+
+echo ""
+echo "--- Group C: BTreeMap::from(...).into() in test files ---"
+echo ""
+
+# These are standalone BTreeMap::from([...]).into() calls that produce
+# a Value::Object but aren't wrapped in Value::Object(...) directly.
+group_c_files=(
+  "src/value/value/iter.rs"
+)
+
+for file in "${group_c_files[@]}"; do
+  if [[ -f "$file" ]]; then
+    echo "  -> $file"
+    if [[ -n "$APPLY" ]]; then
+      sed -i '' 's/BTreeMap::from/ObjectMap::from/g' "$file"
+    else
+      grep -n 'BTreeMap::from' "$file" 2>/dev/null | while read -r line; do
+        echo "    would replace: $line"
+      done
+    fi
+  fi
+done
+
+echo ""
+echo "--- Macros ---"
+echo ""
+
+echo "[value! macro] src/value/mod.rs"
+if [[ -n "$APPLY" ]]; then
+  sed -i '' 's|::std::collections::BTreeMap::default()|$crate::value::ObjectMap::default()|' \
+    src/value/mod.rs
+  sed -i '' 's|collect::<::std::collections::BTreeMap<_, $crate::value::Value>>()|collect::<$crate::value::ObjectMap>()|' \
+    src/value/mod.rs
+else
+  grep -n 'BTreeMap' src/value/mod.rs | head -5
+fi
+
+echo "[btreemap! macro] src/value/btreemap.rs"
+echo "  NOTE: btreemap! macro intentionally returns BTreeMap. Consider renaming"
+echo "  to objectmap! or updating return type in a separate step."
+
+echo ""
+echo "--- Import fixups ---"
+echo ""
+
+# Files where BTreeMap import should be replaced with ObjectMap
+swap_import_files=(
+  "src/value/value/crud/insert.rs"
+  "src/value/value/serde.rs"
+  "src/parsing/query_string.rs"
+  "src/datadog/grok/filters/keyvalue.rs"
+  "src/stdlib/parse_grok.rs"
+  "src/stdlib/encode_key_value.rs"
+  "src/stdlib/from_unix_timestamp.rs"
+  "src/stdlib/shannon_entropy.rs"
+  "src/stdlib/uuid_v4.rs"
+  "src/stdlib/uuid_v7.rs"
+)
+
+# Files where BTreeMap import should just be removed (ObjectMap comes via prelude or other import)
+remove_import_files=(
+  "src/cli/repl.rs"
+  "lib/fuzz/src/main.rs"
+)
+
+# Files where ObjectMap import needs to be added (no prelude, no existing import)
+add_objectmap_import=(
+  "src/cli/cmd.rs:use crate::value::ObjectMap;"
+  "src/cli/repl.rs:use crate::value::ObjectMap;"
+  "examples/simple.rs"  # handled specially below
+)
+
+if [[ -n "$APPLY" ]]; then
+  # Swap BTreeMap -> ObjectMap imports
+  for file in "${swap_import_files[@]}"; do
+    if [[ -f "$file" ]]; then
+      # In test modules: use std::collections::BTreeMap -> use crate::value::ObjectMap
+      sed -i '' 's/use std::collections::BTreeMap;/use crate::value::ObjectMap;/' "$file"
+      # In main code: remove BTreeMap from grouped imports if it becomes unused
+      # Handle "collections::BTreeMap" in grouped use statements
+      sed -i '' 's/collections::BTreeMap, //' "$file"
+      sed -i '' 's/, collections::BTreeMap//' "$file"
+      sed -i '' 's/collections::BTreeMap//' "$file"
+    fi
+  done
+
+  # Remove now-unused BTreeMap imports
+  for file in "${remove_import_files[@]}"; do
+    if [[ -f "$file" ]]; then
+      sed -i '' '/^use std::collections::BTreeMap;$/d' "$file"
+    fi
+  done
+
+  # For files in src/value/ that need ObjectMap but aren't in the compiler prelude
+  # crud/insert.rs
+  if ! grep -q 'use.*ObjectMap' src/value/value/crud/insert.rs 2>/dev/null; then
+    sed -i '' '/^use crate::value::Value;$/a\
+use crate::value::value::ObjectMap;
+' src/value/value/crud/insert.rs
+  fi
+
+  # serde.rs
+  if ! grep -q 'use.*ObjectMap' src/value/value/serde.rs 2>/dev/null; then
+    sed -i '' '1s/^/use super::ObjectMap;\n/' src/value/value/serde.rs
+  fi
+
+  # keyvalue.rs
+  if ! grep -q 'use.*ObjectMap' src/datadog/grok/filters/keyvalue.rs 2>/dev/null; then
+    sed -i '' '/^use crate::value::Value;/s/Value}/Value, value::ObjectMap}/' src/datadog/grok/filters/keyvalue.rs 2>/dev/null || \
+    sed -i '' '/^use crate::value::Value;$/a\
+use crate::value::value::ObjectMap;
+' src/datadog/grok/filters/keyvalue.rs
+  fi
+
+  # xml.rs: remove BTreeMap from grouped import, keep btree_map::Entry
+  sed -i '' 's/collections::{BTreeMap, btree_map::Entry}/collections::btree_map::Entry/' src/parsing/xml.rs 2>/dev/null || true
+
+  # parse_key_value.rs: remove BTreeMap from grouped import, keep btree_map::Entry
+  sed -i '' 's/collections::{BTreeMap, btree_map::Entry}/collections::btree_map::Entry/' src/stdlib/parse_key_value.rs 2>/dev/null || true
+
+  # cli/cmd.rs: add ObjectMap import
+  if ! grep -q 'use crate::value::ObjectMap' src/cli/cmd.rs 2>/dev/null; then
+    sed -i '' '/^use crate::compiler::TargetValueRef;$/a\
+use crate::value::ObjectMap;
+' src/cli/cmd.rs
+  fi
+  # Remove BTreeMap from grouped import in cmd.rs
+  sed -i '' 's/    collections::BTreeMap,\n//' src/cli/cmd.rs 2>/dev/null || true
+  sed -i '' '/^    collections::BTreeMap,$/d' src/cli/cmd.rs
+
+  # cli/repl.rs: add ObjectMap import
+  if ! grep -q 'use crate::value::ObjectMap' src/cli/repl.rs 2>/dev/null; then
+    sed -i '' '/^use crate::value::Value;$/i\
+use crate::value::ObjectMap;
+' src/cli/repl.rs
+  fi
+
+  # examples/simple.rs: swap BTreeMap for ObjectMap in vrl import
+  sed -i '' 's/use std::collections::BTreeMap;//' examples/simple.rs 2>/dev/null || true
+  sed -i '' 's/value::{Secrets, Value}/value::{ObjectMap, Secrets, Value}/' examples/simple.rs 2>/dev/null || true
+
+  # value/value/iter.rs: swap BTreeMap for ObjectMap in test module
+  sed -i '' 's/use std::collections::{BTreeMap, HashMap};/use std::collections::HashMap;/' src/value/value/iter.rs 2>/dev/null || true
+  if ! grep -q 'use crate::value::value::ObjectMap' src/value/value/iter.rs 2>/dev/null; then
+    sed -i '' '/use std::collections::HashMap;/a\
+    use crate::value::value::ObjectMap;
+' src/value/value/iter.rs
+  fi
+
+  # value/value/path.rs: swap BTreeMap for ObjectMap in test module
+  sed -i '' 's/use std::collections::BTreeMap;/use crate::value::value::ObjectMap;/' src/value/value/path.rs 2>/dev/null || true
+
+  # datadog/grok/parse_grok.rs: the top-level BTreeMap import is no longer needed
+  # (ObjectMap is already imported), but the test module needs BTreeMap for
+  # parse_grok_rules() which takes BTreeMap<KeyString, String> (aliases, not ObjectMap).
+  sed -i '' '/^use std::collections::BTreeMap;$/d' src/datadog/grok/parse_grok.rs 2>/dev/null || true
+  # Add BTreeMap import to the test module if not already present
+  if grep -q '#\[cfg(test)\]' src/datadog/grok/parse_grok.rs 2>/dev/null; then
+    if ! grep -q 'use std::collections::BTreeMap' src/datadog/grok/parse_grok.rs 2>/dev/null; then
+      sed -i '' '/^mod tests {$/a\
+    use std::collections::BTreeMap;
+' src/datadog/grok/parse_grok.rs
+    fi
+  fi
+else
+  echo "  (import fixups shown only in --apply mode)"
+fi
+
+echo ""
+echo "--- Formatting & validation ---"
+echo ""
+
+if [[ -n "$APPLY" ]]; then
+  echo "Running cargo fmt..."
+  cargo fmt
+
+  echo "Running cargo check..."
+  if cargo check 2>&1 | tail -3; then
+    echo ""
+    echo "Running cargo test..."
+    if cargo test 2>&1 | tail -3; then
+      echo ""
+      echo "==> All changes applied and validated successfully."
+    else
+      echo ""
+      echo "==> Tests failed. Review errors above."
+    fi
+  else
+    echo ""
+    echo "==> cargo check found issues. Review errors above."
+  fi
+else
+  echo "==> Dry run complete. Run with --apply to modify files."
+fi

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -1,6 +1,6 @@
 use crate::compiler::TargetValueRef;
+use crate::value::ObjectMap;
 use std::{
-    collections::BTreeMap,
     fs::File,
     io::{self, Read},
     iter::IntoIterator,
@@ -88,7 +88,7 @@ impl Opts {
         }?;
 
         match input.as_str() {
-            "" => Ok(vec![Value::Object(BTreeMap::default())]),
+            "" => Ok(vec![Value::Object(ObjectMap::default())]),
             _ => input
                 .lines()
                 .map(|line| Ok(serde_to_vrl(serde_json::from_str(line)?)))
@@ -154,7 +154,7 @@ fn run(opts: &Opts, stdlib_functions: Vec<Box<dyn Function>>) -> Result<(), Erro
         }
 
         for mut object in objects {
-            let mut metadata = Value::Object(BTreeMap::new());
+            let mut metadata = Value::Object(ObjectMap::new());
             let mut secrets = Secrets::new();
             let mut target = TargetValueRef {
                 value: &mut object,
@@ -197,7 +197,7 @@ fn repl(
         .into_iter()
         .map(|value| TargetValue {
             value,
-            metadata: Value::Object(BTreeMap::new()),
+            metadata: Value::Object(ObjectMap::new()),
             secrets: Secrets::new(),
         })
         .collect();
@@ -229,7 +229,7 @@ fn serde_to_vrl(value: serde_json::Value) -> Value {
         JsonValue::Object(v) => v
             .into_iter()
             .map(|(k, v)| (k.into(), serde_to_vrl(v)))
-            .collect::<BTreeMap<_, _>>()
+            .collect::<ObjectMap>()
             .into(),
         JsonValue::Bool(v) => v.into(),
         JsonValue::Number(v) if v.is_f64() => Value::from_f64_or_zero(v.as_f64().unwrap()),
@@ -247,5 +247,5 @@ fn read<R: Read>(mut reader: R) -> Result<String, Error> {
 }
 
 fn default_objects() -> Vec<Value> {
-    vec![Value::Object(BTreeMap::new())]
+    vec![Value::Object(ObjectMap::new())]
 }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -5,6 +5,7 @@ use crate::compiler::state::{RuntimeState, TypeState};
 use crate::compiler::{CompileConfig, Function, VrlRuntime, compile_with_state};
 use crate::diagnostic::Formatter;
 use crate::owned_metadata_path;
+use crate::value::ObjectMap;
 use crate::value::Secrets;
 use crate::value::Value;
 use indoc::indoc;
@@ -20,7 +21,6 @@ use rustyline::{
     validate::{self, ValidationResult, Validator},
 };
 use std::borrow::Cow::{self, Borrowed, Owned};
-use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::LazyLock;
 
@@ -134,7 +134,7 @@ impl Repl {
                             if index == objects.len() {
                                 objects.push(TargetValue {
                                     value: Value::Null,
-                                    metadata: Value::Object(BTreeMap::new()),
+                                    metadata: Value::Object(ObjectMap::new()),
                                     secrets: Secrets::new(),
                                 });
                             }

--- a/src/compiler/expression/object.rs
+++ b/src/compiler/expression/object.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt, ops::Deref};
 
-use crate::value::{KeyString, Value};
+use crate::value::{KeyString, ObjectMap, Value};
 use crate::{
     compiler::{
         Context, Expression, TypeDef,
@@ -35,7 +35,7 @@ impl Expression for Object {
         self.inner
             .iter()
             .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.clone(), v)))
-            .collect::<Result<BTreeMap<_, _>, _>>()
+            .collect::<Result<ObjectMap, _>>()
             .map(Value::Object)
     }
 
@@ -43,7 +43,7 @@ impl Expression for Object {
         self.inner
             .iter()
             .map(|(key, expr)| expr.resolve_constant(state).map(|v| (key.clone(), v)))
-            .collect::<Option<BTreeMap<_, _>>>()
+            .collect::<Option<ObjectMap>>()
             .map(Value::Object)
     }
 

--- a/src/core/encode_key_value.rs
+++ b/src/core/encode_key_value.rs
@@ -37,8 +37,8 @@ impl Error for EncodingError {
 /// # Errors
 ///
 /// Returns an `EncodingError` if the input contains non-`String` map keys.
-pub fn to_string<V: Serialize>(
-    input: &BTreeMap<KeyString, V>,
+pub fn to_string<'a, V: Serialize + 'a>(
+    input: impl IntoIterator<Item = (&'a KeyString, &'a V)> + 'a,
     fields_order: &[KeyString],
     key_value_delimiter: &str,
     field_delimiter: &str,

--- a/src/core/encode_logfmt.rs
+++ b/src/core/encode_logfmt.rs
@@ -10,7 +10,9 @@ use super::encode_key_value::{EncodingError, to_string as encode_key_value};
 /// # Errors
 ///
 /// Returns an `EncodingError` if any of the keys are not strings.
-pub fn encode_map<V: Serialize>(input: &BTreeMap<KeyString, V>) -> Result<String, EncodingError> {
+pub fn encode_map<'a, V: Serialize + 'a>(
+    input: impl IntoIterator<Item = (&'a KeyString, &'a V)> + 'a,
+) -> Result<String, EncodingError> {
     encode_key_value(input, &[], "=", " ", true)
 }
 

--- a/src/core/encode_logfmt.rs
+++ b/src/core/encode_logfmt.rs
@@ -27,7 +27,7 @@ pub fn encode_value(input: &Value) -> Result<String, EncodingError> {
         encode_map(map)
     } else {
         let mut map = BTreeMap::new();
-        map.insert("message".to_string().into(), &input);
+        map.insert("message".into(), &input);
         encode_map(&map)
     }
 }

--- a/src/datadog/grok/filters/keyvalue.rs
+++ b/src/datadog/grok/filters/keyvalue.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use crate::value::ObjectMap;
 use std::fmt::Formatter;
 
 use crate::value::Value;
@@ -168,7 +168,7 @@ impl KeyValueFilter {
     pub fn apply_filter(&self, value: &Value) -> Result<Value, InternalError> {
         match value {
             Value::Bytes(bytes) => {
-                let mut result = Value::Object(BTreeMap::default());
+                let mut result = Value::Object(ObjectMap::default());
                 let value = String::from_utf8_lossy(bytes);
                 self.re_pattern.captures_iter(value.as_ref()).for_each(|c| {
                     self.parse_key_value_capture(&mut result, c);

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::path::parse_value_path;
 use crate::value::{ObjectMap, Value};
-use std::collections::BTreeMap;
 
 /// Errors which cause the Datadog grok algorithm to stop processing and not return a parsed result.
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
@@ -57,7 +56,7 @@ pub fn parse_grok(
 /// Internal Errors:
 /// - FailedToApplyFilter - matches the rule, but there was a runtime error while applying on of the filters
 fn apply_grok_rule(source: &str, grok_rule: &GrokRule) -> Result<ParsedGrokObject, FatalError> {
-    let mut parsed = Value::Object(BTreeMap::new());
+    let mut parsed = Value::Object(ObjectMap::new());
     let mut internal_errors = vec![];
 
     match grok_rule.pattern.match_against(source) {
@@ -171,6 +170,7 @@ mod tests {
     use crate::value::Value;
     use chrono::{Datelike, NaiveDate, Timelike, Utc};
     use ordered_float::NotNan;
+    use std::collections::BTreeMap;
     use tracing_test::traced_test;
 
     use super::super::parse_grok_rules::parse_grok_rules;
@@ -459,7 +459,7 @@ mod tests {
             "%{notSpace:field1:integer} %{data:field2:json}",
             "not_a_number not a json",
             Ok(ParsedGrokObject {
-                parsed: Value::from(BTreeMap::new()),
+                parsed: Value::from(ObjectMap::new()),
                 internal_errors: vec![
                     InternalError::FailedToApplyFilter(
                         "Integer".to_owned(),
@@ -812,7 +812,7 @@ mod tests {
                 "%{data:field:array}",
                 "abc",
                 Ok(ParsedGrokObject {
-                    parsed: Value::from(BTreeMap::new()),
+                    parsed: Value::from(ObjectMap::new()),
                     internal_errors: vec![InternalError::FailedToApplyFilter(
                         "Array(..)".to_owned(),
                         "\"abc\"".to_owned(),
@@ -824,7 +824,7 @@ mod tests {
                 "%{data:field:array(scale(10))}",
                 "[a,b]",
                 Ok(ParsedGrokObject {
-                    parsed: Value::from(BTreeMap::new()),
+                    parsed: Value::from(ObjectMap::new()),
                     internal_errors: vec![InternalError::FailedToApplyFilter(
                         "Scale(..)".to_owned(),
                         "\"a\"".to_owned(),
@@ -961,7 +961,7 @@ mod tests {
             (
                 "%{data::keyvalue}",
                 "key:=valueStr",
-                Ok(Value::from(BTreeMap::new())),
+                Ok(Value::from(ObjectMap::new())),
             ),
             // empty key or null
             (
@@ -983,7 +983,7 @@ mod tests {
             (
                 "%{data::keyvalue}",
                 "=,=value",
-                Ok(Value::from(BTreeMap::new())),
+                Ok(Value::from(ObjectMap::new())),
             ),
             // type inference
             (
@@ -1013,17 +1013,17 @@ mod tests {
             (
                 "%{data::keyvalue}",
                 "key = valueStr",
-                Ok(Value::from(BTreeMap::new())),
+                Ok(Value::from(ObjectMap::new())),
             ),
             (
                 "%{data::keyvalue}",
                 "key= valueStr",
-                Ok(Value::from(BTreeMap::new())),
+                Ok(Value::from(ObjectMap::new())),
             ),
             (
                 "%{data::keyvalue}",
                 "key =valueStr",
-                Ok(Value::from(BTreeMap::new())),
+                Ok(Value::from(ObjectMap::new())),
             ),
             (
                 r#"%{data::keyvalue(":")}"#,
@@ -1338,7 +1338,7 @@ mod tests {
             (
                 "%{data::json}",
                 r#"{"root": {"object": {"empty": {}}, "string": "abc" }}"#,
-                Ok(Value::Object(btreemap!(
+                Ok(Value::from(btreemap!(
                     "root" => btreemap! (
                         "string" => "abc"
                     )
@@ -1347,7 +1347,7 @@ mod tests {
             (
                 "%{data:field:json}",
                 r#"{"root": {"object": {"empty": {}}, "string": "abc" }}"#,
-                Ok(Value::Object(btreemap!(
+                Ok(Value::from(btreemap!(
                     "field" => btreemap!(
                         "root" => btreemap! (
                             "string" => "abc"
@@ -1357,7 +1357,7 @@ mod tests {
             (
                 r#"%{notSpace:network.destination.ip:nullIf("-")}"#,
                 "-",
-                Ok(Value::Object(btreemap!())),
+                Ok(Value::from(btreemap!())),
             ),
         ]);
     }
@@ -1366,7 +1366,7 @@ mod tests {
         test_full_grok(vec![(
             "%{data::json}",
             r#"{"a.b": "c"}"#,
-            Ok(Value::Object(btreemap!(
+            Ok(Value::from(btreemap!(
                 "a" => btreemap! (
                     "b" => "c"
                 )

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -116,7 +116,7 @@ fn apply_grok_rule(source: &str, grok_rule: &GrokRule) -> Result<ParsedGrokObjec
                     parsed
                         .as_object_mut()
                         .expect("parsed value is not an object")
-                        .insert(name.to_string().into(), value.into());
+                        .insert(name.into(), value.into());
                 }
             }
 

--- a/src/parsing/query_string.rs
+++ b/src/parsing/query_string.rs
@@ -1,5 +1,5 @@
 use crate::compiler::prelude::*;
-use std::collections::BTreeMap;
+use crate::value::ObjectMap;
 use url::form_urlencoded;
 
 pub fn parse_query_string(bytes: &Bytes, ignore_keys_without_values: bool) -> Resolved {
@@ -7,7 +7,7 @@ pub fn parse_query_string(bytes: &Bytes, ignore_keys_without_values: bool) -> Re
     if !query_string.is_empty() && query_string[0] == b'?' {
         query_string = &query_string[1..];
     }
-    let mut result = BTreeMap::new();
+    let mut result = ObjectMap::new();
     let parsed = form_urlencoded::parse(query_string);
     for (k, value) in parsed {
         let value = value.as_ref();

--- a/src/parsing/query_string.rs
+++ b/src/parsing/query_string.rs
@@ -15,7 +15,7 @@ pub fn parse_query_string(bytes: &Bytes, ignore_keys_without_values: bool) -> Re
             continue;
         }
         result
-            .entry(k.into_owned().into())
+            .entry(k.into())
             .and_modify(|v| {
                 match v {
                     Value::Array(v) => {

--- a/src/parsing/xml.rs
+++ b/src/parsing/xml.rs
@@ -8,8 +8,8 @@ use regex::{Regex, RegexBuilder};
 use roxmltree::NodeType;
 pub use roxmltree::{Document, Node};
 use rust_decimal::prelude::Zero;
-use std::sync::LazyLock;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
 /// A lazily initialized regular expression that matches excess whitespace between XML/HTML tags.
 ///
@@ -224,10 +224,7 @@ pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
                         if node.is_element() {
                             let mut map = ObjectMap::new();
 
-                            map.insert(
-                                node.tag_name().name().into(),
-                                process_node(node, config),
-                            );
+                            map.insert(node.tag_name().name().into(), process_node(node, config));
 
                             Value::Object(map)
                         } else {

--- a/src/parsing/xml.rs
+++ b/src/parsing/xml.rs
@@ -168,8 +168,8 @@ pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
 
         for n in node.children().filter(|n| n.is_element() || n.is_text()) {
             let name = match n.node_type() {
-                NodeType::Element => n.tag_name().name().to_string().into(),
-                NodeType::Text => config.text_key.to_string().into(),
+                NodeType::Element => n.tag_name().name().into(),
+                NodeType::Text => KeyString::from(config.text_key.as_ref()),
                 _ => unreachable!("shouldn't be other XML nodes"),
             };
 
@@ -225,7 +225,7 @@ pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
                             let mut map = ObjectMap::new();
 
                             map.insert(
-                                node.tag_name().name().to_string().into(),
+                                node.tag_name().name().into(),
                                 process_node(node, config),
                             );
 

--- a/src/parsing/xml.rs
+++ b/src/parsing/xml.rs
@@ -2,16 +2,14 @@
 //! that are sufficient to process a `roxmltree::Node`.
 
 use crate::compiler::prelude::*;
+use crate::value::ObjectMapEntry;
 use regex::{Regex, RegexBuilder};
 // Re-export `roxmltree` to match the public API of `process_node`.
 use roxmltree::NodeType;
 pub use roxmltree::{Document, Node};
 use rust_decimal::prelude::Zero;
 use std::sync::LazyLock;
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, btree_map::Entry},
-};
+use std::borrow::Cow;
 
 /// A lazily initialized regular expression that matches excess whitespace between XML/HTML tags.
 ///
@@ -156,7 +154,7 @@ pub fn parse_xml(value: Value, options: ParseOptions) -> Resolved {
 pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
     // Helper to recurse over a `Node`s children, and build an object.
     let recurse = |node: Node| -> ObjectMap {
-        let mut map = BTreeMap::new();
+        let mut map = ObjectMap::new();
 
         // Expand attributes, if required.
         if config.include_attr {
@@ -180,7 +178,7 @@ pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
 
             // If the key already exists, add it. Otherwise, insert.
             match map.entry(name) {
-                Entry::Occupied(mut entry) => {
+                ObjectMapEntry::Occupied(mut entry) => {
                     let v = entry.get_mut();
 
                     // Push a value onto the existing array, or wrap in a `Value::Array`.
@@ -194,7 +192,7 @@ pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
                         }
                     };
                 }
-                Entry::Vacant(entry) => {
+                ObjectMapEntry::Vacant(entry) => {
                     entry.insert(value);
                 }
             }
@@ -224,7 +222,7 @@ pub fn process_node(node: Node, config: &ParseXmlConfig) -> Value {
 
                         // If the node is an element, treat it as an object.
                         if node.is_element() {
-                            let mut map = BTreeMap::new();
+                            let mut map = ObjectMap::new();
 
                             map.insert(
                                 node.tag_name().name().to_string().into(),

--- a/src/protobuf/encode.rs
+++ b/src/protobuf/encode.rs
@@ -303,7 +303,7 @@ mod tests {
     use chrono::DateTime;
     use ordered_float::NotNan;
     use prost_reflect::MapKey;
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
     use std::path::PathBuf;
     use std::{env, fs};
 
@@ -331,7 +331,7 @@ mod tests {
     fn test_encode_integers() {
         let message = encode_message(
             &test_message_descriptor("Integers"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 ("i32".into(), Value::Integer(-1234)),
                 ("i64".into(), Value::Integer(-9876)),
                 ("u32".into(), Value::Integer(1234)),
@@ -350,7 +350,7 @@ mod tests {
     fn test_encode_integers_from_bytes() {
         let message = encode_message(
             &test_message_descriptor("Integers"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 ("i32".into(), Value::Bytes(Bytes::from("-1234"))),
                 ("i64".into(), Value::Bytes(Bytes::from("-9876"))),
                 ("u32".into(), Value::Bytes(Bytes::from("1234"))),
@@ -369,7 +369,7 @@ mod tests {
     fn test_encode_floats() {
         let message = encode_message(
             &test_message_descriptor("Floats"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 ("d".into(), Value::Float(NotNan::new(11.0).unwrap())),
                 ("f".into(), Value::Float(NotNan::new(2.0).unwrap())),
             ])),
@@ -384,7 +384,7 @@ mod tests {
     fn test_encode_bytes_as_float() {
         let message = encode_message(
             &test_message_descriptor("Floats"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 ("d".into(), Value::Bytes(Bytes::from("11.0"))),
                 ("f".into(), Value::Bytes(Bytes::from("2.0"))),
             ])),
@@ -399,7 +399,7 @@ mod tests {
     fn test_encode_integer_as_double() {
         let message = encode_message(
             &test_message_descriptor("Floats"),
-            Value::Object(BTreeMap::from([("d".into(), Value::Integer(42))])),
+            Value::Object(ObjectMap::from([("d".into(), Value::Integer(42))])),
             &Options::default(),
         )
         .unwrap();
@@ -468,7 +468,7 @@ mod tests {
         let bytes = Bytes::from(vec![0, 1, 2, 3]);
         let message = encode_message(
             &test_message_descriptor("Bytes"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 ("text".into(), Value::Bytes(Bytes::from("vector"))),
                 ("binary".into(), Value::Bytes(bytes.clone())),
             ])),
@@ -483,19 +483,19 @@ mod tests {
     fn test_encode_map() {
         let message = encode_message(
             &test_message_descriptor("Map"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 (
                     "names".into(),
-                    Value::Object(BTreeMap::from([
+                    Value::Object(ObjectMap::from([
                         ("forty-four".into(), Value::Integer(44)),
                         ("one".into(), Value::Integer(1)),
                     ])),
                 ),
                 (
                     "people".into(),
-                    Value::Object(BTreeMap::from([(
+                    Value::Object(ObjectMap::from([(
                         "mark".into(),
-                        Value::Object(BTreeMap::from([
+                        Value::Object(ObjectMap::from([
                             ("nickname".into(), Value::Bytes(Bytes::from("jeff"))),
                             ("age".into(), Value::Integer(22)),
                         ])),
@@ -541,7 +541,7 @@ mod tests {
     fn test_encode_enum() {
         let message = encode_message(
             &test_message_descriptor("Enum"),
-            Value::Object(BTreeMap::from([
+            Value::Object(ObjectMap::from([
                 (
                     "breakfast".into(),
                     Value::Bytes(Bytes::from("fruit_tomato")),
@@ -561,7 +561,7 @@ mod tests {
     fn test_encode_timestamp() {
         let message = encode_message(
             &test_message_descriptor("Timestamp"),
-            Value::Object(BTreeMap::from([(
+            Value::Object(ObjectMap::from([(
                 "morning".into(),
                 Value::Timestamp(
                     DateTime::from_timestamp(8675, 309).expect("could not compute timestamp"),
@@ -579,7 +579,7 @@ mod tests {
     fn test_encode_repeated_primitive() {
         let message = encode_message(
             &test_message_descriptor("RepeatedPrimitive"),
-            Value::Object(BTreeMap::from([(
+            Value::Object(ObjectMap::from([(
                 "numbers".into(),
                 Value::Array(vec![
                     Value::Integer(8),
@@ -601,15 +601,15 @@ mod tests {
     fn test_encode_repeated_message() {
         let message = encode_message(
             &test_message_descriptor("RepeatedMessage"),
-            Value::Object(BTreeMap::from([(
+            Value::Object(ObjectMap::from([(
                 "messages".into(),
                 Value::Array(vec![
-                    Value::Object(BTreeMap::from([(
+                    Value::Object(ObjectMap::from([(
                         "text".into(),
                         Value::Bytes(Bytes::from("vector")),
                     )])),
-                    Value::Object(BTreeMap::from([("index".into(), Value::Integer(4444))])),
-                    Value::Object(BTreeMap::from([
+                    Value::Object(ObjectMap::from([("index".into(), Value::Integer(4444))])),
+                    Value::Object(ObjectMap::from([
                         ("text".into(), Value::Bytes(Bytes::from("protobuf"))),
                         ("index".into(), Value::Integer(1)),
                     ])),
@@ -644,21 +644,21 @@ mod tests {
     fn test_encode_value_as_string() {
         let mut message = encode_message(
             &test_message_descriptor("Bytes"),
-            Value::Object(BTreeMap::from([("text".into(), Value::Boolean(true))])),
+            Value::Object(ObjectMap::from([("text".into(), Value::Boolean(true))])),
             &Options::default(),
         )
         .unwrap();
         assert_eq!(Some("true"), mfield!(message, "text").as_str());
         message = encode_message(
             &test_message_descriptor("Bytes"),
-            Value::Object(BTreeMap::from([("text".into(), Value::Integer(123))])),
+            Value::Object(ObjectMap::from([("text".into(), Value::Integer(123))])),
             &Options::default(),
         )
         .unwrap();
         assert_eq!(Some("123"), mfield!(message, "text").as_str());
         message = encode_message(
             &test_message_descriptor("Bytes"),
-            Value::Object(BTreeMap::from([(
+            Value::Object(ObjectMap::from([(
                 "text".into(),
                 Value::Float(NotNan::new(45.67).unwrap()),
             )])),
@@ -668,7 +668,7 @@ mod tests {
         assert_eq!(Some("45.67"), mfield!(message, "text").as_str());
         message = encode_message(
             &test_message_descriptor("Bytes"),
-            Value::Object(BTreeMap::from([(
+            Value::Object(ObjectMap::from([(
                 "text".into(),
                 Value::Timestamp(
                     DateTime::from_timestamp(8675, 309).expect("could not compute timestamp"),

--- a/src/protobuf/encode.rs
+++ b/src/protobuf/encode.rs
@@ -299,6 +299,7 @@ mod tests {
     use crate::protobuf::descriptor::get_message_descriptor;
     use crate::protobuf::parse::parse_proto;
     use crate::value;
+    use crate::value::ObjectMap;
     use bytes::Bytes;
     use chrono::DateTime;
     use ordered_float::NotNan;
@@ -410,7 +411,7 @@ mod tests {
     fn test_encode_integer_as_float() {
         let message = encode_message(
             &test_message_descriptor("Floats"),
-            Value::Object(BTreeMap::from([("f".into(), Value::Integer(123))])),
+            Value::Object(ObjectMap::from([("f".into(), Value::Integer(123))])),
             &Options::default(),
         )
         .unwrap();
@@ -423,7 +424,7 @@ mod tests {
         for (i, expected) in [(0, false), (1, true), (42, true), (-1, true)] {
             let message = encode_message(
                 &descriptor,
-                Value::Object(BTreeMap::from([("b".into(), Value::Integer(i))])),
+                Value::Object(ObjectMap::from([("b".into(), Value::Integer(i))])),
                 &Options::default(),
             )
             .unwrap();
@@ -437,7 +438,7 @@ mod tests {
         for s in ["true", "TRUE", "True", "1", "yes", "YES", "y", "Y", "t"] {
             let message = encode_message(
                 &descriptor,
-                Value::Object(BTreeMap::from([("b".into(), Value::from(s))])),
+                Value::Object(ObjectMap::from([("b".into(), Value::from(s))])),
                 &Options::default(),
             )
             .unwrap();
@@ -446,7 +447,7 @@ mod tests {
         for s in ["false", "FALSE", "False", "0", "no", "NO", "n", "N", "f"] {
             let message = encode_message(
                 &descriptor,
-                Value::Object(BTreeMap::from([("b".into(), Value::from(s))])),
+                Value::Object(ObjectMap::from([("b".into(), Value::from(s))])),
                 &Options::default(),
             )
             .unwrap();
@@ -456,7 +457,7 @@ mod tests {
         for s in ["", "invalid", "maybe"] {
             let result = encode_message(
                 &descriptor,
-                Value::Object(BTreeMap::from([("b".into(), Value::from(s))])),
+                Value::Object(ObjectMap::from([("b".into(), Value::from(s))])),
                 &Options::default(),
             );
             assert!(result.is_err(), "expected error for s={s:?}");
@@ -704,7 +705,7 @@ mod tests {
         for (label, value) in cases {
             let result = encode_message(
                 &descriptor,
-                Value::Object(BTreeMap::from([("text".into(), value)])),
+                Value::Object(ObjectMap::from([("text".into(), value)])),
                 &strict,
             );
             assert!(result.is_err(), "expected strict mode to reject {label}");
@@ -814,8 +815,8 @@ mod tests {
         // Round-trip a VRL Object containing one map per supported proto key type
         // through encode_proto -> parse_proto. Non-string keys must survive the
         // string-to-MapKey-to-string conversion on both sides.
-        let entry = |k: &str| Value::Object(BTreeMap::from([(k.into(), Value::from("v"))]));
-        let input = Value::Object(BTreeMap::from([
+        let entry = |k: &str| Value::Object(ObjectMap::from([(k.into(), Value::from("v"))]));
+        let input = Value::Object(ObjectMap::from([
             ("by_bool".into(), entry("true")),
             ("by_int32".into(), entry("-5")),
             ("by_int64".into(), entry("-9999999999")),

--- a/src/stdlib/compact.rs
+++ b/src/stdlib/compact.rs
@@ -338,12 +338,14 @@ mod test {
                 btreemap! {
                     "key1" => "",
                     "key3" => "",
-                }, // expected
+                }
+                .into(), // expected
                 btreemap! {
                     "key1" => "",
                     "key2" => Value::Null,
                     "key3" => "",
-                }, // original
+                }
+                .into(), // original
                 CompactOptions {
                     string: false,
                     ..CompactOptions::default()
@@ -353,12 +355,14 @@ mod test {
                 btreemap! {
                     "key1" => Value::from(1),
                     "key3" => Value::from(2),
-                },
+                }
+                .into(),
                 btreemap! {
                     "key1" => Value::from(1),
                     "key2" => Value::Array(vec![]),
                     "key3" => Value::from(2),
-                },
+                }
+                .into(),
                 CompactOptions::default(),
             ),
             (
@@ -426,12 +430,14 @@ mod test {
                     "key1" => Value::from(1),
                     "key2" => Value::Array(vec![2.into()]),
                     "key3" => Value::from(2),
-                },
+                }
+                .into(),
                 btreemap! {
                     "key1" => Value::from(1),
                     "key2" => Value::Array(vec![Value::Null, 2.into(), Value::Null]),
                     "key3" => Value::from(2),
-                },
+                }
+                .into(),
                 CompactOptions::default(),
             ),
         ];

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -695,6 +695,7 @@ impl Function for DnsLookup {
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
+    #[cfg(feature = "test")]
     use std::collections::HashSet;
 
     use super::*;

--- a/src/stdlib/dns_lookup.rs
+++ b/src/stdlib/dns_lookup.rs
@@ -326,20 +326,23 @@ mod non_wasm {
 use non_wasm::*;
 
 
-static DEFAULT_QTYPE: Value = Value::Bytes(Bytes::from_static("A".as_bytes()));
-static DEFAULT_CLASS: Value = Value::Bytes(Bytes::from_static("IN".as_bytes()));
-static DEFAULT_OPTIONS: Value =
-    Value::Object(std::collections::BTreeMap::new());
+use std::sync::LazyLock;
 
-const PARAMETERS: &[Parameter] = &[
-    Parameter::required("value", kind::BYTES, "The domain name to query."),
-    Parameter::optional("qtype", kind::BYTES, "The DNS record type to query (e.g., A, AAAA, MX, TXT). Defaults to A.")
-        .default(&DEFAULT_QTYPE),
-    Parameter::optional("class", kind::BYTES, "The DNS query class. Defaults to IN (Internet).")
-        .default(&DEFAULT_CLASS),
-    Parameter::optional("options", kind::OBJECT, "DNS resolver options. Supported fields: servers (array of nameserver addresses), timeout (seconds), attempts (number of retry attempts), ndots, aa_only, tcp, recurse, rotate.")
-        .default(&DEFAULT_OPTIONS),
-];
+static DEFAULT_QTYPE: LazyLock<Value> = LazyLock::new(|| Value::Bytes(Bytes::from("A")));
+static DEFAULT_CLASS: LazyLock<Value> = LazyLock::new(|| Value::Bytes(Bytes::from("IN")));
+static DEFAULT_OPTIONS: LazyLock<Value> = LazyLock::new(|| Value::Object(ObjectMap::new()));
+
+static PARAMETERS: LazyLock<Vec<Parameter>> = LazyLock::new(|| {
+    vec![
+        Parameter::required("value", kind::BYTES, "The domain name to query."),
+        Parameter::optional("qtype", kind::BYTES, "The DNS record type to query (e.g., A, AAAA, MX, TXT). Defaults to A.")
+            .default(&DEFAULT_QTYPE),
+        Parameter::optional("class", kind::BYTES, "The DNS query class. Defaults to IN (Internet).")
+            .default(&DEFAULT_CLASS),
+        Parameter::optional("options", kind::OBJECT, "DNS resolver options. Supported fields: servers (array of nameserver addresses), timeout (seconds), attempts (number of retry attempts), ndots, aa_only, tcp, recurse, rotate.")
+            .default(&DEFAULT_OPTIONS),
+    ]
+});
 
 #[derive(Clone, Copy, Debug)]
 pub struct DnsLookup;
@@ -366,7 +369,7 @@ impl Function for DnsLookup {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        PARAMETERS
+        PARAMETERS.as_slice()
     }
 
     #[allow(clippy::too_many_lines)]
@@ -692,8 +695,6 @@ impl Function for DnsLookup {
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
-    use std::collections::BTreeMap;
-    #[cfg(feature = "test")]
     use std::collections::HashSet;
 
     use super::*;
@@ -854,7 +855,7 @@ mod tests {
 
     fn prepare_dns_lookup(dns_lookup_fn: &DnsLookupFn) -> Resolved {
         let tz = TimeZone::default();
-        let mut object: Value = Value::Object(BTreeMap::new());
+        let mut object: Value = Value::Object(ObjectMap::new());
         let mut runtime_state = state::RuntimeState::default();
         let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
         dns_lookup_fn.resolve(&mut ctx)

--- a/src/stdlib/encode_key_value.rs
+++ b/src/stdlib/encode_key_value.rs
@@ -237,7 +237,7 @@ impl FunctionExpression for EncodeKeyValueFn {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use crate::value::ObjectMap;
 
     use crate::{
         btreemap,
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_encode_decode_cycle() {
         let before: Value = {
-            let mut map = Value::from(BTreeMap::default());
+            let mut map = Value::from(ObjectMap::default());
             map.insert("key", r#"this has a " quote"#);
             map
         };

--- a/src/stdlib/encode_key_value.rs
+++ b/src/stdlib/encode_key_value.rs
@@ -199,7 +199,7 @@ fn resolve_fields(fields: Value) -> ExpressionResult<Vec<KeyString>> {
         .enumerate()
         .map(|(idx, v)| {
             v.try_bytes_utf8_lossy()
-                .map(|v| KeyString::from(v))
+                .map(KeyString::from)
                 .map_err(|e| format!("invalid field value type at index {idx}: {e}").into())
         })
         .collect()

--- a/src/stdlib/encode_key_value.rs
+++ b/src/stdlib/encode_key_value.rs
@@ -199,7 +199,7 @@ fn resolve_fields(fields: Value) -> ExpressionResult<Vec<KeyString>> {
         .enumerate()
         .map(|(idx, v)| {
             v.try_bytes_utf8_lossy()
-                .map(|v| v.to_string().into())
+                .map(|v| KeyString::from(v))
                 .map_err(|e| format!("invalid field value type at index {idx}: {e}").into())
         })
         .collect()

--- a/src/stdlib/filter.rs
+++ b/src/stdlib/filter.rs
@@ -1,5 +1,4 @@
 use crate::compiler::prelude::*;
-use std::collections::BTreeMap;
 
 fn filter<T>(value: Value, ctx: &mut Context, runner: &closure::Runner<T>) -> Resolved
 where
@@ -17,7 +16,7 @@ where
                     Err(err) => Some(Err(err)),
                 },
             )
-            .collect::<ExpressionResult<BTreeMap<_, _>>>()
+            .collect::<ExpressionResult<ObjectMap>>()
             .map(Into::into),
 
         Value::Array(array) => array

--- a/src/stdlib/flatten.rs
+++ b/src/stdlib/flatten.rs
@@ -198,11 +198,7 @@ struct MapFlatten<'a> {
 }
 
 impl<'a> MapFlatten<'a> {
-    fn new(
-        values: ObjectMapIter<'a>,
-        separator: &'a str,
-        except: &'a HashSet<KeyString>,
-    ) -> Self {
+    fn new(values: ObjectMapIter<'a>, separator: &'a str, except: &'a HashSet<KeyString>) -> Self {
         Self {
             values,
             separator,

--- a/src/stdlib/flatten.rs
+++ b/src/stdlib/flatten.rs
@@ -230,7 +230,7 @@ impl<'a> MapFlatten<'a> {
     /// Returns the key with the parent prepended.
     fn new_key(&self, key: &str) -> KeyString {
         match self.parent {
-            None => key.to_string().into(),
+            None => key.into(),
             Some(ref parent) => format!("{parent}{}{key}", self.separator).into(),
         }
     }

--- a/src/stdlib/flatten.rs
+++ b/src/stdlib/flatten.rs
@@ -1,31 +1,34 @@
 use std::collections::HashSet;
-use std::collections::btree_map;
+use std::sync::LazyLock;
 
 use crate::compiler::expression::Expr;
 use crate::compiler::prelude::*;
+use crate::value::ObjectMapIter;
 
-static DEFAULT_SEPARATOR: Value = Value::Bytes(Bytes::from_static(".".as_bytes()));
-static DEFAULT_EXCEPT: Value = Value::Array(vec![]);
+static DEFAULT_SEPARATOR: LazyLock<Value> = LazyLock::new(|| Value::Bytes(Bytes::from(".")));
+static DEFAULT_EXCEPT: LazyLock<Value> = LazyLock::new(|| Value::Array(vec![]));
 
-const PARAMETERS: &[Parameter] = &[
-    Parameter::required(
-        "value",
-        kind::OBJECT | kind::ARRAY,
-        "The array or object to flatten.",
-    ),
-    Parameter::optional(
-        "separator",
-        kind::BYTES,
-        "The separator to join nested keys",
-    )
-    .default(&DEFAULT_SEPARATOR),
-    Parameter::optional(
-        "except",
-        kind::ARRAY,
-        "An array of key names to exclude from flattening at any depth.",
-    )
-    .default(&DEFAULT_EXCEPT),
-];
+static PARAMETERS: LazyLock<Vec<Parameter>> = LazyLock::new(|| {
+    vec![
+        Parameter::required(
+            "value",
+            kind::OBJECT | kind::ARRAY,
+            "The array or object to flatten.",
+        ),
+        Parameter::optional(
+            "separator",
+            kind::BYTES,
+            "The separator to join nested keys",
+        )
+        .default(&DEFAULT_SEPARATOR),
+        Parameter::optional(
+            "except",
+            kind::ARRAY,
+            "An array of key names to exclude from flattening at any depth.",
+        )
+        .default(&DEFAULT_EXCEPT),
+    ]
+});
 
 fn flatten(value: Value, separator: &Value, except: &HashSet<KeyString>) -> Resolved {
     let separator = separator.try_bytes_utf8_lossy()?;
@@ -72,7 +75,7 @@ impl Function for Flatten {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        PARAMETERS
+        PARAMETERS.as_slice()
     }
 
     fn examples(&self) -> &'static [Example] {
@@ -187,7 +190,7 @@ impl FunctionExpression for FlattenFn {
 
 /// An iterator to walk over maps allowing us to flatten nested maps to a single level.
 struct MapFlatten<'a> {
-    values: btree_map::Iter<'a, KeyString, Value>,
+    values: ObjectMapIter<'a>,
     separator: &'a str,
     inner: Option<Box<MapFlatten<'a>>>,
     parent: Option<KeyString>,
@@ -196,7 +199,7 @@ struct MapFlatten<'a> {
 
 impl<'a> MapFlatten<'a> {
     fn new(
-        values: btree_map::Iter<'a, KeyString, Value>,
+        values: ObjectMapIter<'a>,
         separator: &'a str,
         except: &'a HashSet<KeyString>,
     ) -> Self {
@@ -211,7 +214,7 @@ impl<'a> MapFlatten<'a> {
 
     fn new_from_parent(
         parent: KeyString,
-        values: btree_map::Iter<'a, KeyString, Value>,
+        values: ObjectMapIter<'a>,
         separator: &'a str,
         except: &'a HashSet<KeyString>,
     ) -> Self {

--- a/src/stdlib/from_unix_timestamp.rs
+++ b/src/stdlib/from_unix_timestamp.rs
@@ -201,12 +201,12 @@ mod tests {
     use crate::compiler::TimeZone;
     use crate::compiler::expression::Literal;
     use crate::value;
+    use crate::value::ObjectMap;
     use regex::Regex;
-    use std::collections::BTreeMap;
 
     #[test]
     fn out_of_range_integer() {
-        let mut object: Value = BTreeMap::new().into();
+        let mut object: Value = ObjectMap::new().into();
         let mut runtime_state = state::RuntimeState::default();
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);

--- a/src/stdlib/http_request.rs
+++ b/src/stdlib/http_request.rs
@@ -321,45 +321,48 @@ mod non_wasm {
 #[allow(clippy::wildcard_imports)]
 #[cfg(not(target_arch = "wasm32"))]
 use non_wasm::*;
+use std::sync::LazyLock;
 
-static DEFAULT_METHOD: Value = Value::Bytes(Bytes::from_static("get".as_bytes()));
-static DEFAULT_HEADERS: Value = Value::Object(std::collections::BTreeMap::new());
-static DEFAULT_BODY: Value = Value::Bytes(Bytes::from_static("".as_bytes()));
-static DEFAULT_REDACT_HEADERS: Value = Value::Boolean(true);
+static DEFAULT_METHOD: LazyLock<Value> = LazyLock::new(|| Value::Bytes(Bytes::from("get")));
+static DEFAULT_HEADERS: LazyLock<Value> = LazyLock::new(|| Value::Object(ObjectMap::new()));
+static DEFAULT_BODY: LazyLock<Value> = LazyLock::new(|| Value::Bytes(Bytes::from("")));
+static DEFAULT_REDACT_HEADERS: LazyLock<Value> = LazyLock::new(|| Value::Boolean(true));
 
-const PARAMETERS: &[Parameter] = &[
-    Parameter::required("url", kind::BYTES, "The URL to make the HTTP request to."),
-    Parameter::optional(
-        "method",
-        kind::BYTES,
-        "The HTTP method to use (e.g., GET, POST, PUT, DELETE). Defaults to GET.",
-    )
-    .default(&DEFAULT_METHOD),
-    Parameter::optional(
-        "headers",
-        kind::OBJECT,
-        "An object containing HTTP headers to send with the request.",
-    )
-    .default(&DEFAULT_HEADERS),
-    Parameter::optional("body", kind::BYTES, "The request body content to send.")
-        .default(&DEFAULT_BODY),
-    Parameter::optional(
-        "http_proxy",
-        kind::BYTES,
-        "HTTP proxy URL to use for the request.",
-    ),
-    Parameter::optional(
-        "https_proxy",
-        kind::BYTES,
-        "HTTPS proxy URL to use for the request.",
-    ),
-    Parameter::optional(
-        "redact_headers",
-        kind::BOOLEAN,
-        "Whether to redact sensitive header values in error messages.",
-    )
-    .default(&DEFAULT_REDACT_HEADERS),
-];
+static PARAMETERS: LazyLock<Vec<Parameter>> = LazyLock::new(|| {
+    vec![
+        Parameter::required("url", kind::BYTES, "The URL to make the HTTP request to."),
+        Parameter::optional(
+            "method",
+            kind::BYTES,
+            "The HTTP method to use (e.g., GET, POST, PUT, DELETE). Defaults to GET.",
+        )
+        .default(&DEFAULT_METHOD),
+        Parameter::optional(
+            "headers",
+            kind::OBJECT,
+            "An object containing HTTP headers to send with the request.",
+        )
+        .default(&DEFAULT_HEADERS),
+        Parameter::optional("body", kind::BYTES, "The request body content to send.")
+            .default(&DEFAULT_BODY),
+        Parameter::optional(
+            "http_proxy",
+            kind::BYTES,
+            "HTTP proxy URL to use for the request.",
+        ),
+        Parameter::optional(
+            "https_proxy",
+            kind::BYTES,
+            "HTTPS proxy URL to use for the request.",
+        ),
+        Parameter::optional(
+            "redact_headers",
+            kind::BOOLEAN,
+            "Whether to redact sensitive header values in error messages.",
+        )
+        .default(&DEFAULT_REDACT_HEADERS),
+    ]
+});
 
 #[derive(Clone, Copy, Debug)]
 pub struct HttpRequest;
@@ -467,7 +470,7 @@ impl Function for HttpRequest {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        PARAMETERS
+        PARAMETERS.as_slice()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/stdlib/log_util.rs
+++ b/src/stdlib/log_util.rs
@@ -254,7 +254,7 @@ pub(crate) fn log_fields(
             name.and_then(|name| {
                 captures.name(name).map(|value| {
                     Ok((
-                        name.to_string().into(),
+                        name.into(),
                         capture_value(name, value.as_str(), timestamp_format, timezone)?,
                     ))
                 })

--- a/src/stdlib/merge.rs
+++ b/src/stdlib/merge.rs
@@ -1,18 +1,20 @@
 use crate::compiler::prelude::*;
-use std::collections::BTreeMap;
+use std::sync::LazyLock;
 
-static DEFAULT_DEEP: Value = Value::Boolean(false);
+static DEFAULT_DEEP: LazyLock<Value> = LazyLock::new(|| Value::Boolean(false));
 
-const PARAMETERS: &[Parameter] = &[
-    Parameter::required("to", kind::OBJECT, "The object to merge into."),
-    Parameter::required("from", kind::OBJECT, "The object to merge from."),
-    Parameter::optional(
-        "deep",
-        kind::BOOLEAN,
-        "A deep merge is performed if `true`, otherwise only top-level fields are merged.",
-    )
-    .default(&DEFAULT_DEEP),
-];
+static PARAMETERS: LazyLock<Vec<Parameter>> = LazyLock::new(|| {
+    vec![
+        Parameter::required("to", kind::OBJECT, "The object to merge into."),
+        Parameter::required("from", kind::OBJECT, "The object to merge from."),
+        Parameter::optional(
+            "deep",
+            kind::BOOLEAN,
+            "A deep merge is performed if `true`, otherwise only top-level fields are merged.",
+        )
+        .default(&DEFAULT_DEEP),
+    ]
+});
 
 #[derive(Clone, Copy, Debug)]
 pub struct Merge;
@@ -43,7 +45,7 @@ fields are also objects.",
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        PARAMETERS
+        PARAMETERS.as_slice()
     }
 
     fn examples(&self) -> &'static [Example] {
@@ -160,12 +162,9 @@ impl FunctionExpression for MergeFn {
 /// merge maps with a depth of 3,500 before encountering issues. So I think that
 /// is likely to be within acceptable limits. If it becomes a problem, we can
 /// unroll this function, but that will come at a cost of extra code complexity.
-fn merge_maps<K>(map1: &mut BTreeMap<K, Value>, map2: &BTreeMap<K, Value>, deep: bool)
-where
-    K: std::cmp::Ord + Clone,
-{
+fn merge_maps(map1: &mut ObjectMap, map2: &ObjectMap, deep: bool) {
     for (key2, value2) in map2 {
-        match (deep, map1.get_mut(key2), value2) {
+        match (deep, map1.get_mut(key2.as_str()), value2) {
             (true, Some(Value::Object(child1)), Value::Object(child2)) => {
                 // We are doing a deep merge and both fields are maps.
                 merge_maps(child1, child2, deep);

--- a/src/stdlib/parse_aws_alb_log.rs
+++ b/src/stdlib/parse_aws_alb_log.rs
@@ -245,7 +245,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
 
 #[allow(clippy::too_many_lines)]
 fn parse_log(mut input: &str, strict_mode: bool) -> ExpressionResult<Value> {
-    let mut log = BTreeMap::<KeyString, Value>::new();
+    let mut log = ObjectMap::new();
 
     macro_rules! get_value {
         ($name:expr_2021, $parser:expr_2021, $err:ty) => {{

--- a/src/stdlib/parse_aws_alb_log.rs
+++ b/src/stdlib/parse_aws_alb_log.rs
@@ -323,7 +323,7 @@ fn parse_log(mut input: &str, strict_mode: bool) -> ExpressionResult<Value> {
     let request = get_value!("request", take_quoted1);
     let mut iter = request.splitn(2, ' ');
     log.insert(
-        "request_method".to_owned().into(),
+        "request_method".into(),
         match iter.next().unwrap().into() {
             Value::Bytes(bytes) if bytes == "-" => Value::Null,
             value => value,
@@ -333,7 +333,7 @@ fn parse_log(mut input: &str, strict_mode: bool) -> ExpressionResult<Value> {
         Some(value) => {
             let mut iter = value.rsplitn(2, ' ');
             log.insert(
-                "request_protocol".to_owned().into(),
+                "request_protocol".into(),
                 match iter.next().unwrap().into() {
                     Value::Bytes(bytes) if bytes == "-" => Value::Null,
                     value => value,

--- a/src/stdlib/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/src/stdlib/parse_aws_cloudwatch_log_subscription_message.rs
@@ -44,7 +44,7 @@ fn parse_aws_cloudwatch_log_subscription_message(bytes: Value) -> Resolved {
     let bytes = bytes.try_bytes()?;
     let message = serde_json::from_slice::<AwsCloudWatchLogsSubscriptionMessage>(&bytes)
         .map_err(|e| format!("unable to parse: {e}"))?;
-    let map = Value::from(BTreeMap::from([
+    let map = Value::from(ObjectMap::from([
         (KeyString::from("owner"), Value::from(message.owner)),
         (
             KeyString::from("message_type"),
@@ -66,7 +66,7 @@ fn parse_aws_cloudwatch_log_subscription_message(bytes: Value) -> Resolved {
                     .log_events
                     .into_iter()
                     .map(|event| {
-                        Value::from(BTreeMap::from([
+                        Value::from(ObjectMap::from([
                             (KeyString::from("id"), Value::from(event.id)),
                             (KeyString::from("timestamp"), Value::from(event.timestamp)),
                             (KeyString::from("message"), Value::from(event.message)),

--- a/src/stdlib/parse_aws_vpc_flow_log.rs
+++ b/src/stdlib/parse_aws_vpc_flow_log.rs
@@ -243,7 +243,7 @@ macro_rules! create_match {
 }
 
 fn parse_log(input: &str, format: Option<&str>) -> ParseResult<Value> {
-    let mut log = BTreeMap::new();
+    let mut log = ObjectMap::new();
 
     let mut input = input.split(' ');
     let mut format = format

--- a/src/stdlib/parse_etld.rs
+++ b/src/stdlib/parse_etld.rs
@@ -206,7 +206,7 @@ impl FunctionExpression for ParseEtldFn {
 
         Ok(map
             .into_iter()
-            .map(|(k, v)| (k.to_owned(), v))
+            .map(|(k, v)| (KeyString::from(k), v))
             .collect::<Value>())
     }
 

--- a/src/stdlib/parse_grok.rs
+++ b/src/stdlib/parse_grok.rs
@@ -15,7 +15,7 @@ mod non_wasm {
                 let mut result = ObjectMap::new();
 
                 for (name, value) in &matches {
-                    result.insert(name.to_string().into(), Value::from(value));
+                    result.insert(name.into(), Value::from(value));
                 }
 
                 Ok(Value::from(result))

--- a/src/stdlib/parse_grok.rs
+++ b/src/stdlib/parse_grok.rs
@@ -5,14 +5,14 @@ mod non_wasm {
     use crate::compiler::prelude::*;
     use crate::diagnostic::{Label, Span};
     use crate::value::Value;
+    use std::fmt;
     pub(super) use std::sync::Arc;
-    use std::{collections::BTreeMap, fmt};
 
     fn parse_grok(value: &Value, pattern: &Arc<grok::Pattern>) -> Resolved {
         let bytes = value.try_bytes_utf8_lossy()?;
         match pattern.match_against(&bytes) {
             Some(matches) => {
-                let mut result = BTreeMap::new();
+                let mut result = ObjectMap::new();
 
                 for (name, value) in &matches {
                     result.insert(name.to_string().into(), Value::from(value));

--- a/src/stdlib/parse_groks.rs
+++ b/src/stdlib/parse_groks.rs
@@ -66,32 +66,35 @@ mod non_wasm {
 #[allow(clippy::wildcard_imports)]
 #[cfg(not(target_arch = "wasm32"))]
 use non_wasm::*;
+use std::sync::LazyLock;
 #[cfg(not(target_arch = "wasm32"))]
 use std::{fs::File, io::BufReader, path::Path};
 
-static DEFAULT_ALIASES: Value = Value::Object(std::collections::BTreeMap::new());
-static DEFAULT_ALIAS_SOURCES: Value = Value::Array(vec![]);
+static DEFAULT_ALIASES: LazyLock<Value> = LazyLock::new(|| Value::Object(ObjectMap::new()));
+static DEFAULT_ALIAS_SOURCES: LazyLock<Value> = LazyLock::new(|| Value::Array(vec![]));
 
-const PARAMETERS: &[Parameter] = &[
-    Parameter::required("value", kind::BYTES, "The string to parse."),
-    Parameter::required(
-        "patterns",
-        kind::ARRAY,
-        "The [Grok patterns](https://github.com/daschl/grok/tree/master/patterns), which are tried in order until the first match.",
-    ),
-    Parameter::optional(
-        "aliases",
-        kind::OBJECT,
-        "The shared set of grok aliases that can be referenced in the patterns to simplify them.",
-    )
-    .default(&DEFAULT_ALIASES),
-    Parameter::optional(
-        "alias_sources",
-        kind::ARRAY,
-        "Path to the file containing aliases in a JSON format.",
-    )
-    .default(&DEFAULT_ALIAS_SOURCES),
-];
+static PARAMETERS: LazyLock<Vec<Parameter>> = LazyLock::new(|| {
+    vec![
+        Parameter::required("value", kind::BYTES, "The string to parse."),
+        Parameter::required(
+            "patterns",
+            kind::ARRAY,
+            "The [Grok patterns](https://github.com/daschl/grok/tree/master/patterns), which are tried in order until the first match.",
+        ),
+        Parameter::optional(
+            "aliases",
+            kind::OBJECT,
+            "The shared set of grok aliases that can be referenced in the patterns to simplify them.",
+        )
+        .default(&DEFAULT_ALIASES),
+        Parameter::optional(
+            "alias_sources",
+            kind::ARRAY,
+            "Path to the file containing aliases in a JSON format.",
+        )
+        .default(&DEFAULT_ALIAS_SOURCES),
+    ]
+});
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseGroks;
@@ -130,7 +133,7 @@ impl Function for ParseGroks {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        PARAMETERS
+        PARAMETERS.as_slice()
     }
 
     fn examples(&self) -> &'static [Example] {
@@ -472,10 +475,10 @@ mod test {
                     "_x_forwarded_for": r#"%{regex("[^\\\"]*"):http._x_forwarded_for:nullIf("-")}"#
                 })
             ],
-            want: Ok(Value::Object(btreemap! {
+            want: Ok(Value::from(btreemap! {
                 "date_access" => "13/Jul/2016:10:55:36",
                 "duration" => 202_000_000,
-                "http" => btreemap! {
+                "http" => Value::from(btreemap! {
                     "auth" => "frank",
                     "ident" => "-",
                     "method" => "GET",
@@ -484,13 +487,13 @@ mod test {
                     "version" => "1.0",
                     "referer" => "http://www.perdu.com/",
                     "useragent" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36",
-                },
-                "network" => btreemap! {
+                }),
+                "network" => Value::from(btreemap! {
                     "bytes_written" => 2326,
-                    "client" => btreemap! {
+                    "client" => Value::from(btreemap! {
                         "ip" => "127.0.0.1"
-                    }
-                }
+                    })
+                })
             })),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }

--- a/src/stdlib/parse_influxdb.rs
+++ b/src/stdlib/parse_influxdb.rs
@@ -18,7 +18,7 @@ fn influxdb_line_to_metrics(line: ParsedLine) -> Result<Vec<ObjectMap>, Expressi
 
     let tags: Option<ObjectMap> = series.tag_set.as_ref().map(|tags| {
         tags.iter()
-            .map(|t| (t.0.to_string().into(), t.1.to_string().into()))
+            .map(|t| (KeyString::from(&*t.0), Value::from(&*t.1)))
             .collect()
     });
 

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -1,5 +1,6 @@
 use crate::compiler::function::EnumVariant;
 use crate::compiler::prelude::*;
+use crate::value::ObjectMapEntry;
 use crate::value;
 use nom::{
     self, IResult, Parser,
@@ -14,7 +15,6 @@ use nom::{
 use nom_language::error::VerboseError;
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, btree_map::Entry},
     iter::Peekable,
     str::{Chars, FromStr},
 };
@@ -69,13 +69,13 @@ pub fn parse_key_value(
 
     // Construct Value::Object by grouping values with the same key into an array.
     // This logic depends on values not being arrays which is true for this parser.
-    let mut map = BTreeMap::new();
+    let mut map = ObjectMap::new();
     for (key, value) in values {
         match map.entry(key) {
-            Entry::Vacant(entry) => {
+            ObjectMapEntry::Vacant(entry) => {
                 entry.insert(value);
             }
-            Entry::Occupied(mut entry) => {
+            ObjectMapEntry::Occupied(mut entry) => {
                 if let Value::Boolean(true) = value {
                     // We are done
                 } else {

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -437,7 +437,7 @@ fn parse_key_value_<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
             },
             |(field, sep, value): (Cow<'_, str>, Vec<&str>, Value)| {
                 (
-                    field.to_string().into(),
+                    field.into(),
                     if sep.len() == 1 { value } else { value!(true) },
                 )
             },

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -1,7 +1,7 @@
 use crate::compiler::function::EnumVariant;
 use crate::compiler::prelude::*;
-use crate::value::ObjectMapEntry;
 use crate::value;
+use crate::value::ObjectMapEntry;
 use nom::{
     self, IResult, Parser,
     branch::alt,

--- a/src/stdlib/parse_syslog.rs
+++ b/src/stdlib/parse_syslog.rs
@@ -130,7 +130,7 @@ fn resolve_year((month, _date, _hour, _min, _sec): IncompleteDate) -> i32 {
 
 /// Create a `Value::Map` from the fields of the given syslog message.
 fn message_to_value(message: Message<&str>) -> Value {
-    let mut result = BTreeMap::new();
+    let mut result = ObjectMap::new();
 
     result.insert("message".to_string().into(), message.msg.to_string().into());
 
@@ -178,7 +178,7 @@ fn message_to_value(message: Message<&str>) -> Value {
     }
 
     for element in message.structured_data {
-        let mut sdata = BTreeMap::new();
+        let mut sdata = ObjectMap::new();
         for (name, value) in element.params() {
             sdata.insert((*name).into(), value.into());
         }

--- a/src/stdlib/parse_syslog.rs
+++ b/src/stdlib/parse_syslog.rs
@@ -132,41 +132,35 @@ fn resolve_year((month, _date, _hour, _min, _sec): IncompleteDate) -> i32 {
 fn message_to_value(message: Message<&str>) -> Value {
     let mut result = ObjectMap::new();
 
-    result.insert("message".to_string().into(), message.msg.to_string().into());
+    result.insert("message".into(), message.msg.into());
 
     if let Some(host) = message.hostname {
-        result.insert("hostname".to_string().into(), host.to_string().into());
+        result.insert("hostname".into(), host.into());
     }
 
     if let Some(severity) = message.severity {
-        result.insert(
-            "severity".to_string().into(),
-            severity.as_str().to_owned().into(),
-        );
+        result.insert("severity".into(), severity.as_str().into());
     }
 
     if let Some(facility) = message.facility {
-        result.insert(
-            "facility".to_string().into(),
-            facility.as_str().to_owned().into(),
-        );
+        result.insert("facility".into(), facility.as_str().into());
     }
 
     if let Protocol::RFC5424(version) = message.protocol {
-        result.insert("version".to_string().into(), version.into());
+        result.insert("version".into(), version.into());
     }
 
     if let Some(app_name) = message.appname {
-        result.insert("appname".to_string().into(), app_name.to_owned().into());
+        result.insert("appname".into(), app_name.into());
     }
 
     if let Some(msg_id) = message.msgid {
-        result.insert("msgid".to_string().into(), msg_id.to_owned().into());
+        result.insert("msgid".into(), msg_id.into());
     }
 
     if let Some(timestamp) = message.timestamp {
         let timestamp: DateTime<Utc> = timestamp.into();
-        result.insert("timestamp".to_string().into(), timestamp.into());
+        result.insert("timestamp".into(), timestamp.into());
     }
 
     if let Some(procid) = message.procid {
@@ -174,7 +168,7 @@ fn message_to_value(message: Message<&str>) -> Value {
             ProcId::PID(pid) => pid.into(),
             ProcId::Name(name) => name.to_string().into(),
         };
-        result.insert("procid".to_string().into(), value);
+        result.insert("procid".into(), value);
     }
 
     for element in message.structured_data {
@@ -182,7 +176,7 @@ fn message_to_value(message: Message<&str>) -> Value {
         for (name, value) in element.params() {
             sdata.insert((*name).into(), value.into());
         }
-        result.insert(element.id.to_string().into(), sdata.into());
+        result.insert(element.id.into(), sdata.into());
     }
 
     result.into()

--- a/src/stdlib/parse_url.rs
+++ b/src/stdlib/parse_url.rs
@@ -159,7 +159,7 @@ fn url_to_value(url: &Url, default_known_ports: bool) -> Value {
     );
 
     map.into_iter()
-        .map(|(k, v)| (k.to_owned(), v))
+        .map(|(k, v)| (KeyString::from(k), v))
         .collect::<Value>()
 }
 

--- a/src/stdlib/replace_with.rs
+++ b/src/stdlib/replace_with.rs
@@ -92,7 +92,7 @@ const STRING_NAME: &str = "string";
 const CAPTURES_NAME: &str = "captures";
 
 fn captures_to_value(captures: &Captures, capture_names: CaptureNames) -> Value {
-    let mut object: ObjectMap = BTreeMap::new();
+    let mut object: ObjectMap = ObjectMap::new();
 
     // The full match, named "string"
     object.insert(STRING_NAME.into(), captures.get(0).unwrap().as_str().into());

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -224,7 +224,7 @@ impl FunctionExpression for ShannonEntropyFn {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use crate::value::ObjectMap;
 
     use super::*;
     use crate::{stdlib::util::round_to_precision, value};
@@ -326,7 +326,7 @@ mod tests {
 
     fn prepare_function(function: &ShannonEntropyFn) -> Resolved {
         let tz = TimeZone::default();
-        let mut object: Value = Value::Object(BTreeMap::new());
+        let mut object: Value = Value::Object(ObjectMap::new());
         let mut runtime_state = state::RuntimeState::default();
         let mut ctx = Context::new(&mut object, &mut runtime_state, &tz);
         function.resolve(&mut ctx)

--- a/src/stdlib/tag_types_externally.rs
+++ b/src/stdlib/tag_types_externally.rs
@@ -1,5 +1,4 @@
 use crate::compiler::prelude::*;
-use std::collections::BTreeMap;
 
 #[derive(Clone, Copy, Debug)]
 pub struct TagTypesExternally;
@@ -131,7 +130,7 @@ fn tag_type_externally(value: Value) -> Value {
     };
 
     if let Some(key) = key {
-        BTreeMap::from([(key.to_owned().into(), value)]).into()
+        ObjectMap::from([(key.to_owned().into(), value)]).into()
     } else {
         value
     }

--- a/src/stdlib/tag_types_externally.rs
+++ b/src/stdlib/tag_types_externally.rs
@@ -130,7 +130,7 @@ fn tag_type_externally(value: Value) -> Value {
     };
 
     if let Some(key) = key {
-        ObjectMap::from([(key.to_owned().into(), value)]).into()
+        ObjectMap::from([(key.into(), value)]).into()
     } else {
         value
     }

--- a/src/stdlib/tally.rs
+++ b/src/stdlib/tally.rs
@@ -14,12 +14,7 @@ fn tally(value: Value) -> Resolved {
     }
     let map: ObjectMap = map
         .into_iter()
-        .map(|(k, v)| {
-            (
-                String::from_utf8_lossy(&k).into(),
-                Value::from(v),
-            )
-        })
+        .map(|(k, v)| (String::from_utf8_lossy(&k).into(), Value::from(v)))
         .collect();
     Ok(map.into())
 }

--- a/src/stdlib/tally.rs
+++ b/src/stdlib/tally.rs
@@ -16,7 +16,7 @@ fn tally(value: Value) -> Resolved {
         .into_iter()
         .map(|(k, v)| {
             (
-                String::from_utf8_lossy(&k).into_owned().into(),
+                String::from_utf8_lossy(&k).into(),
                 Value::from(v),
             )
         })

--- a/src/stdlib/tally.rs
+++ b/src/stdlib/tally.rs
@@ -1,5 +1,5 @@
 use crate::compiler::prelude::*;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 fn tally(value: Value) -> Resolved {
     let value = value.try_array()?;
@@ -12,7 +12,7 @@ fn tally(value: Value) -> Resolved {
             return Err(format!("all values must be strings, found: {value:?}").into());
         }
     }
-    let map: BTreeMap<_, _> = map
+    let map: ObjectMap = map
         .into_iter()
         .map(|(k, v)| {
             (

--- a/src/stdlib/type_def.rs
+++ b/src/stdlib/type_def.rs
@@ -4,7 +4,7 @@ fn type_def(type_def: &VrlTypeDef) -> Value {
     let mut tree = type_def.kind().canonicalize().debug_info();
 
     if type_def.is_fallible() {
-        tree.insert("fallible".to_owned().into(), true.into());
+        tree.insert("fallible".into(), true.into());
     }
 
     tree.into()

--- a/src/stdlib/unflatten.rs
+++ b/src/stdlib/unflatten.rs
@@ -44,7 +44,7 @@ where
         .into_iter()
         .map(|(key, value)| {
             let (head, rest) = match key.split_once(separator) {
-                Some((key, rest)) => (key.to_string().into(), Some(rest.to_string().into())),
+                Some((key, rest)) => (key.into(), Some(rest.into())),
                 None => (key.clone(), None),
             };
             (head, rest, value)

--- a/src/stdlib/uuid_v4.rs
+++ b/src/stdlib/uuid_v4.rs
@@ -62,8 +62,8 @@ impl FunctionExpression for UuidV4Fn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::ObjectMap;
     use crate::value::Value;
-    use std::collections::BTreeMap;
 
     test_type_def![default {
         expr: |_| { UuidV4Fn },
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn uuid_v4() {
         let mut state = state::RuntimeState::default();
-        let mut object: Value = Value::Object(BTreeMap::new());
+        let mut object: Value = Value::Object(ObjectMap::new());
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut state, &tz);
         let value = UuidV4Fn.resolve(&mut ctx).unwrap();

--- a/src/stdlib/uuid_v7.rs
+++ b/src/stdlib/uuid_v7.rs
@@ -118,8 +118,8 @@ impl FunctionExpression for UuidV7Fn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::ObjectMap;
     use crate::value::Value;
-    use std::collections::BTreeMap;
 
     test_type_def![default {
         expr: |_| { UuidV7Fn { timestamp: None } },
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn uuid_v7() {
         let mut state = state::RuntimeState::default();
-        let mut object: Value = Value::Object(BTreeMap::new());
+        let mut object: Value = Value::Object(ObjectMap::new());
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut state, &tz);
         let value = UuidV7Fn { timestamp: None }.resolve(&mut ctx).unwrap();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::print_stderr)] // tests
 
 use std::path::{MAIN_SEPARATOR, PathBuf};
-use std::{collections::BTreeMap, env, str::FromStr, time::Instant};
+use std::{env, str::FromStr, time::Instant};
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use nu_ansi_term::Color;
@@ -17,6 +17,7 @@ use crate::compiler::{
     value::VrlValueConvert,
 };
 use crate::diagnostic::{DiagnosticList, Formatter};
+use crate::value::ObjectMap;
 use crate::value::Secrets;
 use crate::value::Value;
 
@@ -471,7 +472,7 @@ fn run_vrl(
     timezone: TimeZone,
     vrl_runtime: VrlRuntime,
 ) -> Result<Value, Terminate> {
-    let mut metadata = Value::from(BTreeMap::new());
+    let mut metadata = Value::from(ObjectMap::new());
     let mut target = TargetValueRef {
         value: test_object,
         metadata: &mut metadata,

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{fs, path::Path};
 
 use crate::compiler::function::Example;
 use crate::path::OwnedTargetPath;
 use crate::path::parse_value_path;
 use crate::test::{example_vrl_path, test_prefix};
-use crate::value::Value;
+use crate::value::{ObjectMap, Value};
 
 #[derive(Debug)]
 pub struct Test {
@@ -119,7 +119,7 @@ impl Test {
 
         let mut error = None;
         let object = if object.is_empty() {
-            Value::Object(BTreeMap::default())
+            Value::Object(ObjectMap::default())
         } else {
             serde_json::from_str::<'_, Value>(&object).unwrap_or_else(|err| {
                 error = Some(format!("unable to parse object as JSON: {err}"));
@@ -153,7 +153,7 @@ impl Test {
             Some(input) => {
                 serde_json::from_str::<Value>(input).expect("example input should be valid JSON")
             }
-            None => Value::Object(BTreeMap::default()),
+            None => Value::Object(ObjectMap::default()),
         };
         let result = match example.result {
             Ok(string) => string.to_owned(),

--- a/src/value/btreemap.rs
+++ b/src/value/btreemap.rs
@@ -1,4 +1,4 @@
-/// A macro to easily create a map containing `Value`
+/// A macro to easily create a `BTreeMap`
 #[macro_export]
 macro_rules! btreemap {
     () => (::std::collections::BTreeMap::new());
@@ -8,6 +8,23 @@ macro_rules! btreemap {
 
     ($($key:expr_2021 => $value:expr_2021),*) => {
         ::std::collections::BTreeMap::from([
+            $(
+                ($key.into(), $value.into()),
+            )*
+        ])
+    };
+}
+
+/// A macro to easily create an `ObjectMap`
+#[macro_export]
+macro_rules! objectmap {
+    () => ($crate::value::ObjectMap::new());
+
+    // trailing comma case
+    ($($key:expr_2021 => $value:expr_2021,)+) => (objectmap!($($key => $value),+));
+
+    ($($key:expr_2021 => $value:expr_2021),*) => {
+        $crate::value::ObjectMap::from([
             $(
                 ($key.into(), $value.into()),
             )*
@@ -31,5 +48,16 @@ mod tests {
         map.insert("1", "one");
         map.insert("2", "two");
         assert_eq!(btreemap! { "1" => "one", "2" => "two" }, map);
+    }
+
+    #[test]
+    fn test_objectmap() {
+        use crate::value::ObjectMap;
+
+        assert_eq!(objectmap! {}, ObjectMap::new());
+
+        let mut map = ObjectMap::new();
+        map.insert("key".into(), "value".into());
+        assert_eq!(objectmap! { "key" => "value" }, map);
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -40,7 +40,7 @@ macro_rules! value {
     });
 
     ({$($($k1:literal)? $($k2:ident)?: $v:tt),+ $(,)?}) => ({
-        let map = vec![$((String::from($($k1)? $(stringify!($k2))?).into(), $crate::value!($v))),+]
+        let map = vec![$(($crate::value::KeyString::from($($k1)? $(stringify!($k2))?), $crate::value!($v))),+]
             .into_iter()
             .collect::<$crate::value::ObjectMap>();
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -18,7 +18,10 @@ pub use kind::Kind;
 pub use self::keystring::KeyString;
 pub use self::secrets::Secrets;
 #[allow(clippy::module_name_repetitions)]
-pub use self::value::{ObjectMap, Value, ValueRegex};
+pub use self::value::{
+    ObjectMap, ObjectMapEntry, ObjectMapIter, ObjectMapKeys, ObjectMapValues,
+    Value, ValueRegex,
+};
 
 /// A macro to easily generate Values
 #[macro_export]
@@ -33,13 +36,13 @@ macro_rules! value {
     });
 
     ({}) => ({
-        $crate::value::Value::Object(::std::collections::BTreeMap::default())
+        $crate::value::Value::Object($crate::value::ObjectMap::default())
     });
 
     ({$($($k1:literal)? $($k2:ident)?: $v:tt),+ $(,)?}) => ({
         let map = vec![$((String::from($($k1)? $(stringify!($k2))?).into(), $crate::value!($v))),+]
             .into_iter()
-            .collect::<::std::collections::BTreeMap<_, $crate::value::Value>>();
+            .collect::<$crate::value::ObjectMap>();
 
         $crate::value::Value::Object(map)
     });

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -19,8 +19,7 @@ pub use self::keystring::KeyString;
 pub use self::secrets::Secrets;
 #[allow(clippy::module_name_repetitions)]
 pub use self::value::{
-    ObjectMap, ObjectMapEntry, ObjectMapIter, ObjectMapKeys, ObjectMapValues,
-    Value, ValueRegex,
+    ObjectMap, ObjectMapEntry, ObjectMapIter, ObjectMapKeys, ObjectMapValues, Value, ValueRegex,
 };
 
 /// A macro to easily generate Values

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -7,9 +7,15 @@ pub use iter::{IterItem, ValueIter};
 
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, SecondsFormat, Utc};
+use ecow::EcoVec;
 use ordered_float::NotNan;
 use std::borrow::Cow;
-use std::{cmp::Ordering, collections::BTreeMap};
+use std::fmt;
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, btree_map},
+    hash::{Hash, Hasher},
+};
 
 use super::KeyString;
 use crate::path::ValuePath;
@@ -31,7 +37,749 @@ mod serde;
 pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// The storage mapping for the `Object` variant.
-pub type ObjectMap = BTreeMap<KeyString, Value>;
+///
+/// This is a newtype wrapper around `BTreeMap<KeyString, Value>` that preserves
+/// sorted iteration order. The internal representation is opaque and may change
+/// for efficiency in the future.
+pub enum ObjectMap {
+    BTree(BTreeMap<KeyString, Value>),
+    Flat(EcoVec<(KeyString, Value)>),
+    VecFlat(Vec<(KeyString, Value)>),
+}
+
+impl Clone for ObjectMap {
+    fn clone(&self) -> Self {
+        match self {
+            Self::BTree(map) => Self::BTree(map.clone()),
+            // O(1): EcoVec clone just increments a refcount.
+            Self::Flat(vec) => Self::Flat(vec.clone()),
+            Self::VecFlat(vec) => Self::VecFlat(vec.clone()),
+        }
+    }
+}
+
+impl fmt::Debug for ObjectMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BTree(map) => f.debug_map().entries(map.iter()).finish(),
+            _ => {
+                let s = self.as_flat_slice().unwrap();
+                f.debug_map().entries(s.iter().map(|(k, v)| (k, v))).finish()
+            }
+        }
+    }
+}
+
+impl Default for ObjectMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub enum ObjectMapKeys<'a> {
+    BTree(btree_map::Keys<'a, KeyString, Value>),
+    Flat(std::slice::Iter<'a, (KeyString, Value)>),
+}
+
+impl<'a> Iterator for ObjectMapKeys<'a> {
+    type Item = &'a KeyString;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(k, _)| k),
+        }
+    }
+}
+
+pub enum ObjectMapValues<'a> {
+    BTree(btree_map::Values<'a, KeyString, Value>),
+    Flat(std::slice::Iter<'a, (KeyString, Value)>),
+}
+
+impl<'a> Iterator for ObjectMapValues<'a> {
+    type Item = &'a Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(_, v)| v),
+        }
+    }
+}
+
+pub enum ObjectMapValuesMut<'a> {
+    BTree(btree_map::ValuesMut<'a, KeyString, Value>),
+    Flat(std::slice::IterMut<'a, (KeyString, Value)>),
+}
+
+impl<'a> Iterator for ObjectMapValuesMut<'a> {
+    type Item = &'a mut Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(_, v)| v),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ObjectMapIter<'a> {
+    BTree(btree_map::Iter<'a, KeyString, Value>),
+    Flat(std::slice::Iter<'a, (KeyString, Value)>),
+}
+
+impl<'a> Iterator for ObjectMapIter<'a> {
+    type Item = (&'a KeyString, &'a Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(k, v)| (k, v)),
+        }
+    }
+}
+
+pub enum ObjectMapIterMut<'a> {
+    BTree(btree_map::IterMut<'a, KeyString, Value>),
+    Flat(std::slice::IterMut<'a, (KeyString, Value)>),
+}
+
+impl<'a> Iterator for ObjectMapIterMut<'a> {
+    type Item = (&'a KeyString, &'a mut Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(k, v)| (k as &KeyString, v)),
+        }
+    }
+}
+
+pub enum ObjectMapIntoKeys {
+    BTree(btree_map::IntoKeys<KeyString, Value>),
+    Flat(std::vec::IntoIter<(KeyString, Value)>),
+}
+
+impl Iterator for ObjectMapIntoKeys {
+    type Item = KeyString;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(k, _)| k),
+        }
+    }
+}
+
+pub enum ObjectMapIntoValues {
+    BTree(btree_map::IntoValues<KeyString, Value>),
+    Flat(std::vec::IntoIter<(KeyString, Value)>),
+}
+
+impl Iterator for ObjectMapIntoValues {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next().map(|(_, v)| v),
+        }
+    }
+}
+
+pub enum ObjectMapIntoIter {
+    BTree(btree_map::IntoIter<KeyString, Value>),
+    Flat(std::vec::IntoIter<(KeyString, Value)>),
+}
+
+impl Iterator for ObjectMapIntoIter {
+    type Item = (KeyString, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTree(iter) => iter.next(),
+            Self::Flat(iter) => iter.next(),
+        }
+    }
+}
+
+pub enum ObjectMapEntry<'a> {
+    Occupied(ObjectMapOccupiedEntry<'a>),
+    Vacant(ObjectMapVacantEntry<'a>),
+}
+
+pub struct FlatOccupiedEntry<'a> {
+    vec: &'a mut EcoVec<(KeyString, Value)>,
+    index: usize,
+}
+
+impl<'a> FlatOccupiedEntry<'a> {
+    pub fn get(&self) -> &Value {
+        &self.vec[self.index].1
+    }
+
+    pub fn get_mut(&mut self) -> &mut Value {
+        &mut self.vec.make_mut()[self.index].1
+    }
+
+    pub fn insert(&mut self, value: Value) -> Value {
+        std::mem::replace(&mut self.vec.make_mut()[self.index].1, value)
+    }
+
+    pub fn into_mut(self) -> &'a mut Value {
+        &mut self.vec.make_mut()[self.index].1
+    }
+}
+
+pub struct FlatVacantEntry<'a> {
+    vec: &'a mut EcoVec<(KeyString, Value)>,
+    key: KeyString,
+}
+
+impl<'a> FlatVacantEntry<'a> {
+    pub fn insert(self, value: Value) -> &'a mut Value {
+        self.vec.push((self.key, value));
+        let idx = self.vec.len() - 1;
+        &mut self.vec.make_mut()[idx].1
+    }
+}
+
+pub struct VecFlatOccupiedEntry<'a> {
+    vec: &'a mut Vec<(KeyString, Value)>,
+    index: usize,
+}
+
+impl<'a> VecFlatOccupiedEntry<'a> {
+    pub fn get(&self) -> &Value { &self.vec[self.index].1 }
+    pub fn get_mut(&mut self) -> &mut Value { &mut self.vec[self.index].1 }
+    pub fn insert(&mut self, value: Value) -> Value { std::mem::replace(&mut self.vec[self.index].1, value) }
+    pub fn into_mut(self) -> &'a mut Value { &mut self.vec[self.index].1 }
+}
+
+pub struct VecFlatVacantEntry<'a> {
+    vec: &'a mut Vec<(KeyString, Value)>,
+    key: KeyString,
+}
+
+impl<'a> VecFlatVacantEntry<'a> {
+    pub fn insert(self, value: Value) -> &'a mut Value {
+        self.vec.push((self.key, value));
+        let idx = self.vec.len() - 1;
+        &mut self.vec[idx].1
+    }
+}
+
+pub enum ObjectMapOccupiedEntry<'a> {
+    BTree(btree_map::OccupiedEntry<'a, KeyString, Value>),
+    Flat(FlatOccupiedEntry<'a>),
+    VecFlat(VecFlatOccupiedEntry<'a>),
+}
+
+impl ObjectMapOccupiedEntry<'_> {
+    pub fn get(&self) -> &Value {
+        match self {
+            Self::BTree(entry) => entry.get(),
+            Self::Flat(entry) => entry.get(),
+            Self::VecFlat(entry) => entry.get(),
+        }
+    }
+
+    pub fn get_mut(&mut self) -> &mut Value {
+        match self {
+            Self::BTree(entry) => entry.get_mut(),
+            Self::Flat(entry) => entry.get_mut(),
+            Self::VecFlat(entry) => entry.get_mut(),
+        }
+    }
+
+    pub fn insert(&mut self, value: Value) -> Value {
+        match self {
+            Self::BTree(entry) => entry.insert(value),
+            Self::Flat(entry) => entry.insert(value),
+            Self::VecFlat(entry) => entry.insert(value),
+        }
+    }
+}
+
+pub enum ObjectMapVacantEntry<'a> {
+    BTree(btree_map::VacantEntry<'a, KeyString, Value>),
+    Flat(FlatVacantEntry<'a>),
+    VecFlat(VecFlatVacantEntry<'a>),
+}
+
+impl<'a> ObjectMapVacantEntry<'a> {
+    pub fn insert(self, value: Value) -> &'a mut Value {
+        match self {
+            Self::BTree(entry) => entry.insert(value),
+            Self::Flat(entry) => entry.insert(value),
+            Self::VecFlat(entry) => entry.insert(value),
+        }
+    }
+}
+
+impl<'a> ObjectMapEntry<'a> {
+    pub fn and_modify<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&mut Value),
+    {
+        match self {
+            Self::Occupied(mut entry) => {
+                f(entry.get_mut());
+                Self::Occupied(entry)
+            }
+            Self::Vacant(entry) => Self::Vacant(entry),
+        }
+    }
+
+    pub fn or_insert(self, default: Value) -> &'a mut Value {
+        match self {
+            Self::Occupied(entry) => match entry {
+                ObjectMapOccupiedEntry::BTree(entry) => entry.into_mut(),
+                ObjectMapOccupiedEntry::Flat(entry) => entry.into_mut(),
+                ObjectMapOccupiedEntry::VecFlat(entry) => entry.into_mut(),
+            },
+            Self::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    pub fn or_insert_with<F>(self, default: F) -> &'a mut Value
+    where
+        F: FnOnce() -> Value,
+    {
+        match self {
+            Self::Occupied(entry) => match entry {
+                ObjectMapOccupiedEntry::BTree(entry) => entry.into_mut(),
+                ObjectMapOccupiedEntry::Flat(entry) => entry.into_mut(),
+                ObjectMapOccupiedEntry::VecFlat(entry) => entry.into_mut(),
+            },
+            Self::Vacant(entry) => entry.insert(default()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelectedBackend {
+    BTree,
+    Flat,
+    VecFlat,
+}
+
+fn selected_backend() -> SelectedBackend {
+    use std::sync::OnceLock;
+    static SELECTED: OnceLock<SelectedBackend> = OnceLock::new();
+    *SELECTED.get_or_init(|| {
+        match std::env::var("VRL_OBJECT_MAP").ok().as_deref() {
+            Some(s) if s.eq_ignore_ascii_case("btree") => SelectedBackend::BTree,
+            Some(s) if s.eq_ignore_ascii_case("vec") || s.eq_ignore_ascii_case("vecflat") => SelectedBackend::VecFlat,
+            _ => SelectedBackend::Flat,
+        }
+    })
+}
+
+impl ObjectMap {
+    fn as_flat_slice(&self) -> Option<&[(KeyString, Value)]> {
+        match self {
+            Self::Flat(vec) => Some(vec),
+            Self::VecFlat(vec) => Some(vec),
+            Self::BTree(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub fn new() -> Self {
+        match selected_backend() {
+            SelectedBackend::BTree => Self::new_btree(),
+            SelectedBackend::Flat => Self::Flat(EcoVec::new()),
+            SelectedBackend::VecFlat => Self::VecFlat(Vec::new()),
+        }
+    }
+
+    #[must_use]
+    pub fn new_btree() -> Self {
+        Self::BTree(BTreeMap::new())
+    }
+
+    pub fn insert(&mut self, key: KeyString, value: Value) -> Option<Value> {
+        match self {
+            Self::BTree(map) => map.insert(key, value),
+            Self::Flat(vec) => {
+                if let Some(pos) = vec.iter().position(|(k, _)| *k == key) {
+                    Some(std::mem::replace(&mut vec.make_mut()[pos].1, value))
+                } else {
+                    vec.push((key, value));
+                    None
+                }
+            }
+            Self::VecFlat(vec) => {
+                if let Some(pos) = vec.iter().position(|(k, _)| *k == key) {
+                    Some(std::mem::replace(&mut vec[pos].1, value))
+                } else {
+                    vec.push((key, value));
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        match self {
+            Self::BTree(map) => map.get(key),
+            _ => self.as_flat_slice().unwrap()
+                .iter()
+                .find(|(k, _)| k.as_str() == key)
+                .map(|(_, v)| v),
+        }
+    }
+
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut Value> {
+        match self {
+            Self::BTree(map) => map.get_mut(key),
+            Self::Flat(vec) => {
+                let pos = vec.iter().position(|(k, _)| k.as_str() == key)?;
+                Some(&mut vec.make_mut()[pos].1)
+            }
+            Self::VecFlat(vec) => vec
+                .iter_mut()
+                .find(|(k, _)| k.as_str() == key)
+                .map(|(_, v)| v),
+        }
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<Value> {
+        match self {
+            Self::BTree(map) => map.remove(key),
+            Self::Flat(vec) => {
+                let pos = vec.iter().position(|(k, _)| k.as_str() == key)?;
+                Some(vec.remove(pos).1)
+            }
+            Self::VecFlat(vec) => {
+                let pos = vec.iter().position(|(k, _)| k.as_str() == key)?;
+                Some(vec.swap_remove(pos).1)
+            }
+        }
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        match self {
+            Self::BTree(map) => map.contains_key(key),
+            _ => self.as_flat_slice().unwrap().iter().any(|(k, _)| k.as_str() == key),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::BTree(map) => map.len(),
+            _ => self.as_flat_slice().unwrap().len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::BTree(map) => map.is_empty(),
+            _ => self.as_flat_slice().unwrap().is_empty(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        match self {
+            Self::BTree(map) => map.clear(),
+            Self::Flat(vec) => vec.clear(),
+            Self::VecFlat(vec) => vec.clear(),
+        }
+    }
+
+    pub fn keys(&self) -> ObjectMapKeys<'_> {
+        match self {
+            Self::BTree(map) => ObjectMapKeys::BTree(map.keys()),
+            _ => ObjectMapKeys::Flat(self.as_flat_slice().unwrap().iter()),
+        }
+    }
+
+    pub fn values(&self) -> ObjectMapValues<'_> {
+        match self {
+            Self::BTree(map) => ObjectMapValues::BTree(map.values()),
+            _ => ObjectMapValues::Flat(self.as_flat_slice().unwrap().iter()),
+        }
+    }
+
+    pub fn values_mut(&mut self) -> ObjectMapValuesMut<'_> {
+        match self {
+            Self::BTree(map) => ObjectMapValuesMut::BTree(map.values_mut()),
+            Self::Flat(vec) => ObjectMapValuesMut::Flat(vec.make_mut().iter_mut()),
+            Self::VecFlat(vec) => ObjectMapValuesMut::Flat(vec.iter_mut()),
+        }
+    }
+
+    pub fn iter(&self) -> ObjectMapIter<'_> {
+        match self {
+            Self::BTree(map) => ObjectMapIter::BTree(map.iter()),
+            _ => ObjectMapIter::Flat(self.as_flat_slice().unwrap().iter()),
+        }
+    }
+
+    pub fn iter_mut(&mut self) -> ObjectMapIterMut<'_> {
+        match self {
+            Self::BTree(map) => ObjectMapIterMut::BTree(map.iter_mut()),
+            Self::Flat(vec) => ObjectMapIterMut::Flat(vec.make_mut().iter_mut()),
+            Self::VecFlat(vec) => ObjectMapIterMut::Flat(vec.iter_mut()),
+        }
+    }
+
+    pub fn into_keys(self) -> ObjectMapIntoKeys {
+        match self {
+            Self::BTree(map) => ObjectMapIntoKeys::BTree(map.into_keys()),
+            Self::Flat(vec) => ObjectMapIntoKeys::Flat(vec.into_iter().collect::<Vec<_>>().into_iter()),
+            Self::VecFlat(vec) => ObjectMapIntoKeys::Flat(vec.into_iter()),
+        }
+    }
+
+    pub fn into_values(self) -> ObjectMapIntoValues {
+        match self {
+            Self::BTree(map) => ObjectMapIntoValues::BTree(map.into_values()),
+            Self::Flat(vec) => ObjectMapIntoValues::Flat(vec.into_iter().collect::<Vec<_>>().into_iter()),
+            Self::VecFlat(vec) => ObjectMapIntoValues::Flat(vec.into_iter()),
+        }
+    }
+
+    pub fn entry(&mut self, key: KeyString) -> ObjectMapEntry<'_> {
+        match self {
+            Self::BTree(map) => match map.entry(key) {
+                btree_map::Entry::Occupied(entry) => {
+                    ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::BTree(entry))
+                }
+                btree_map::Entry::Vacant(entry) => {
+                    ObjectMapEntry::Vacant(ObjectMapVacantEntry::BTree(entry))
+                }
+            },
+            Self::Flat(vec) => match vec.iter().position(|(k, _)| *k == key) {
+                Some(index) => ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::Flat(
+                    FlatOccupiedEntry { vec, index },
+                )),
+                None => ObjectMapEntry::Vacant(ObjectMapVacantEntry::Flat(
+                    FlatVacantEntry { vec, key },
+                )),
+            },
+            Self::VecFlat(vec) => match vec.iter().position(|(k, _)| *k == key) {
+                Some(index) => ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::VecFlat(
+                    VecFlatOccupiedEntry { vec, index },
+                )),
+                None => ObjectMapEntry::Vacant(ObjectMapVacantEntry::VecFlat(
+                    VecFlatVacantEntry { vec, key },
+                )),
+            },
+        }
+    }
+
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&KeyString, &mut Value) -> bool,
+    {
+        match self {
+            Self::BTree(map) => map.retain(f),
+            Self::Flat(vec) => {
+                let mut i = 0;
+                while i < vec.len() {
+                    let (ref k, ref mut v) = vec.make_mut()[i];
+                    if f(k, v) {
+                        i += 1;
+                    } else {
+                        vec.remove(i);
+                    }
+                }
+            }
+            Self::VecFlat(vec) => vec.retain_mut(|(k, v)| f(k, v)),
+        }
+    }
+
+    /// Insert a new empty child `ObjectMap` at the given key and return a
+    /// mutable reference to it.  The child uses the same variant as the parent.
+    pub fn insert_child(&mut self, key: KeyString) -> &mut ObjectMap {
+        let child = match self {
+            Self::BTree(_) => ObjectMap::new_btree(),
+            Self::Flat(_) => ObjectMap::Flat(EcoVec::new()),
+            Self::VecFlat(_) => ObjectMap::VecFlat(Vec::new()),
+        };
+        self.insert(key.clone(), Value::Object(child));
+        match self.get_mut(key.as_ref()).unwrap() {
+            Value::Object(map) => map,
+            _ => unreachable!(),
+        }
+    }
+}
+
+// --- Trait implementations ---
+
+impl PartialEq for ObjectMap {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len()
+            && self
+                .iter()
+                .all(|(key, value)| other.get(key.as_ref()) == Some(value))
+    }
+}
+
+impl Eq for ObjectMap {}
+
+impl Hash for ObjectMap {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let mut entries = self.iter().collect::<Vec<_>>();
+        entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        for (key, value) in entries {
+            key.hash(state);
+            value.hash(state);
+        }
+    }
+}
+
+impl PartialOrd for ObjectMap {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let mut left = self.iter().collect::<Vec<_>>();
+        let mut right = other.iter().collect::<Vec<_>>();
+        left.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        right.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+
+        left.partial_cmp(&right)
+    }
+}
+
+impl IntoIterator for ObjectMap {
+    type Item = (KeyString, Value);
+    type IntoIter = ObjectMapIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::BTree(map) => ObjectMapIntoIter::BTree(map.into_iter()),
+            Self::Flat(vec) => {
+                let v: Vec<_> = vec.into_iter().collect();
+                ObjectMapIntoIter::Flat(v.into_iter())
+            }
+            Self::VecFlat(vec) => ObjectMapIntoIter::Flat(vec.into_iter()),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a ObjectMap {
+    type Item = (&'a KeyString, &'a Value);
+    type IntoIter = ObjectMapIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut ObjectMap {
+    type Item = (&'a KeyString, &'a mut Value);
+    type IntoIter = ObjectMapIterMut<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl FromIterator<(KeyString, Value)> for ObjectMap {
+    fn from_iter<I: IntoIterator<Item = (KeyString, Value)>>(iter: I) -> Self {
+        let vec: Vec<_> = iter.into_iter().collect();
+        match selected_backend() {
+            SelectedBackend::VecFlat => Self::VecFlat(vec),
+            _ => Self::Flat(EcoVec::from(vec)),
+        }
+    }
+}
+
+impl Extend<(KeyString, Value)> for ObjectMap {
+    fn extend<I: IntoIterator<Item = (KeyString, Value)>>(&mut self, iter: I) {
+        match self {
+            Self::BTree(map) => map.extend(iter),
+            Self::Flat(_) | Self::VecFlat(_) => {
+                for (k, v) in iter {
+                    self.insert(k, v);
+                }
+            }
+        }
+    }
+}
+
+impl<const N: usize> From<[(KeyString, Value); N]> for ObjectMap {
+    fn from(arr: [(KeyString, Value); N]) -> Self {
+        match selected_backend() {
+            SelectedBackend::VecFlat => Self::VecFlat(Vec::from(arr)),
+            _ => Self::Flat(EcoVec::from(Vec::from(arr))),
+        }
+    }
+}
+
+impl From<BTreeMap<KeyString, Value>> for ObjectMap {
+    fn from(map: BTreeMap<KeyString, Value>) -> Self {
+        let vec: Vec<_> = map.into_iter().collect();
+        match selected_backend() {
+            SelectedBackend::VecFlat => Self::VecFlat(vec),
+            _ => Self::Flat(EcoVec::from(vec)),
+        }
+    }
+}
+
+impl std::ops::Index<&str> for ObjectMap {
+    type Output = Value;
+
+    fn index(&self, key: &str) -> &Value {
+        self.get(key).expect("key not found")
+    }
+}
+
+impl std::ops::Index<&KeyString> for ObjectMap {
+    type Output = Value;
+
+    fn index(&self, key: &KeyString) -> &Value {
+        self.get(key.as_ref()).expect("key not found")
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl PartialEq<BTreeMap<KeyString, Value>> for ObjectMap {
+    fn eq(&self, other: &BTreeMap<KeyString, Value>) -> bool {
+        self.len() == other.len()
+            && other
+                .iter()
+                .all(|(key, value)| self.get(key.as_ref()) == Some(value))
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl PartialEq<ObjectMap> for BTreeMap<KeyString, Value> {
+    fn eq(&self, other: &ObjectMap) -> bool {
+        other.len() == self.len()
+            && self
+                .iter()
+                .all(|(key, value)| other.get(key.as_ref()) == Some(value))
+    }
+}
+
+impl ::serde::Serialize for ObjectMap {
+    fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use ::serde::ser::SerializeMap;
+        match self {
+            Self::BTree(map) => map.serialize(serializer),
+            _ => {
+                let s = self.as_flat_slice().unwrap();
+                let mut map = serializer.serialize_map(Some(s.len()))?;
+                for (k, v) in s {
+                    map.serialize_entry(k, v)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for ObjectMap {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        BTreeMap::deserialize(deserializer)
+            .map(IntoIterator::into_iter)
+            .map(Self::from_iter)
+    }
+}
 
 /// The main value type used in Vector events, and VRL.
 #[derive(Eq, PartialEq, Hash, Debug, Clone)]
@@ -99,7 +847,7 @@ impl Value {
     /// Return if the node is empty, that is, it is an array or map with no items.
     ///
     /// ```rust
-    /// use vrl::value::Value;
+    /// use vrl::value::{Value, ObjectMap};
     /// use std::collections::BTreeMap;
     /// use vrl::path;
     ///
@@ -113,7 +861,7 @@ impl Value {
     /// val.insert(path!(3), 1);
     /// assert_eq!(val.is_empty(), false);
     ///
-    /// let mut val = Value::from(BTreeMap::default());
+    /// let mut val = Value::from(ObjectMap::default());
     /// assert_eq!(val.is_empty(), true);
     /// val.insert(path!("foo"), 1);
     /// assert_eq!(val.is_empty(), false);
@@ -223,6 +971,7 @@ pub fn timestamp_to_string(timestamp: &DateTime<Utc>) -> String {
 #[cfg(test)]
 mod test {
     use quickcheck::{QuickCheck, TestResult};
+    use serde_json::json;
 
     use crate::path;
     use crate::path::BorrowedSegment;
@@ -234,7 +983,7 @@ mod test {
 
         #[test]
         fn remove_prune_map_with_map() {
-            let mut value = Value::from(BTreeMap::default());
+            let mut value = Value::from(ObjectMap::default());
             let key = "foo.bar";
             let marker = Value::from(true);
             assert_eq!(value.insert(key, marker.clone()), None);
@@ -245,7 +994,7 @@ mod test {
 
         #[test]
         fn remove_prune_map_with_array() {
-            let mut value = Value::from(BTreeMap::default());
+            let mut value = Value::from(ObjectMap::default());
             let key = "foo[0]";
             let marker = Value::from(true);
             assert_eq!(value.insert(key, marker.clone()), None);
@@ -280,7 +1029,7 @@ mod test {
     #[test]
     fn quickcheck_value() {
         fn inner(mut path: Vec<BorrowedSegment<'static>>) -> TestResult {
-            let mut value = Value::from(BTreeMap::default());
+            let mut value = Value::from(ObjectMap::default());
             let mut marker = Value::from(true);
 
             // Push a field at the start of the path so the top level is a map.
@@ -320,5 +1069,72 @@ mod test {
             Some(Ordering::Equal)
         );
         assert_eq!(Value::from(10.5).partial_cmp(&Value::from(10)), None);
+    }
+
+    #[test]
+    fn object_map_flat_variant_supports_crud() {
+        let mut value = Value::Object(ObjectMap::new());
+
+        assert_eq!(value.insert("foo.bar", 1), None);
+        assert_eq!(value.get("foo.bar"), Some(&Value::from(1)));
+        assert_eq!(value.remove("foo.bar", true), Some(Value::from(1)));
+        assert!(!value.contains("foo"));
+    }
+
+    #[test]
+    fn object_map_equality_ignores_variant() {
+        let flat = ObjectMap::from([
+            ("alpha".into(), Value::from(1)),
+            ("beta".into(), Value::from(2)),
+        ]);
+
+        let btree = ObjectMap::BTree(BTreeMap::from([
+            ("beta".into(), Value::from(2)),
+            ("alpha".into(), Value::from(1)),
+        ]));
+
+        assert_eq!(flat, btree);
+    }
+
+    #[test]
+    fn object_map_partial_ord_uses_sorted_contents() {
+        let left = ObjectMap::from([
+            ("beta".into(), Value::from(2)),
+            ("alpha".into(), Value::from(1)),
+        ]);
+        let right = ObjectMap::from([
+            ("alpha".into(), Value::from(1)),
+            ("beta".into(), Value::from(3)),
+        ]);
+
+        assert_eq!(left.partial_cmp(&right), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn object_map_flat_round_trips_through_serde() {
+        let map = ObjectMap::from([
+            ("beta".into(), Value::from(2)),
+            ("alpha".into(), Value::from(1)),
+        ]);
+
+        let serialized = serde_json::to_value(&map).unwrap();
+        let deserialized: ObjectMap = serde_json::from_value(json!({
+            "alpha": 1,
+            "beta": 2,
+        }))
+        .unwrap();
+
+        assert_eq!(serialized, json!({"beta": 2, "alpha": 1}));
+        assert_eq!(map, deserialized);
+    }
+
+    #[test]
+    fn object_map_new_returns_flat() {
+        assert!(matches!(ObjectMap::new(), ObjectMap::Flat(_)));
+    }
+
+    #[test]
+    fn object_map_new_btree_returns_btree() {
+        assert!(matches!(ObjectMap::new_btree(), ObjectMap::BTree(_)));
     }
 }

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -64,7 +64,9 @@ impl fmt::Debug for ObjectMap {
             Self::BTree(map) => f.debug_map().entries(map.iter()).finish(),
             _ => {
                 let s = self.as_flat_slice().unwrap();
-                f.debug_map().entries(s.iter().map(|(k, v)| (k, v))).finish()
+                f.debug_map()
+                    .entries(s.iter().map(|(k, v)| (k, v)))
+                    .finish()
             }
         }
     }
@@ -252,10 +254,18 @@ pub struct VecFlatOccupiedEntry<'a> {
 }
 
 impl<'a> VecFlatOccupiedEntry<'a> {
-    pub fn get(&self) -> &Value { &self.vec[self.index].1 }
-    pub fn get_mut(&mut self) -> &mut Value { &mut self.vec[self.index].1 }
-    pub fn insert(&mut self, value: Value) -> Value { std::mem::replace(&mut self.vec[self.index].1, value) }
-    pub fn into_mut(self) -> &'a mut Value { &mut self.vec[self.index].1 }
+    pub fn get(&self) -> &Value {
+        &self.vec[self.index].1
+    }
+    pub fn get_mut(&mut self) -> &mut Value {
+        &mut self.vec[self.index].1
+    }
+    pub fn insert(&mut self, value: Value) -> Value {
+        std::mem::replace(&mut self.vec[self.index].1, value)
+    }
+    pub fn into_mut(self) -> &'a mut Value {
+        &mut self.vec[self.index].1
+    }
 }
 
 pub struct VecFlatVacantEntry<'a> {
@@ -369,12 +379,12 @@ enum SelectedBackend {
 fn selected_backend() -> SelectedBackend {
     use std::sync::OnceLock;
     static SELECTED: OnceLock<SelectedBackend> = OnceLock::new();
-    *SELECTED.get_or_init(|| {
-        match std::env::var("VRL_OBJECT_MAP").ok().as_deref() {
-            Some(s) if s.eq_ignore_ascii_case("btree") => SelectedBackend::BTree,
-            Some(s) if s.eq_ignore_ascii_case("vec") || s.eq_ignore_ascii_case("vecflat") => SelectedBackend::VecFlat,
-            _ => SelectedBackend::Flat,
+    *SELECTED.get_or_init(|| match std::env::var("VRL_OBJECT_MAP").ok().as_deref() {
+        Some(s) if s.eq_ignore_ascii_case("btree") => SelectedBackend::BTree,
+        Some(s) if s.eq_ignore_ascii_case("vec") || s.eq_ignore_ascii_case("vecflat") => {
+            SelectedBackend::VecFlat
         }
+        _ => SelectedBackend::Flat,
     })
 }
 
@@ -426,7 +436,9 @@ impl ObjectMap {
     pub fn get(&self, key: &str) -> Option<&Value> {
         match self {
             Self::BTree(map) => map.get(key),
-            _ => self.as_flat_slice().unwrap()
+            _ => self
+                .as_flat_slice()
+                .unwrap()
                 .iter()
                 .find(|(k, _)| k.as_str() == key)
                 .map(|(_, v)| v),
@@ -464,7 +476,11 @@ impl ObjectMap {
     pub fn contains_key(&self, key: &str) -> bool {
         match self {
             Self::BTree(map) => map.contains_key(key),
-            _ => self.as_flat_slice().unwrap().iter().any(|(k, _)| k.as_str() == key),
+            _ => self
+                .as_flat_slice()
+                .unwrap()
+                .iter()
+                .any(|(k, _)| k.as_str() == key),
         }
     }
 
@@ -530,7 +546,9 @@ impl ObjectMap {
     pub fn into_keys(self) -> ObjectMapIntoKeys {
         match self {
             Self::BTree(map) => ObjectMapIntoKeys::BTree(map.into_keys()),
-            Self::Flat(vec) => ObjectMapIntoKeys::Flat(vec.into_iter().collect::<Vec<_>>().into_iter()),
+            Self::Flat(vec) => {
+                ObjectMapIntoKeys::Flat(vec.into_iter().collect::<Vec<_>>().into_iter())
+            }
             Self::VecFlat(vec) => ObjectMapIntoKeys::Flat(vec.into_iter()),
         }
     }
@@ -538,7 +556,9 @@ impl ObjectMap {
     pub fn into_values(self) -> ObjectMapIntoValues {
         match self {
             Self::BTree(map) => ObjectMapIntoValues::BTree(map.into_values()),
-            Self::Flat(vec) => ObjectMapIntoValues::Flat(vec.into_iter().collect::<Vec<_>>().into_iter()),
+            Self::Flat(vec) => {
+                ObjectMapIntoValues::Flat(vec.into_iter().collect::<Vec<_>>().into_iter())
+            }
             Self::VecFlat(vec) => ObjectMapIntoValues::Flat(vec.into_iter()),
         }
     }
@@ -554,20 +574,24 @@ impl ObjectMap {
                 }
             },
             Self::Flat(vec) => match vec.iter().position(|(k, _)| *k == key) {
-                Some(index) => ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::Flat(
-                    FlatOccupiedEntry { vec, index },
-                )),
-                None => ObjectMapEntry::Vacant(ObjectMapVacantEntry::Flat(
-                    FlatVacantEntry { vec, key },
-                )),
+                Some(index) => {
+                    ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::Flat(FlatOccupiedEntry {
+                        vec,
+                        index,
+                    }))
+                }
+                None => {
+                    ObjectMapEntry::Vacant(ObjectMapVacantEntry::Flat(FlatVacantEntry { vec, key }))
+                }
             },
             Self::VecFlat(vec) => match vec.iter().position(|(k, _)| *k == key) {
                 Some(index) => ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::VecFlat(
                     VecFlatOccupiedEntry { vec, index },
                 )),
-                None => ObjectMapEntry::Vacant(ObjectMapVacantEntry::VecFlat(
-                    VecFlatVacantEntry { vec, key },
-                )),
+                None => ObjectMapEntry::Vacant(ObjectMapVacantEntry::VecFlat(VecFlatVacantEntry {
+                    vec,
+                    key,
+                })),
             },
         }
     }

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -62,12 +62,14 @@ impl fmt::Debug for ObjectMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::BTree(map) => f.debug_map().entries(map.iter()).finish(),
-            _ => {
-                let s = self.as_flat_slice().unwrap();
-                f.debug_map()
-                    .entries(s.iter().map(|(k, v)| (k, v)))
-                    .finish()
-            }
+            Self::Flat(vec) => f
+                .debug_map()
+                .entries(vec.iter().map(|(k, v)| (k, v)))
+                .finish(),
+            Self::VecFlat(vec) => f
+                .debug_map()
+                .entries(vec.iter().map(|(k, v)| (k, v)))
+                .finish(),
         }
     }
 }
@@ -218,6 +220,7 @@ pub struct FlatOccupiedEntry<'a> {
 }
 
 impl<'a> FlatOccupiedEntry<'a> {
+    #[must_use]
     pub fn get(&self) -> &Value {
         &self.vec[self.index].1
     }
@@ -230,6 +233,7 @@ impl<'a> FlatOccupiedEntry<'a> {
         std::mem::replace(&mut self.vec.make_mut()[self.index].1, value)
     }
 
+    #[must_use]
     pub fn into_mut(self) -> &'a mut Value {
         &mut self.vec.make_mut()[self.index].1
     }
@@ -257,15 +261,20 @@ pub struct VecFlatOccupiedEntry<'a> {
 }
 
 impl<'a> VecFlatOccupiedEntry<'a> {
+    #[must_use]
     pub fn get(&self) -> &Value {
         &self.vec[self.index].1
     }
+
     pub fn get_mut(&mut self) -> &mut Value {
         &mut self.vec[self.index].1
     }
+
     pub fn insert(&mut self, value: Value) -> Value {
         std::mem::replace(&mut self.vec[self.index].1, value)
     }
+
+    #[must_use]
     pub fn into_mut(self) -> &'a mut Value {
         &mut self.vec[self.index].1
     }
@@ -294,6 +303,7 @@ pub enum ObjectMapOccupiedEntry<'a> {
 }
 
 impl ObjectMapOccupiedEntry<'_> {
+    #[must_use]
     pub fn get(&self) -> &Value {
         match self {
             Self::BTree(entry) => entry.get(),
@@ -336,6 +346,7 @@ impl<'a> ObjectMapVacantEntry<'a> {
 }
 
 impl<'a> ObjectMapEntry<'a> {
+    #[must_use]
     pub fn and_modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut Value),
@@ -395,14 +406,6 @@ fn selected_backend() -> SelectedBackend {
 }
 
 impl ObjectMap {
-    fn as_flat_slice(&self) -> Option<&[(KeyString, Value)]> {
-        match self {
-            Self::Flat(vec) => Some(vec),
-            Self::VecFlat(vec) => Some(vec),
-            Self::BTree(_) => None,
-        }
-    }
-
     #[must_use]
     pub fn new() -> Self {
         match selected_backend() {
@@ -437,15 +440,12 @@ impl ObjectMap {
         }
     }
 
+    #[must_use]
     pub fn get(&self, key: &str) -> Option<&Value> {
         match self {
             Self::BTree(map) => map.get(key),
-            _ => self
-                .as_flat_slice()
-                .unwrap()
-                .iter()
-                .find(|(k, _)| k.as_str() == key)
-                .map(|(_, v)| v),
+            Self::Flat(vec) => vec.iter().find(|(k, _)| k.as_str() == key).map(|(_, v)| v),
+            Self::VecFlat(vec) => vec.iter().find(|(k, _)| k.as_str() == key).map(|(_, v)| v),
         }
     }
 
@@ -477,28 +477,30 @@ impl ObjectMap {
         }
     }
 
+    #[must_use]
     pub fn contains_key(&self, key: &str) -> bool {
         match self {
             Self::BTree(map) => map.contains_key(key),
-            _ => self
-                .as_flat_slice()
-                .unwrap()
-                .iter()
-                .any(|(k, _)| k.as_str() == key),
+            Self::Flat(vec) => vec.iter().any(|(k, _)| k.as_str() == key),
+            Self::VecFlat(vec) => vec.iter().any(|(k, _)| k.as_str() == key),
         }
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         match self {
             Self::BTree(map) => map.len(),
-            _ => self.as_flat_slice().unwrap().len(),
+            Self::Flat(vec) => vec.len(),
+            Self::VecFlat(vec) => vec.len(),
         }
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         match self {
             Self::BTree(map) => map.is_empty(),
-            _ => self.as_flat_slice().unwrap().is_empty(),
+            Self::Flat(vec) => vec.is_empty(),
+            Self::VecFlat(vec) => vec.is_empty(),
         }
     }
 
@@ -510,17 +512,21 @@ impl ObjectMap {
         }
     }
 
+    #[must_use]
     pub fn keys(&self) -> ObjectMapKeys<'_> {
         match self {
             Self::BTree(map) => ObjectMapKeys::BTree(map.keys()),
-            _ => ObjectMapKeys::Flat(self.as_flat_slice().unwrap().iter()),
+            Self::Flat(vec) => ObjectMapKeys::Flat(vec.iter()),
+            Self::VecFlat(vec) => ObjectMapKeys::Flat(vec.iter()),
         }
     }
 
+    #[must_use]
     pub fn values(&self) -> ObjectMapValues<'_> {
         match self {
             Self::BTree(map) => ObjectMapValues::BTree(map.values()),
-            _ => ObjectMapValues::Flat(self.as_flat_slice().unwrap().iter()),
+            Self::Flat(vec) => ObjectMapValues::Flat(vec.iter()),
+            Self::VecFlat(vec) => ObjectMapValues::Flat(vec.iter()),
         }
     }
 
@@ -532,10 +538,12 @@ impl ObjectMap {
         }
     }
 
+    #[must_use]
     pub fn iter(&self) -> ObjectMapIter<'_> {
         match self {
             Self::BTree(map) => ObjectMapIter::BTree(map.iter()),
-            _ => ObjectMapIter::Flat(self.as_flat_slice().unwrap().iter()),
+            Self::Flat(vec) => ObjectMapIter::Flat(vec.iter()),
+            Self::VecFlat(vec) => ObjectMapIter::Flat(vec.iter()),
         }
     }
 
@@ -547,6 +555,7 @@ impl ObjectMap {
         }
     }
 
+    #[must_use]
     pub fn into_keys(self) -> ObjectMapIntoKeys {
         match self {
             Self::BTree(map) => ObjectMapIntoKeys::BTree(map.into_keys()),
@@ -557,6 +566,7 @@ impl ObjectMap {
         }
     }
 
+    #[must_use]
     pub fn into_values(self) -> ObjectMapIntoValues {
         match self {
             Self::BTree(map) => ObjectMapIntoValues::BTree(map.into_values()),
@@ -625,16 +635,57 @@ impl ObjectMap {
 
     /// Insert a new empty child `ObjectMap` at the given key and return a
     /// mutable reference to it.  The child uses the same variant as the parent.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inserted child value is unexpectedly not an object. This
+    /// should be unreachable because the value is constructed immediately before
+    /// insertion.
     pub fn insert_child(&mut self, key: KeyString) -> &mut ObjectMap {
-        let child = match self {
-            Self::BTree(_) => ObjectMap::new_btree(),
-            Self::Flat(_) => ObjectMap::Flat(EcoVec::new()),
-            Self::VecFlat(_) => ObjectMap::VecFlat(Vec::new()),
+        let value = match self {
+            Self::BTree(map) => {
+                let child = Value::Object(ObjectMap::new_btree());
+                match map.entry(key) {
+                    btree_map::Entry::Occupied(mut entry) => {
+                        entry.insert(child);
+                        entry.into_mut()
+                    }
+                    btree_map::Entry::Vacant(entry) => entry.insert(child),
+                }
+            }
+            Self::Flat(vec) => {
+                let child = Value::Object(ObjectMap::Flat(EcoVec::new()));
+                let index = match vec.binary_search_by(|(k, _)| k.cmp(&key)) {
+                    Ok(index) => {
+                        vec.make_mut()[index].1 = child;
+                        index
+                    }
+                    Err(index) => {
+                        vec.insert(index, (key, child));
+                        index
+                    }
+                };
+                &mut vec.make_mut()[index].1
+            }
+            Self::VecFlat(vec) => {
+                let child = Value::Object(ObjectMap::VecFlat(Vec::new()));
+                let index = match vec.binary_search_by(|(k, _)| k.cmp(&key)) {
+                    Ok(index) => {
+                        vec[index].1 = child;
+                        index
+                    }
+                    Err(index) => {
+                        vec.insert(index, (key, child));
+                        index
+                    }
+                };
+                &mut vec[index].1
+            }
         };
-        self.insert(key.clone(), Value::Object(child));
-        match self.get_mut(key.as_ref()).unwrap() {
+
+        match value {
             Value::Object(map) => map,
-            _ => unreachable!(),
+            _ => unreachable!("inserted child value must be an object"),
         }
     }
 }
@@ -655,7 +706,7 @@ impl Eq for ObjectMap {}
 impl Hash for ObjectMap {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let mut entries = self.iter().collect::<Vec<_>>();
-        entries.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        entries.sort_unstable_by_key(|(key, _)| *key);
         for (key, value) in entries {
             key.hash(state);
             value.hash(state);
@@ -667,8 +718,8 @@ impl PartialOrd for ObjectMap {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let mut left = self.iter().collect::<Vec<_>>();
         let mut right = other.iter().collect::<Vec<_>>();
-        left.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
-        right.sort_unstable_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        left.sort_unstable_by_key(|(key, _)| *key);
+        right.sort_unstable_by_key(|(key, _)| *key);
 
         left.partial_cmp(&right)
     }
@@ -786,10 +837,16 @@ impl ::serde::Serialize for ObjectMap {
         use ::serde::ser::SerializeMap;
         match self {
             Self::BTree(map) => map.serialize(serializer),
-            _ => {
-                let s = self.as_flat_slice().unwrap();
-                let mut map = serializer.serialize_map(Some(s.len()))?;
-                for (k, v) in s {
+            Self::Flat(vec) => {
+                let mut map = serializer.serialize_map(Some(vec.len()))?;
+                for (k, v) in vec {
+                    map.serialize_entry(k, v)?;
+                }
+                map.end()
+            }
+            Self::VecFlat(vec) => {
+                let mut map = serializer.serialize_map(Some(vec.len()))?;
+                for (k, v) in vec {
                     map.serialize_entry(k, v)?;
                 }
                 map.end()

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -242,8 +242,11 @@ pub struct FlatVacantEntry<'a> {
 
 impl<'a> FlatVacantEntry<'a> {
     pub fn insert(self, value: Value) -> &'a mut Value {
-        self.vec.push((self.key, value));
-        let idx = self.vec.len() - 1;
+        let idx = self
+            .vec
+            .binary_search_by(|(k, _)| k.cmp(&self.key))
+            .unwrap_or_else(|idx| idx);
+        self.vec.insert(idx, (self.key, value));
         &mut self.vec.make_mut()[idx].1
     }
 }
@@ -275,8 +278,11 @@ pub struct VecFlatVacantEntry<'a> {
 
 impl<'a> VecFlatVacantEntry<'a> {
     pub fn insert(self, value: Value) -> &'a mut Value {
-        self.vec.push((self.key, value));
-        let idx = self.vec.len() - 1;
+        let idx = self
+            .vec
+            .binary_search_by(|(k, _)| k.cmp(&self.key))
+            .unwrap_or_else(|idx| idx);
+        self.vec.insert(idx, (self.key, value));
         &mut self.vec[idx].1
     }
 }
@@ -414,22 +420,20 @@ impl ObjectMap {
     pub fn insert(&mut self, key: KeyString, value: Value) -> Option<Value> {
         match self {
             Self::BTree(map) => map.insert(key, value),
-            Self::Flat(vec) => {
-                if let Some(pos) = vec.iter().position(|(k, _)| *k == key) {
-                    Some(std::mem::replace(&mut vec.make_mut()[pos].1, value))
-                } else {
-                    vec.push((key, value));
+            Self::Flat(vec) => match vec.binary_search_by(|(k, _)| k.cmp(&key)) {
+                Ok(pos) => Some(std::mem::replace(&mut vec.make_mut()[pos].1, value)),
+                Err(pos) => {
+                    vec.insert(pos, (key, value));
                     None
                 }
-            }
-            Self::VecFlat(vec) => {
-                if let Some(pos) = vec.iter().position(|(k, _)| *k == key) {
-                    Some(std::mem::replace(&mut vec[pos].1, value))
-                } else {
-                    vec.push((key, value));
+            },
+            Self::VecFlat(vec) => match vec.binary_search_by(|(k, _)| k.cmp(&key)) {
+                Ok(pos) => Some(std::mem::replace(&mut vec[pos].1, value)),
+                Err(pos) => {
+                    vec.insert(pos, (key, value));
                     None
                 }
-            }
+            },
         }
     }
 
@@ -468,7 +472,7 @@ impl ObjectMap {
             }
             Self::VecFlat(vec) => {
                 let pos = vec.iter().position(|(k, _)| k.as_str() == key)?;
-                Some(vec.swap_remove(pos).1)
+                Some(vec.remove(pos).1)
             }
         }
     }
@@ -573,25 +577,27 @@ impl ObjectMap {
                     ObjectMapEntry::Vacant(ObjectMapVacantEntry::BTree(entry))
                 }
             },
-            Self::Flat(vec) => match vec.iter().position(|(k, _)| *k == key) {
-                Some(index) => {
+            Self::Flat(vec) => match vec.binary_search_by(|(k, _)| k.cmp(&key)) {
+                Ok(index) => {
                     ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::Flat(FlatOccupiedEntry {
                         vec,
                         index,
                     }))
                 }
-                None => {
+                Err(_) => {
                     ObjectMapEntry::Vacant(ObjectMapVacantEntry::Flat(FlatVacantEntry { vec, key }))
                 }
             },
-            Self::VecFlat(vec) => match vec.iter().position(|(k, _)| *k == key) {
-                Some(index) => ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::VecFlat(
+            Self::VecFlat(vec) => match vec.binary_search_by(|(k, _)| k.cmp(&key)) {
+                Ok(index) => ObjectMapEntry::Occupied(ObjectMapOccupiedEntry::VecFlat(
                     VecFlatOccupiedEntry { vec, index },
                 )),
-                None => ObjectMapEntry::Vacant(ObjectMapVacantEntry::VecFlat(VecFlatVacantEntry {
-                    vec,
-                    key,
-                })),
+                Err(_) => {
+                    ObjectMapEntry::Vacant(ObjectMapVacantEntry::VecFlat(VecFlatVacantEntry {
+                        vec,
+                        key,
+                    }))
+                }
             },
         }
     }
@@ -704,11 +710,9 @@ impl<'a> IntoIterator for &'a mut ObjectMap {
 
 impl FromIterator<(KeyString, Value)> for ObjectMap {
     fn from_iter<I: IntoIterator<Item = (KeyString, Value)>>(iter: I) -> Self {
-        let vec: Vec<_> = iter.into_iter().collect();
-        match selected_backend() {
-            SelectedBackend::VecFlat => Self::VecFlat(vec),
-            _ => Self::Flat(EcoVec::from(vec)),
-        }
+        let mut map = Self::new();
+        map.extend(iter);
+        map
     }
 }
 
@@ -727,19 +731,16 @@ impl Extend<(KeyString, Value)> for ObjectMap {
 
 impl<const N: usize> From<[(KeyString, Value); N]> for ObjectMap {
     fn from(arr: [(KeyString, Value); N]) -> Self {
-        match selected_backend() {
-            SelectedBackend::VecFlat => Self::VecFlat(Vec::from(arr)),
-            _ => Self::Flat(EcoVec::from(Vec::from(arr))),
-        }
+        arr.into_iter().collect()
     }
 }
 
 impl From<BTreeMap<KeyString, Value>> for ObjectMap {
     fn from(map: BTreeMap<KeyString, Value>) -> Self {
-        let vec: Vec<_> = map.into_iter().collect();
         match selected_backend() {
-            SelectedBackend::VecFlat => Self::VecFlat(vec),
-            _ => Self::Flat(EcoVec::from(vec)),
+            SelectedBackend::BTree => Self::BTree(map),
+            SelectedBackend::Flat => Self::Flat(EcoVec::from(map.into_iter().collect::<Vec<_>>())),
+            SelectedBackend::VecFlat => Self::VecFlat(map.into_iter().collect()),
         }
     }
 }

--- a/src/value/value/convert.rs
+++ b/src/value/value/convert.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::{borrow::Cow, num::NonZero};
 
@@ -347,6 +348,12 @@ impl From<f64> for Value {
 impl From<ObjectMap> for Value {
     fn from(value: ObjectMap) -> Self {
         Self::Object(value)
+    }
+}
+
+impl From<BTreeMap<KeyString, Value>> for Value {
+    fn from(value: BTreeMap<KeyString, Value>) -> Self {
+        Self::Object(ObjectMap::from(value))
     }
 }
 

--- a/src/value/value/crud/insert.rs
+++ b/src/value/value/crud/insert.rs
@@ -16,8 +16,7 @@ pub fn insert<'a, T: ValueCollection>(
                 insert(map, field.into(), path_iter, insert_value)
             } else {
                 let mut map = ObjectMap::new();
-                let prev_value =
-                    insert(&mut map, field.into(), path_iter, insert_value);
+                let prev_value = insert(&mut map, field.into(), path_iter, insert_value);
                 value.insert_value(key, Value::Object(map));
                 prev_value
             }

--- a/src/value/value/crud/insert.rs
+++ b/src/value/value/crud/insert.rs
@@ -1,8 +1,8 @@
 use super::ValueCollection;
 use crate::path::BorrowedSegment;
+use crate::value::ObjectMap;
 use crate::value::Value;
 use std::borrow::Borrow;
-use std::collections::BTreeMap;
 
 pub fn insert<'a, T: ValueCollection>(
     value: &mut T,
@@ -15,7 +15,7 @@ pub fn insert<'a, T: ValueCollection>(
             if let Some(Value::Object(map)) = value.get_mut_value(key.borrow()) {
                 insert(map, field.to_string().into(), path_iter, insert_value)
             } else {
-                let mut map = BTreeMap::new();
+                let mut map = ObjectMap::new();
                 let prev_value =
                     insert(&mut map, field.to_string().into(), path_iter, insert_value);
                 value.insert_value(key, Value::Object(map));

--- a/src/value/value/crud/insert.rs
+++ b/src/value/value/crud/insert.rs
@@ -13,11 +13,11 @@ pub fn insert<'a, T: ValueCollection>(
     match path_iter.next() {
         Some(BorrowedSegment::Field(field)) => {
             if let Some(Value::Object(map)) = value.get_mut_value(key.borrow()) {
-                insert(map, field.to_string().into(), path_iter, insert_value)
+                insert(map, field.into(), path_iter, insert_value)
             } else {
                 let mut map = ObjectMap::new();
                 let prev_value =
-                    insert(&mut map, field.to_string().into(), path_iter, insert_value);
+                    insert(&mut map, field.into(), path_iter, insert_value);
                 value.insert_value(key, Value::Object(map));
                 prev_value
             }

--- a/src/value/value/iter.rs
+++ b/src/value/value/iter.rs
@@ -266,7 +266,8 @@ impl From<IterData> for Value {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use crate::value::value::ObjectMap;
+    use std::collections::HashMap;
 
     use super::*;
 
@@ -314,7 +315,7 @@ mod tests {
             (
                 "object non-recursive",
                 TestCase {
-                    value: Value::Object(BTreeMap::from([("foo".into(), true.into())])),
+                    value: Value::Object(ObjectMap::from([("foo".into(), true.into())])),
                     recursive: false,
                     items: vec![true.into()],
                 },
@@ -322,37 +323,43 @@ mod tests {
             (
                 "object recursive",
                 TestCase {
-                    value: BTreeMap::from([(
+                    value: ObjectMap::from([(
                         "foo".into(),
-                        BTreeMap::from([("foo".into(), true.into()), ("bar".into(), "baz".into())])
-                            .into(),
+                        ObjectMap::from([
+                            ("foo".into(), true.into()),
+                            ("bar".into(), "baz".into()),
+                        ])
+                        .into(),
                     )])
                     .into(),
                     recursive: true,
                     items: vec![
-                        BTreeMap::from([("foo".into(), true.into()), ("bar".into(), "baz".into())])
-                            .into(),
-                        "baz".into(),
+                        ObjectMap::from([
+                            ("foo".into(), true.into()),
+                            ("bar".into(), "baz".into()),
+                        ])
+                        .into(),
                         true.into(),
+                        "baz".into(),
                     ],
                 },
             ),
             (
                 "object multi-recursive",
                 TestCase {
-                    value: BTreeMap::from([
+                    value: ObjectMap::from([
                         (
                             "foo".into(),
-                            BTreeMap::from([("bar".into(), Value::Null)]).into(),
+                            ObjectMap::from([("bar".into(), Value::Null)]).into(),
                         ),
                         ("baz".into(), true.into()),
                     ])
                     .into(),
                     recursive: true,
                     items: vec![
-                        true.into(),
-                        BTreeMap::from([("bar".into(), Value::Null)]).into(),
+                        ObjectMap::from([("bar".into(), Value::Null)]).into(),
                         Value::Null,
+                        true.into(),
                     ],
                 },
             ),
@@ -372,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_mutations() {
-        let data: Value = BTreeMap::from([("foo".into(), vec![true].into())]).into();
+        let data: Value = ObjectMap::from([("foo".into(), vec![true].into())]).into();
 
         // Empty vec before recursing means recursion doesn't find any elements.
         let mut iter = data.clone().into_iter(true);
@@ -439,7 +446,7 @@ mod tests {
                 IterItem::Value(value) => values.push(value.clone()),
                 IterItem::KeyValue(_key, value) => match value {
                     value @ Value::Array(..) => {
-                        *value = BTreeMap::from([("bar".into(), true.into())]).into();
+                        *value = ObjectMap::from([("bar".into(), true.into())]).into();
                         changed = true;
                     }
                     value => values.push(value.clone()),

--- a/src/value/value/iter.rs
+++ b/src/value/value/iter.rs
@@ -339,8 +339,8 @@ mod tests {
                             ("bar".into(), "baz".into()),
                         ])
                         .into(),
-                        true.into(),
                         "baz".into(),
+                        true.into(),
                     ],
                 },
             ),
@@ -357,9 +357,9 @@ mod tests {
                     .into(),
                     recursive: true,
                     items: vec![
+                        true.into(),
                         ObjectMap::from([("bar".into(), Value::Null)]).into(),
                         Value::Null,
-                        true.into(),
                     ],
                 },
             ),

--- a/src/value/value/lua.rs
+++ b/src/value/value/lua.rs
@@ -2,7 +2,15 @@ use mlua::prelude::LuaResult;
 use mlua::{FromLua, IntoLua, Lua, Value as LuaValue};
 use ordered_float::NotNan;
 
-use crate::value::Value;
+use std::collections::BTreeMap;
+
+use crate::value::{KeyString, ObjectMap, Value};
+
+impl FromLua for ObjectMap {
+    fn from_lua(value: LuaValue, lua: &Lua) -> LuaResult<Self> {
+        <BTreeMap<KeyString, Value>>::from_lua(value, lua).map(Self::from)
+    }
+}
 
 impl IntoLua for Value {
     #![allow(clippy::wrong_self_convention)] // this trait is defined by mlua
@@ -43,7 +51,7 @@ impl FromLua for Value {
                 } else if table_is_timestamp(&t)? {
                     table_to_timestamp(t).map(Self::Timestamp)
                 } else {
-                    <_>::from_lua(LuaValue::Table(t), lua).map(Self::Object)
+                    ObjectMap::from_lua(LuaValue::Table(t), lua).map(Self::Object)
                 }
             }
             other => Err(mlua::Error::FromLuaConversionError {

--- a/src/value/value/path.rs
+++ b/src/value/value/path.rs
@@ -17,7 +17,7 @@ impl Value {
 
 #[cfg(test)]
 mod at_path_tests {
-    use std::collections::BTreeMap;
+    use crate::value::value::ObjectMap;
 
     use crate::path;
     use crate::path::parse_value_path;
@@ -29,10 +29,10 @@ mod at_path_tests {
         let path = parse_value_path(".foo.bar.baz").unwrap();
         let value = Value::Integer(12);
 
-        let bar_value = Value::Object(BTreeMap::from([("baz".into(), value.clone())]));
-        let foo_value = Value::Object(BTreeMap::from([("bar".into(), bar_value)]));
+        let bar_value = Value::Object(ObjectMap::from([("baz".into(), value.clone())]));
+        let foo_value = Value::Object(ObjectMap::from([("bar".into(), bar_value)]));
 
-        let object = Value::Object(BTreeMap::from([("foo".into(), foo_value)]));
+        let object = Value::Object(ObjectMap::from([("foo".into(), foo_value)]));
 
         assert_eq!(value.at_path(&path), object);
     }
@@ -62,12 +62,12 @@ mod at_path_tests {
         let value = Value::Object([("bar".into(), vec![12].into())].into()); //value!({ "bar": [12] });
 
         let baz_value = Value::Array(vec![Value::Null, value.clone()]);
-        let foo_value = Value::Object(BTreeMap::from([("baz".into(), baz_value)]));
+        let foo_value = Value::Object(ObjectMap::from([("baz".into(), baz_value)]));
 
         let object = Value::Array(vec![
             Value::Null,
             Value::Null,
-            Value::Object(BTreeMap::from([("foo".into(), foo_value)])),
+            Value::Object(ObjectMap::from([("foo".into(), foo_value)])),
         ]);
 
         assert_eq!(value.at_path(&path), object);

--- a/src/value/value/serde.rs
+++ b/src/value/value/serde.rs
@@ -1,4 +1,5 @@
-use std::{borrow::Cow, collections::BTreeMap, fmt};
+use super::ObjectMap;
+use std::{borrow::Cow, fmt};
 
 use crate::value::value::{StdError, Value, simdutf_bytes_utf8_lossy, timestamp_to_string};
 use bytes::Bytes;
@@ -177,7 +178,7 @@ impl<'de> Deserialize<'de> for Value {
             where
                 V: MapAccess<'de>,
             {
-                let mut map = BTreeMap::new();
+                let mut map = ObjectMap::new();
                 while let Some((key, value)) = visitor.next_entry()? {
                     map.insert(key, value);
                 }


### PR DESCRIPTION
## Summary

This is an experimental PR evaluating alternative `ObjectMap` storage layouts.

The goal is to improve memory locality and clone/allocation efficiency for VRL
object values. Today `ObjectMap` is effectively BTree-backed, which gives good
lookup behavior but poor locality and expensive structural clones. This branch
adds enum-backed `ObjectMap` variants so we can compare the current BTree layout
against flatter vector-backed layouts.

The enum is mostly experimental scaffolding. It lets us compare designs, but it
also adds cost through larger object size and extra branching. If we identify a
winning representation, implementing that representation directly should be
better than keeping enum dispatch in the hot path.

## What changed

- Added enum-backed `ObjectMap` storage variants.
- Added flat/vector-backed `ObjectMap` experiments.
- Moved many call sites away from assuming `ObjectMap` is a `BTreeMap`.
- Added targeted `ObjectMap` benchmarks:
  - `objectmap`
  - `objectmap_cliff`
  - `objectmap_hybrid`
- Added independent `KeyString` construction cleanup and benchmarks.

## Benchmark takeaways

The isolated benchmarks show the expected tradeoff:

- Flat maps have a clear width cliff for isolated lookup/update operations.
- Hit lookups are only competitive at very small widths.
- Miss lookups cross over around ~128 fields.
- Building wide flat maps from scratch is worse due to repeated linear scans.

However, the more realistic cloned-event benchmarks are much more promising:

- Flat storage benefits from cheaper clones and better memory locality.
- `objectmap_cliff/realistic_event` favors flat maps from roughly width 16 onward.
- `objectmap_cliff/realistic_event_readonly` strongly favors flat maps because
  clones remain cheap and no mutation forces extra work.

So the experiment suggests the core hypothesis is valid: improving memory
locality and clone efficiency can outweigh worse isolated lookup behavior in
realistic VRL/event workloads.

## KeyString changes

This branch also includes independent `KeyString` cleanup.

Several call sites were constructing temporary `String`s only to immediately
convert them into `KeyString`. With today’s `String`-backed `KeyString`, the
impact is small because LLVM can often optimize the extra work away. The cleanup
becomes more important if we later move `KeyString` to an SSO/refcounted backing
type, where direct construction from `&str`/`Cow<str>` can avoid heap allocation.

These changes are separable from the `ObjectMap` experiment, but came out of the
same performance investigation.

## API compatibility

This is technically a breaking change.

`ObjectMap` / `Value::Object` have exposed `BTreeMap`-specific behavior and
construction patterns publicly. External code that constructs, destructures, or
uses `Value::Object` as a `BTreeMap` will need to move to `ObjectMap` APIs
instead.

This is part of the experiment: hiding the backing map type is necessary if we
want freedom to change the representation.

## Validation

Local checks run:

```bash
cargo fmt --check
cargo test --features 'default test'
cargo bench --features 'default test' --bench objectmap_cliff --no-run
cargo bench --features 'default test' --bench objectmap_hybrid --no-run
cargo bench --features 'default test' --bench objectmap_cliff -- --noplot
```

## Open questions

- Have we sufficiently captured workloads that are adversarial to this design,
  such that we would have confidence turning it on by default?
- Do we need to maintain the enum-backed implementation for optionality / opt-in
  despite its cost, or should we switch to a single winning representation once
  the design is chosen?
