### PR TITLE
fix(stdlib): avoid panic in nom convert_error on lines >= 65535 bytes

### DIFF
--- a/changelog.d/1848.fix.md
+++ b/changelog.d/1848.fix.md
@@ -1,3 +1,3 @@
-Fixed a panic in `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines ≥ 65,535 bytes (tracked in [vectordotdev/vector#23606](https://github.com/vectordotdev/vector/issues/23606)). This is a workaround until [rust-bakery/nom#1867](https://github.com/rust-bakery/nom/issues/1867) is fixed.
+Fixed a panic in `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines ≥ 65,535 bytes. This is a workaround until [rust-bakery/nom#1867](https://github.com/rust-bakery/nom/issues/1867) is fixed.
 
 authors: pront

--- a/changelog.d/1848.fix.md
+++ b/changelog.d/1848.fix.md
@@ -1,0 +1,3 @@
+Fixed a panic in `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines ≥ 65,535 bytes (tracked in [vectordotdev/vector#23606](https://github.com/vectordotdev/vector/issues/23606)). This is a workaround until [rust-bakery/nom#1867](https://github.com/rust-bakery/nom/issues/1867) is fixed.
+
+authors: pront

--- a/clippy.toml
+++ b/clippy.toml
@@ -21,4 +21,5 @@ arithmetic-side-effects-allowed = [
 # https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_method
 disallowed-methods = [
   { path = "std::io::Write::write", reason = "This doesn't handle short writes, use `write_all` instead." },
+  { path = "nom_language::error::convert_error", reason = "Panics on Rust ≥ 1.87 when any input line is ≥ 65535 bytes (fmt width capped at 0xffff). Use crate::parsing::safe_convert_error instead. See rust-bakery/nom#1868." },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -21,5 +21,5 @@ arithmetic-side-effects-allowed = [
 # https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_method
 disallowed-methods = [
   { path = "std::io::Write::write", reason = "This doesn't handle short writes, use `write_all` instead." },
-  { path = "nom_language::error::convert_error", reason = "Panics on Rust ≥ 1.87 when any input line is ≥ 65535 bytes (fmt width capped at 0xffff). Use crate::parsing::safe_convert_error instead. See rust-bakery/nom#1868." },
+  { path = "nom_language::error::convert_error", reason = "Panics on Rust ≥ 1.87 (https://github.com/rust-bakery/nom/issues/1867). Use crate::parsing::safe_convert_error instead." },
 ]

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,3 +1,45 @@
 pub mod query_string;
 pub mod ruby_hash;
 pub mod xml;
+
+// nom's convert_error formats a caret at column `n` using `{caret:>n$}`, which
+// panics in Rust ≥ 1.87 when n ≥ 65536 (fmt width is capped at 0xffff).
+// Until nom#1868 lands, we guard against that here.
+pub(crate) fn safe_convert_error(
+    input: &str,
+    e: nom_language::error::VerboseError<&str>,
+) -> String {
+    use nom::Offset;
+
+    // For each error entry, check whether its column would overflow the limit.
+    let overflows = e.errors.iter().any(|(substring, _)| {
+        let offset = input.offset(substring);
+        let line_begin = input.as_bytes()[..offset]
+            .iter()
+            .rev()
+            .position(|&b| b == b'\n')
+            .map(|pos| offset - pos)
+            .unwrap_or(0);
+        let column = input[line_begin..].offset(substring) + 1;
+        column >= 65535
+    });
+
+    if overflows {
+        // Compute position of the first error for a useful message.
+        let (substring, _) = &e.errors[0];
+        let offset = input.offset(substring);
+        let prefix = &input.as_bytes()[..offset];
+        let line = prefix.iter().filter(|&&b| b == b'\n').count() + 1;
+        let line_begin = prefix
+            .iter()
+            .rev()
+            .position(|&b| b == b'\n')
+            .map(|pos| offset - pos)
+            .unwrap_or(0);
+        let column = input[line_begin..].offset(substring) + 1;
+        format!("parse error at line {line}, column {column} (line too long to display context)")
+    } else {
+        #[allow(clippy::disallowed_methods)]
+        nom_language::error::convert_error(input, e)
+    }
+}

--- a/src/parsing/ruby_hash.rs
+++ b/src/parsing/ruby_hash.rs
@@ -16,8 +16,7 @@ pub fn parse_ruby_hash(input: &str) -> ExpressionResult<Value> {
     let result = parse_hash(input)
         .map_err(|err| match err {
             nom::Err::Error(err) | nom::Err::Failure(err) => {
-                // Create a descriptive error message if possible.
-                nom_language::error::convert_error(input, err)
+                crate::parsing::safe_convert_error(input, err)
             }
             nom::Err::Incomplete(_) => err.to_string(),
         })

--- a/src/stdlib/decode_mime_q.rs
+++ b/src/stdlib/decode_mime_q.rs
@@ -120,10 +120,7 @@ fn decode_mime_q(bytes: &Value) -> Resolved {
     ))
     .parse(input)
     .map_err(|e| match e {
-        nom::Err::Error(e) | nom::Err::Failure(e) => {
-            // Create a descriptive error message if possible.
-            nom_language::error::convert_error(input, e)
-        }
+        nom::Err::Error(e) | nom::Err::Failure(e) => crate::parsing::safe_convert_error(input, e),
         nom::Err::Incomplete(_) => e.to_string(),
     })?;
 

--- a/src/stdlib/parse_cef.rs
+++ b/src/stdlib/parse_cef.rs
@@ -272,7 +272,7 @@ fn parse(
         .parse(input)
         .map_err(|e| match e {
             nom::Err::Error(e) | nom::Err::Failure(e) => {
-                nom_language::error::convert_error(input, e)
+                crate::parsing::safe_convert_error(input, e)
             }
             nom::Err::Incomplete(_) => e.to_string(),
         })?;

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -351,10 +351,7 @@ fn parse<'a>(
         standalone_key,
     )
     .map_err(|e| match e {
-        nom::Err::Error(e) | nom::Err::Failure(e) => {
-            // Create a descriptive error message if possible.
-            nom_language::error::convert_error(input, e)
-        }
+        nom::Err::Error(e) | nom::Err::Failure(e) => crate::parsing::safe_convert_error(input, e),
         nom::Err::Incomplete(_) => e.to_string(),
     })?;
 
@@ -609,6 +606,17 @@ fn type_def() -> TypeDef {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_long_line_does_not_panic() {
+        // nom's convert_error panics on Rust ≥ 1.87 when any column offset
+        // ≥ 65535 (fmt width capped at 0xffff).  With standalone_key=false a
+        // line that has no `=` delimiter forces a nom Err at EOF, which used
+        // to invoke convert_error and panic.
+        let input = "a".repeat(65535);
+        let result = parse(&input, "=", " ", Whitespace::Lenient, false);
+        assert!(result.is_err(), "expected parse error for long-line input");
+    }
 
     #[test]
     fn test_quote_and_escape_char() {

--- a/src/stdlib/parse_key_value.rs
+++ b/src/stdlib/parse_key_value.rs
@@ -614,8 +614,13 @@ mod test {
         // line that has no `=` delimiter forces a nom Err at EOF, which used
         // to invoke convert_error and panic.
         let input = "a".repeat(65535);
-        let result = parse(&input, "=", " ", Whitespace::Lenient, false);
-        assert!(result.is_err(), "expected parse error for long-line input");
+        let err = parse(&input, "=", " ", Whitespace::Lenient, false)
+            .expect_err("expected parse error for long-line input");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("line 1") && msg.contains("column 65536"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The fix adds `parsing::safe_convert_error()`: if any line of the input is ≥ 65,535 bytes it returns a plain "line too long" message; otherwise it delegates to `nom_language::error::convert_error` as before. All four call sites are updated.

The helper is intentionally a workaround pending [rust-bakery/nom#1868](https://github.com/rust-bakery/nom/pull/1868) (open since Oct 2025, maintainer has limited availability). A comment marks it for removal once that PR lands.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Added a unit test in `parse_key_value` that constructs a 65,535-byte line with no `=` delimiter and `standalone_key=false`, which forces a nom `Err::Error` at EOF. Without the fix this panics; with it the function returns `Err`.

Ran `cargo fmt`, `./scripts/clippy.sh`, and the full `parse_key_value` unit test suite.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).

Changelog fragment: `changelog.d/1848.fix.md`

## References

- Closes: https://github.com/vectordotdev/vrl/issues/1849
- Upstream nom fix (open): rust-bakery/nom#1868