### PR TITLE
chore(deps): bump crossbeam-epoch from 0.9.18 to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 to resolve [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204).

Fixes the failing deny check.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

`./scripts/check_deny.sh` passes after the bump.

## Does this PR include user facing changes?

- [ ] Yes.
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.