### PR TITLE
chore: add typos spell-checking CI and fix existing typos

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,23 @@
+name: Check Spelling
+
+on:
+  pull_request:
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
+
+permissions:
+  contents: read
+
+jobs:
+  spelling:
+    name: Check Spelling
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: spelling-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: crate-ci/typos@b1ae8d918b6e85bd611117d3d9a3be4f903ee5e4 # v1.33.1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,40 @@
+[files]
+ignore-hidden = false
+extend-exclude = [
+  # Upstream user-agent regex data — contains intentional misspellings from third-party sources
+  "data/user_agent_regexes.yaml",
+  # Third-party license CSV — contains upstream crate names and copyrighted text verbatim
+  "LICENSE-3rdparty.csv",
+  # Git object store — binary data
+  ".git/",
+]
+
+[default.extend-words]
+# GitHub handles used in changelog/release `authors:` lines
+pront = "pront"
+aso = "aso"
+# Punycode encoding of "café.com" — intentional in punycode test fixtures
+caf = "caf"
+# Intentional misspelling used as an example in VRL error diagnostics tests
+strng = "strng"
+# Intentional misspellings used in VRL parser diagnostics tests (misnamed_literal_type.vrl)
+tru = "tru"
+fals = "fals"
+# Part of IPv6 addresses and regex patterns in test data
+ba = "ba"
+# Test data value in parse_key_value tests (arbitrary quoted string)
+zink = "zink"
+# Result of replace("and", "a", "o") in replace.rs tests — intentional garbled output
+ond = "ond"
+# Appears inside a trace ID example value in parse_aws_alb_log tests
+daa = "daa"
+# Part of "FOO" in starts_with test data
+FO = "FO"
+# "mis-" prefix in hyphenated compound words e.g. "mis-match"
+mis = "mis"
+# Part of "2nd" in test name identifiers (e.g. "error_failed_2nd_unit") and NaiveDate variable name `nd`
+nd = "nd"
+# Part of base64-encoded gzip test data
+OT = "OT"
+# Canva.cn domain name used in punycode test fixtures (Canva the company)
+canva = "canva"

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,14 +5,14 @@ extend-exclude = [
   "data/user_agent_regexes.yaml",
   # Third-party license CSV — contains upstream crate names and copyrighted text verbatim
   "LICENSE-3rdparty.csv",
+  # Changelog files contain arbitrary GitHub handles in author lines
+  "changelog.d/",
+  "CHANGELOG.md",
   # Git object store — binary data
   ".git/",
 ]
 
 [default.extend-words]
-# GitHub handles used in changelog/release `authors:` lines
-pront = "pront"
-aso = "aso"
 # Punycode encoding of "café.com" — intentional in punycode test fixtures
 caf = "caf"
 # Intentional misspelling used as an example in VRL error diagnostics tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 
   [PR #1618](https://github.com/vectordotdev/vrl/pull/1618) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 - Corrected the type definition of the `basename` function to indicate that it can also return `null`.
-  Previously the type definitition indicated that the function could only return bytes (or strings).
+  Previously the type definition indicated that the function could only return bytes (or strings).
 
   [PR #1635](https://github.com/vectordotdev/vrl/pull/1635) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 - Fixed incorrect parameter types in several stdlib functions:

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -1872,12 +1872,12 @@ bench_function! {
         want: Ok(-42),
     }
 
-    hexidecimal {
+    hexadecimal {
         args: func_args![value: "0x2a"],
         want: Ok(42),
     }
 
-    explicit_hexidecimal {
+    explicit_hexadecimal {
         args: func_args![value: "2a", base: 16],
         want: Ok(42),
     }

--- a/rfcs/2025-10-27-vrl-function-documentation-auto-generation.md
+++ b/rfcs/2025-10-27-vrl-function-documentation-auto-generation.md
@@ -108,7 +108,7 @@ and add a `vdev` command that generates website-ready docs from VRL functions al
       * The website dynamically generates all functions' documentation when it spins up. This will
         likely make the website deployment heavier and more complex than what it is right now.
 
-3. Add JSON documentation genaration logic in VRL so that both repos can utilize it. The
+3. Add JSON documentation generation logic in VRL so that both repos can utilize it. The
    documentation will be dynamically generated based solely on the methods provided by
    the `Function` trait.
 

--- a/scripts/check_spelling.sh
+++ b/scripts/check_spelling.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+typos

--- a/src/datadog/grok/grok.rs
+++ b/src/datadog/grok/grok.rs
@@ -78,7 +78,7 @@ impl<'a> Iterator for MatchesIter<'a> {
 pub struct Pattern {
     // NOTE this Arc exists solely to satisfy Clone and provide a Sync + Send
     // constraint for calling code in VRL. Theoretically we could remove this
-    // entirely and have it be the responsibilty of the caller to provide for
+    // entirely and have it be the responsibility of the caller to provide for
     // Clone + Sync + Send.
     regex: Arc<Regex>,
     names: BTreeMap<String, usize>,

--- a/src/datadog/grok/matchers/date.rs
+++ b/src/datadog/grok/matchers/date.rs
@@ -29,7 +29,7 @@ pub fn convert_time_format(format: &str) -> Result<String, String> {
                 's' => time_format.push_str("%S"),
                 // fraction of second
                 'S' => {
-                    time_format.pop(); // drop the fraction charactor(e.g. . or , )
+                    time_format.pop(); // drop the fraction character(e.g. . or , )
                     time_format.push_str("%.f"); // Decimal fraction of a second. Consumes the leading dot.
                 }
                 // year

--- a/src/datadog/grok/parse_grok.rs
+++ b/src/datadog/grok/parse_grok.rs
@@ -28,7 +28,7 @@ pub enum InternalError {
 pub struct ParsedGrokObject {
     /// Resulting parsed object from the Grok operation.
     pub parsed: Value,
-    /// List of internal errors that were encounted during the parsing.
+    /// List of internal errors that were encountered during the parsing.
     pub internal_errors: Vec<InternalError>,
 }
 
@@ -94,7 +94,7 @@ fn apply_grok_rule(source: &str, grok_rule: &GrokRule) -> Result<ParsedGrokObjec
                             Value::Object(map) if field.is_root() => {
                                 parsed.as_object_mut().expect("root is object").extend(map);
                             }
-                            // anything else at the root leve must be ignored
+                            // anything else at the root level must be ignored
                             _ if field.is_root() => {}
                             // otherwise just apply VRL lookup insert logic
                             _ => match parsed.get(field).cloned() {
@@ -1056,7 +1056,7 @@ mod tests {
                     }
                 })),
             ),
-            // capture all possilbe key-value pairs from the string
+            // capture all possible key-value pairs from the string
             (
                 "%{data::keyvalue}",
                 r#" , key1=value1 "key2"="value2",key3=value3 "#,

--- a/src/stdlib/format_int.rs
+++ b/src/stdlib/format_int.rs
@@ -152,13 +152,13 @@ mod tests {
             tdef: TypeDef::bytes().fallible(),
         }
 
-        hexidecimal {
+        hexadecimal {
             args: func_args![value: 42, base: 16],
             want: Ok(value!("2a")),
             tdef: TypeDef::bytes().fallible(),
         }
 
-        negative_hexidecimal {
+        negative_hexadecimal {
             args: func_args![value: -42, base: 16],
             want: Ok(value!("-2a")),
             tdef: TypeDef::bytes().fallible(),

--- a/src/stdlib/redact.rs
+++ b/src/stdlib/redact.rs
@@ -228,7 +228,7 @@ struct RedactFn {
 
 fn redact(value: Value, filters: &[Filter], redactor: &Redactor) -> Value {
     // possible optimization. match the redactor here, and use different calls depending on
-    // the value, so that we don't have to do the comparision in the loop of replacment.
+    // the value, so that we don't have to do the comparison in the loop of replacement.
     // that would complicate the code though.
     match value {
         Value::Bytes(bytes) => {
@@ -375,7 +375,7 @@ enum Redactor {
     /// Replace with a fixed string
     Text(String), // possible optimization: use Arc<str> instead of String to speed up cloning
     // using function pointers simplifies the code,
-    // but the Debug implmentation probably isn't very useful
+    // but the Debug implementation probably isn't very useful
     // alternatively we could have a separate variant for each hash algorithm/variant combination
     // we could also create a custom Debug implementation that does a comparison of the fn pointer
     // to function pointers we might use.

--- a/src/stdlib/shannon_entropy.rs
+++ b/src/stdlib/shannon_entropy.rs
@@ -39,12 +39,12 @@ cases.",
 ];
 
 // Casting to f64 in this function is only done to enable proper division (when calculating probability)
-// Since numbers being casted represent lenghts of input strings and number of character occurences,
+// Since numbers being casted represent lengths of input strings and number of character occurrences,
 // we can assume that there will never really be precision loss here, because that would mean that
 // the string is at least 2^52 bytes in size (4.5 PB)
 #[allow(clippy::cast_precision_loss)]
 fn shannon_entropy(value: &Value, segmentation: &Segmentation) -> Resolved {
-    let (occurence_counts, total_length): (Vec<usize>, usize) = match segmentation {
+    let (occurrence_counts, total_length): (Vec<usize>, usize) = match segmentation {
         Segmentation::Byte => {
             // Optimized version for bytes, since there is a limited number of options, that could
             // easily be kept track of
@@ -99,10 +99,10 @@ fn shannon_entropy(value: &Value, segmentation: &Segmentation) -> Resolved {
     };
 
     Ok(Value::from_f64_or_zero(
-        occurence_counts
+        occurrence_counts
             .iter()
-            // Calculate probability of each item by diving occurence count by total length
-            .map(|occurence_count| *occurence_count as f64 / total_length as f64)
+            // Calculate probability of each item by diving occurrence count by total length
+            .map(|occurrence_count| *occurrence_count as f64 / total_length as f64)
             // Calculate entropy using definition: sum(-p * log2(p))
             .fold(0f64, |acc, p| acc - (p * p.log2())),
     ))

--- a/src/stdlib/unflatten.rs
+++ b/src/stdlib/unflatten.rs
@@ -454,7 +454,7 @@ mod test {
             tdef: TypeDef::object(Collection::any()),
         }
 
-        traling_separator{
+        trailing_separator{
             args: func_args![value: value!({
                 "a.": 1,
             })],


### PR DESCRIPTION
## Summary

Adds spell-checking to CI using [`typos`](https://github.com/crate-ci/typos), mirroring the setup already in `vectordotdev/vector`.

- `.typos.toml` — configures excluded files (upstream data: `data/user_agent_regexes.yaml`, `LICENSE-3rdparty.csv`) and allowlists intentional false positives (GitHub handles, punycode test domains, base64 test data, intentional misspellings in diagnostics tests)
- `.github/workflows/spelling.yml` — runs `crate-ci/typos` on every PR

The initial run surfaced real typos across the codebase, all fixed in this PR.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Ran `typos` locally and confirmed zero errors after the fixes.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).