### PR TITLE
chore(deps): bump aes from 0.8 to 0.9 and update cipher mode crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -45,10 +56,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e08d0cdb774acd1e4dac11478b1a0c0d203134b2aab0ba25eb430de9b18f8b9"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "cmac",
- "ctr",
+ "ctr 0.9.2",
  "dbl",
  "digest 0.10.7",
  "zeroize",
@@ -312,11 +323,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -361,11 +372,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -388,11 +399,11 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfb-mode"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+checksum = "ac64b0984be8510caae81455ea2c8c23e5af6be61c36129df62f3380d5d64e1f"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -414,7 +425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -437,7 +448,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -516,8 +527,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -575,7 +597,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
  "digest 0.10.7",
 ]
@@ -689,6 +711,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -825,7 +853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
  "aead",
- "cipher",
+ "cipher 0.4.4",
  "generic-array",
  "poly1305",
  "salsa20",
@@ -860,7 +888,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1753,7 +1790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -1786,8 +1823,17 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1796,7 +1842,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e4f67dbfc0f75d7b65953ecf0be3fd84ee0cb1ae72a00a4aa9a2f5518a2c80"
 dependencies = [
- "aes",
+ "aes 0.8.4",
 ]
 
 [[package]]
@@ -2359,11 +2405,11 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc40678e045ff4eb1666ea6c0f994b133c31f673c09aed292261b6d5b6963a0"
+checksum = "5f9e502b30c14fb1fecc196f9543975522c4380e4b0e8dcf4bf42e1d76375173"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3388,7 +3434,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4396,7 +4442,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vrl"
 version = "0.33.1"
 dependencies = [
- "aes",
+ "aes 0.9.1",
  "aes-siv",
  "anyhow",
  "arbitrary",
@@ -4422,7 +4468,7 @@ dependencies = [
  "criterion",
  "crypto_secretbox",
  "csv",
- "ctr",
+ "ctr 0.10.1",
  "digest 0.11.3",
  "dns-lookup",
  "domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,17 +274,17 @@ community-id = { version = "0.2", optional = true }
 zstd = { version = "0.13", default-features = false, features = ["wasm"], optional = true }
 
 # Cryptography
-aes = { version = "0.8", optional = true }
+aes = { version = "0.9", optional = true }
 aes-siv = { version = "0.7.0", optional = true }
 chacha20poly1305 = { version = "0.10", optional = true }
 crypto_secretbox = { version = "0.1", features = ["salsa20"], optional = true }
 ipcrypt-rs = { version = "0.9.4", optional = true, default-features = false }
 
 # Cryptography - Block Modes
-ctr = { version = "0.9", optional = true }
-cbc = { version = "0.1", optional = true, features = ["alloc"] }
-cfb-mode = { version = "0.8", optional = true }
-ofb = { version = "0.6", optional = true }
+ctr = { version = "0.10", optional = true }
+cbc = { version = "0.2", optional = true, features = ["alloc", "block-padding"] }
+cfb-mode = { version = "0.9", optional = true }
+ofb = { version = "0.7", optional = true }
 
 # Protobuf support.
 prost = { version = "0.13", default-features = false, optional = true, features = ["std"] }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -63,6 +63,7 @@ const-oid,https://github.com/RustCrypto/formats,Apache-2.0 OR MIT,RustCrypto Dev
 convert_case,https://github.com/rutrum/convert-case,MIT,rutrum <dave@rutrum.net>
 core-foundation,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
 core-foundation-sys,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
+cpubits,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 crc,https://github.com/mrhooray/crc-rs,MIT OR Apache-2.0,"Rui Hu <code@mrhooray.com>, Akhil Velagapudi <4@4khil.com>"
 crc-catalog,https://github.com/akhilles/crc-catalog,MIT OR Apache-2.0,Akhil Velagapudi <akhilvelagapudi@gmail.com>

--- a/src/stdlib/decrypt.rs
+++ b/src/stdlib/decrypt.rs
@@ -1,10 +1,8 @@
 use crate::compiler::prelude::*;
 use crate::value::Value;
-use aes::cipher::{
-    AsyncStreamCipher, BlockDecryptMut, KeyIvInit, StreamCipher,
-    block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7},
-    generic_array::GenericArray,
-};
+use aes::cipher::{BlockModeDecrypt, Iv, Key, KeyIvInit, StreamCipher};
+use aes_siv::aead::generic_array::GenericArray as AeadArray;
+use cbc::cipher::block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7};
 use aes_siv::{Aes128SivAead, Aes256SivAead};
 use cfb_mode::Decryptor as Cfb;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, XChaCha20Poly1305, aead::Aead};
@@ -22,11 +20,11 @@ macro_rules! decrypt {
     ($algorithm:ty, $ciphertext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
         let mut buffer = vec![0; $ciphertext.len()];
         <$algorithm>::new(
-            &GenericArray::from(get_key_bytes($key)?),
-            &GenericArray::from(get_iv_bytes($iv)?),
+            &Key::<$algorithm>::from(get_key_bytes($key)?),
+            &Iv::<$algorithm>::from(get_iv_bytes($iv)?),
         )
         .decrypt_b2b($ciphertext.as_ref(), buffer.as_mut())
-        .unwrap();
+        .expect("buffer sizes match");
         buffer
     }};
 }
@@ -34,10 +32,10 @@ macro_rules! decrypt {
 macro_rules! decrypt_padded {
     ($algorithm:ty, $padding:ty, $ciphertext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
         <$algorithm>::new(
-            &GenericArray::from(get_key_bytes($key)?),
-            &GenericArray::from(get_iv_bytes($iv)?),
+            &Key::<$algorithm>::from(get_key_bytes($key)?),
+            &Iv::<$algorithm>::from(get_iv_bytes($iv)?),
         )
-        .decrypt_padded_vec_mut::<$padding>($ciphertext.as_ref())
+        .decrypt_padded_vec::<$padding>($ciphertext.as_ref())
         .map_err(|_| format!("Invalid input"))?
     }};
 }
@@ -46,19 +44,18 @@ macro_rules! decrypt_keystream {
     ($algorithm:ty, $ciphertext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
         let mut buffer = vec![0; $ciphertext.len()];
         <$algorithm>::new(
-            &GenericArray::from(get_key_bytes($key)?),
-            &GenericArray::from(get_iv_bytes($iv)?),
+            &Key::<$algorithm>::from(get_key_bytes($key)?),
+            &Iv::<$algorithm>::from(get_iv_bytes($iv)?),
         )
-        .apply_keystream_b2b($ciphertext.as_ref(), buffer.as_mut())
-        .unwrap();
+        .apply_keystream_b2b($ciphertext.as_ref(), buffer.as_mut());
         buffer
     }};
 }
 
 macro_rules! decrypt_stream {
     ($algorithm:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
-        <$algorithm>::new(&GenericArray::from(get_key_bytes($key)?))
-            .decrypt(&GenericArray::from(get_iv_bytes($iv)?), $plaintext.as_ref())
+        <$algorithm>::new(&AeadArray::from(get_key_bytes($key)?))
+            .decrypt(&AeadArray::from(get_iv_bytes($iv)?), $plaintext.as_ref())
             .expect("key/iv sizes were already checked")
     }};
 }

--- a/src/stdlib/encrypt.rs
+++ b/src/stdlib/encrypt.rs
@@ -1,9 +1,7 @@
 use crate::compiler::prelude::*;
-use aes::cipher::{
-    AsyncStreamCipher, BlockEncryptMut, KeyIvInit, StreamCipher,
-    block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7},
-    generic_array::GenericArray,
-};
+use aes::cipher::{BlockModeEncrypt, Iv, Key, KeyIvInit, StreamCipher};
+use aes_siv::aead::generic_array::GenericArray as AeadArray;
+use cbc::cipher::block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7};
 use aes_siv::{Aes128SivAead, Aes256SivAead};
 use cfb_mode::Encryptor as Cfb;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, XChaCha20Poly1305, aead::Aead};
@@ -49,11 +47,11 @@ macro_rules! encrypt {
     ($algorithm:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
         let mut buffer = vec![0; $plaintext.len()];
         <$algorithm>::new(
-            &GenericArray::from(get_key_bytes($key)?),
-            &GenericArray::from(get_iv_bytes($iv)?),
+            &Key::<$algorithm>::from(get_key_bytes($key)?),
+            &Iv::<$algorithm>::from(get_iv_bytes($iv)?),
         )
         .encrypt_b2b($plaintext.as_ref(), buffer.as_mut())
-        .expect("key/iv sizes were already checked");
+        .expect("buffer sizes match");
         buffer
     }};
 }
@@ -61,10 +59,10 @@ macro_rules! encrypt {
 macro_rules! encrypt_padded {
     ($algorithm:ty, $padding:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
         <$algorithm>::new(
-            &GenericArray::from(get_key_bytes($key)?),
-            &GenericArray::from(get_iv_bytes($iv)?),
+            &Key::<$algorithm>::from(get_key_bytes($key)?),
+            &Iv::<$algorithm>::from(get_iv_bytes($iv)?),
         )
-        .encrypt_padded_vec_mut::<$padding>($plaintext.as_ref())
+        .encrypt_padded_vec::<$padding>($plaintext.as_ref())
     }};
 }
 
@@ -72,19 +70,18 @@ macro_rules! encrypt_keystream {
     ($algorithm:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
         let mut buffer = vec![0; $plaintext.len()];
         <$algorithm>::new(
-            &GenericArray::from(get_key_bytes($key)?),
-            &GenericArray::from(get_iv_bytes($iv)?),
+            &Key::<$algorithm>::from(get_key_bytes($key)?),
+            &Iv::<$algorithm>::from(get_iv_bytes($iv)?),
         )
-        .apply_keystream_b2b($plaintext.as_ref(), buffer.as_mut())
-        .expect("key/iv sizes were already checked");
+        .apply_keystream_b2b($plaintext.as_ref(), buffer.as_mut());
         buffer
     }};
 }
 
 macro_rules! encrypt_stream {
     ($algorithm:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
-        <$algorithm>::new(&GenericArray::from(get_key_bytes($key)?))
-            .encrypt(&GenericArray::from(get_iv_bytes($iv)?), $plaintext.as_ref())
+        <$algorithm>::new(&AeadArray::from(get_key_bytes($key)?))
+            .encrypt(&AeadArray::from(get_iv_bytes($iv)?), $plaintext.as_ref())
             .expect("key/iv sizes were already checked")
     }};
 }


### PR DESCRIPTION
## Summary

Properly bumps `aes` from 0.8 to 0.9 by migrating the entire cipher mode ecosystem to versions that support the new `cipher 0.5` trait hierarchy.

**Cargo.toml changes:**
- `aes`: `0.8` → `0.9`
- `cbc`: `0.1` → `0.2`
- `ctr`: `0.9` → `0.10`
- `cfb-mode`: `0.8` → `0.9`
- `ofb`: `0.6` → `0.7`

`aes-siv` and `ipcrypt-rs` still require `aes ^0.8`, so Cargo resolves both `aes 0.8.4` and `aes 0.9.1` in the lock file.

**Code changes (`encrypt.rs` / `decrypt.rs`):**
- Replace `GenericArray` + `BlockEncryptMut`/`BlockDecryptMut` (removed in cipher 0.5) with `Key<C>`/`Iv<C>` from hybrid-array and `BlockModeEncrypt`/`BlockModeDecrypt`
- `encrypt_padded_vec_mut` / `decrypt_padded_vec_mut` → `encrypt_padded_vec` / `decrypt_padded_vec`
- `apply_keystream_b2b` now returns `()` — removed stale `.unwrap()` calls
- CFB `encrypt_b2b`/`decrypt_b2b` are now inherent methods on the encryptor/decryptor structs
- AEAD macros (aes-siv, chacha20poly1305, xchacha20, xsalsa20) retain `GenericArray` via the `aead` crate re-export since those crates still target `generic_array 0.14`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- `cargo check --features enable_crypto_functions` passes cleanly
- `cargo fmt` and `./scripts/clippy.sh` pass with no warnings

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run `dd-rust-license-tool write` and commit the changes. Added `cpubits` (new transitive dep of aes 0.9).

## References

Closes dependabot PR #1833 (already closed — this is the proper replacement).