### PR TITLE
chore(release): relax changelog fragment validation

### DIFF
--- a/release/src/changelog.rs
+++ b/release/src/changelog.rs
@@ -31,15 +31,23 @@ fn parse_authors(raw: &str) -> Result<(String, Vec<String>), String> {
         .ok_or("Fragment content is empty")?;
 
     let last = lines[last_idx].trim();
-    let authors_str = last.strip_prefix("authors:").ok_or_else(|| {
-        "Fragment is missing required 'authors:' field on the last line. \
-         Example: 'authors: github_username'"
-            .to_string()
-    })?;
+    let last_lower = last.to_ascii_lowercase();
+    let prefix_len = if last_lower.starts_with("authors:") {
+        "authors:".len()
+    } else if last_lower.starts_with("author:") {
+        "author:".len()
+    } else {
+        return Err(
+            "Fragment is missing required 'authors:' field on the last line. \
+                    Example: 'authors: github_username'"
+                .to_string(),
+        );
+    };
+    let authors_str = &last[prefix_len..];
 
     let authors: Vec<String> = authors_str
         .split(',')
-        .map(|s| s.trim().to_string())
+        .map(|s| s.trim().trim_start_matches('@').to_string())
         .filter(|s| !s.is_empty())
         .collect();
 
@@ -75,7 +83,8 @@ fn validate_fragment_filename(filename: &str) -> Result<(&str, &str), String> {
     }
 
     let valid_types: Vec<&str> = FRAGMENT_TYPES.iter().map(|(t, _)| *t).collect();
-    if !valid_types.contains(&parts[1]) {
+    let type_lower = parts[1].to_ascii_lowercase();
+    if !valid_types.contains(&type_lower.as_str()) {
         return Err(format!(
             "Invalid fragment type '{}' in '{filename}'. Valid types: {}",
             parts[1],
@@ -117,7 +126,7 @@ impl Changelog {
 
         Ok(Fragment {
             pr_number: pr_number.to_string(),
-            fragment_type: fragment_type.to_string(),
+            fragment_type: fragment_type.to_ascii_lowercase(),
             content,
             authors,
         })
@@ -361,6 +370,12 @@ mod tests {
     }
 
     #[test]
+    fn fragment_type_case_insensitive() {
+        let (_, ty) = validate_fragment_filename("1234.Fix.md").unwrap();
+        assert_eq!(ty, "Fix"); // raw value; normalized to lowercase in parse_fragment
+    }
+
+    #[test]
     fn non_numeric_pr() {
         let err = validate_fragment_filename("abc.feature.md").unwrap_err();
         assert!(err.contains("must be a PR number"), "{err}");
@@ -392,6 +407,26 @@ mod tests {
         let (desc, authors) = parse_authors("A feature.\n\nauthors: alice, bob").unwrap();
         assert_eq!(desc, "A feature.");
         assert_eq!(authors, vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn parse_authors_singular_accepted() {
+        let (desc, authors) = parse_authors("Fixed a bug.\n\nauthor: alice").unwrap();
+        assert_eq!(desc, "Fixed a bug.");
+        assert_eq!(authors, vec!["alice"]);
+    }
+
+    #[test]
+    fn parse_authors_at_prefix_stripped() {
+        let (_, authors) = parse_authors("Fixed a bug.\n\nauthors: @alice, @bob").unwrap();
+        assert_eq!(authors, vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn parse_authors_capital_key_accepted() {
+        let (desc, authors) = parse_authors("Fixed a bug.\n\nAuthors: alice").unwrap();
+        assert_eq!(desc, "Fixed a bug.");
+        assert_eq!(authors, vec!["alice"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reduces contributor friction in the `check-changelog` CI step by accepting common formatting variations that are unambiguous in intent but were previously hard errors.

Four relaxations:
- `author:` (singular) accepted alongside `authors:`
- Any casing on the key (`Authors:`, `AUTHOR:`, etc.)
- Leading `@` on GitHub usernames stripped automatically (e.g. `authors: @alice` → renders correctly instead of producing a broken link)
- Any casing on the fragment type in the filename (`1234.Fix.md` → normalized to `fix` internally)

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

43 unit tests, all passing (`cargo test -p release`).

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.