### PR TITLE
chore(deps): bump chacha20poly1305 from 0.10 to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +65,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e08d0cdb774acd1e4dac11478b1a0c0d203134b2aab0ba25eb430de9b18f8b9"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes 0.8.4",
  "cipher 0.4.4",
  "cmac",
@@ -420,37 +430,26 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
- "aead",
- "chacha20 0.9.1",
- "cipher 0.4.4",
- "poly1305",
- "zeroize",
+ "aead 0.6.1",
+ "chacha20",
+ "cipher 0.5.2",
+ "poly1305 0.9.0",
 ]
 
 [[package]]
@@ -843,7 +842,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -852,10 +853,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "cipher 0.4.4",
  "generic-array",
- "poly1305",
+ "poly1305 0.8.0",
  "salsa20",
  "subtle",
  "zeroize",
@@ -1401,11 +1402,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2676,7 +2679,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -3000,7 +3013,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -3712,7 +3725,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3867,7 +3880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.1",
@@ -4327,6 +4340,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,6 +4501,7 @@ dependencies = [
  "fancy-regex",
  "flate2",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "grok",
  "hex",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ zstd = { version = "0.13", default-features = false, features = ["wasm"], option
 # Cryptography
 aes = { version = "0.9", optional = true }
 aes-siv = { version = "0.7.0", optional = true }
-chacha20poly1305 = { version = "0.10", optional = true }
+chacha20poly1305 = { version = "0.11", optional = true }
 crypto_secretbox = { version = "0.1", features = ["salsa20"], optional = true }
 ipcrypt-rs = { version = "0.9.4", optional = true, default-features = false }
 
@@ -311,6 +311,7 @@ jsonschema = { version = "0.38.1", default-features = false }
 # Dependencies used for WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 uuid = { version = "1", features = ["v4", "v7", "js"], optional = true }
 
 [dev-dependencies]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -37,9 +37,8 @@ cbc,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Devel
 cesu8,https://github.com/emk/cesu8-rs,Apache-2.0 OR MIT,Eric Kidd <git@randomhacks.net>
 cfb-mode,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Developers
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
-chacha20,https://github.com/RustCrypto/stream-ciphers,Apache-2.0 OR MIT,RustCrypto Developers
 chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
-chacha20poly1305,https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305,Apache-2.0 OR MIT,RustCrypto Developers
+chacha20poly1305,https://github.com/RustCrypto/AEADs,Apache-2.0 OR MIT,RustCrypto Developers
 charset,https://github.com/hsivonen/charset,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
 chrono-tz,https://github.com/chronotope/chrono-tz,MIT OR Apache-2.0,The chrono-tz Authors

--- a/src/stdlib/decrypt.rs
+++ b/src/stdlib/decrypt.rs
@@ -1,11 +1,12 @@
 use crate::compiler::prelude::*;
 use crate::value::Value;
 use aes::cipher::{BlockModeDecrypt, Iv, Key, KeyIvInit, StreamCipher};
-use aes_siv::aead::generic_array::GenericArray as AeadArray;
-use cbc::cipher::block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7};
+use aes_siv::aead::{Aead as Aead5, KeyInit as KeyInit5, generic_array::GenericArray as AeadArray};
 use aes_siv::{Aes128SivAead, Aes256SivAead};
+use cbc::cipher::block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7};
 use cfb_mode::Decryptor as Cfb;
-use chacha20poly1305::{ChaCha20Poly1305, KeyInit, XChaCha20Poly1305, aead::Aead};
+use chacha20poly1305::aead::{Aead as ChaChaAead, KeyInit as ChaChaKeyInit, Key as ChaChaKey, Nonce as ChaChaNonce};
+use chacha20poly1305::{ChaCha20Poly1305, XChaCha20Poly1305};
 use crypto_secretbox::XSalsa20Poly1305;
 use ctr::{Ctr64BE, Ctr64LE};
 use ofb::Ofb;
@@ -54,11 +55,12 @@ macro_rules! decrypt_keystream {
 
 macro_rules! decrypt_stream {
     ($algorithm:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
-        <$algorithm>::new(&AeadArray::from(get_key_bytes($key)?))
+        <$algorithm as KeyInit5>::new(&AeadArray::from(get_key_bytes($key)?))
             .decrypt(&AeadArray::from(get_iv_bytes($iv)?), $plaintext.as_ref())
             .expect("key/iv sizes were already checked")
     }};
 }
+
 
 fn decrypt(ciphertext: Value, algorithm: &str, key: Value, iv: Value) -> Resolved {
     let ciphertext = ciphertext.try_bytes()?;
@@ -96,8 +98,12 @@ fn decrypt(ciphertext: Value, algorithm: &str, key: Value, iv: Value) -> Resolve
         "AES-128-CBC-ISO10126" => decrypt_padded!(Aes128Cbc, Iso10126, ciphertext, key, iv),
         "AES-128-SIV" => decrypt_stream!(Aes128SivAead, ciphertext, key, iv),
         "AES-256-SIV" => decrypt_stream!(Aes256SivAead, ciphertext, key, iv),
-        "CHACHA20-POLY1305" => decrypt_stream!(ChaCha20Poly1305, ciphertext, key, iv),
-        "XCHACHA20-POLY1305" => decrypt_stream!(XChaCha20Poly1305, ciphertext, key, iv),
+        "CHACHA20-POLY1305" => ChaCha20Poly1305::new(&ChaChaKey::<ChaCha20Poly1305>::from(get_key_bytes(key)?))
+            .decrypt(&ChaChaNonce::<ChaCha20Poly1305>::from(get_iv_bytes(iv)?), ciphertext.as_ref())
+            .expect("key/iv sizes were already checked"),
+        "XCHACHA20-POLY1305" => XChaCha20Poly1305::new(&ChaChaKey::<XChaCha20Poly1305>::from(get_key_bytes(key)?))
+            .decrypt(&ChaChaNonce::<XChaCha20Poly1305>::from(get_iv_bytes(iv)?), ciphertext.as_ref())
+            .expect("key/iv sizes were already checked"),
         "XSALSA20-POLY1305" => decrypt_stream!(XSalsa20Poly1305, ciphertext, key, iv),
         other => return Err(format!("Invalid algorithm: {other}").into()),
     };

--- a/src/stdlib/encrypt.rs
+++ b/src/stdlib/encrypt.rs
@@ -1,10 +1,11 @@
 use crate::compiler::prelude::*;
 use aes::cipher::{BlockModeEncrypt, Iv, Key, KeyIvInit, StreamCipher};
-use aes_siv::aead::generic_array::GenericArray as AeadArray;
-use cbc::cipher::block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7};
+use aes_siv::aead::{Aead as Aead5, KeyInit as KeyInit5, generic_array::GenericArray as AeadArray};
 use aes_siv::{Aes128SivAead, Aes256SivAead};
+use cbc::cipher::block_padding::{AnsiX923, Iso7816, Iso10126, Pkcs7};
 use cfb_mode::Encryptor as Cfb;
-use chacha20poly1305::{ChaCha20Poly1305, KeyInit, XChaCha20Poly1305, aead::Aead};
+use chacha20poly1305::aead::{Aead as ChaChaAead, KeyInit as ChaChaKeyInit, Key as ChaChaKey, Nonce as ChaChaNonce};
+use chacha20poly1305::{ChaCha20Poly1305, XChaCha20Poly1305};
 use crypto_secretbox::XSalsa20Poly1305;
 use ctr::{Ctr64BE, Ctr64LE};
 use ofb::Ofb;
@@ -80,11 +81,12 @@ macro_rules! encrypt_keystream {
 
 macro_rules! encrypt_stream {
     ($algorithm:ty, $plaintext:expr_2021, $key:expr_2021, $iv:expr_2021) => {{
-        <$algorithm>::new(&AeadArray::from(get_key_bytes($key)?))
+        <$algorithm as KeyInit5>::new(&AeadArray::from(get_key_bytes($key)?))
             .encrypt(&AeadArray::from(get_iv_bytes($iv)?), $plaintext.as_ref())
             .expect("key/iv sizes were already checked")
     }};
 }
+
 
 pub(crate) fn is_valid_algorithm(algorithm: &str) -> bool {
     matches!(
@@ -159,8 +161,12 @@ fn encrypt(plaintext: Value, algorithm: &str, key: Value, iv: Value) -> Resolved
         "AES-128-CBC-ISO10126" => encrypt_padded!(Aes128Cbc, Iso10126, plaintext, key, iv),
         "AES-128-SIV" => encrypt_stream!(Aes128SivAead, plaintext, key, iv),
         "AES-256-SIV" => encrypt_stream!(Aes256SivAead, plaintext, key, iv),
-        "CHACHA20-POLY1305" => encrypt_stream!(ChaCha20Poly1305, plaintext, key, iv),
-        "XCHACHA20-POLY1305" => encrypt_stream!(XChaCha20Poly1305, plaintext, key, iv),
+        "CHACHA20-POLY1305" => ChaCha20Poly1305::new(&ChaChaKey::<ChaCha20Poly1305>::from(get_key_bytes(key)?))
+            .encrypt(&ChaChaNonce::<ChaCha20Poly1305>::from(get_iv_bytes(iv)?), plaintext.as_ref())
+            .expect("key/iv sizes were already checked"),
+        "XCHACHA20-POLY1305" => XChaCha20Poly1305::new(&ChaChaKey::<XChaCha20Poly1305>::from(get_key_bytes(key)?))
+            .encrypt(&ChaChaNonce::<XChaCha20Poly1305>::from(get_iv_bytes(iv)?), plaintext.as_ref())
+            .expect("key/iv sizes were already checked"),
         "XSALSA20-POLY1305" => encrypt_stream!(XSalsa20Poly1305, plaintext, key, iv),
         other => return Err(format!("Invalid algorithm: {other}").into()),
     };


### PR DESCRIPTION
## Summary

Bumps `chacha20poly1305` from 0.10 to 0.11. The new version uses `aead 0.6` instead of `aead 0.5`, which removes one of the paths pulling `getrandom 0.2` into the dependency tree (via `aead 0.5` → `crypto-common 0.1` → `rand_core 0.6` → `getrandom 0.2`).

The `encrypt_stream!`/`decrypt_stream!` macros are split into two: one for the remaining `aead 0.5` algorithms (AES-SIV, XSalsa20), one for the `aead 0.6` ChaCha variants.

Part of a broader effort to unblock version updates blocked by the WASM playground build.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

All 35 encrypt/decrypt unit tests pass.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run `dd-rust-license-tool write` and commit the changes.