### PR TITLE
chore: simplify Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,42 +26,16 @@ default-members = ["."]
 clap = { version = "4", features = ["derive"] }
 
 [features]
-default = ["compiler", "value", "diagnostic", "path", "parser", "stdlib", "datadog", "core", "cli", "enable_env_functions", "enable_system_functions", "enable_network_functions", "enable_crypto_functions"]
+default = ["compiler", "stdlib", "datadog", "cli", "enable_env_functions", "enable_system_functions", "enable_network_functions", "enable_crypto_functions"]
 
-# Contains the core functionality of VRL. Compiling and running VRL programs.
-compiler = ["diagnostic", "path", "parser", "value", "dep:chrono", "dep:serde", "dep:regex", "dep:bytes", "dep:ordered-float", "dep:chrono-tz", "dep:snafu", "dep:thiserror", "dep:dyn-clone", "dep:indoc", "dep:thiserror", "dep:lalrpop-util"]
+# Contains the primary data type used in VRL, along with path types. Useful for crates that work with VRL values without needing the full compiler.
+value = ["dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json", "dep:simdutf8", "dep:serde", "dep:snafu"]
 
-# Contains the primary data type used in VRL.
-value = ["path", "dep:bytes", "dep:regex", "dep:ordered-float", "dep:chrono", "dep:serde_json", "dep:simdutf8"]
-
-# Logic related to errors and displaying info about them.
-diagnostic = ["dep:codespan-reporting", "dep:termcolor"]
-
-# Contains the parser, datatypes, and functions related to VRL paths.
-path = ["value", "dep:serde", "dep:snafu", "dep:regex"]
-
-# Creates an abstract syntax tree (AST) from VRL source code.
-parser = ["path", "diagnostic", "value", "dep:thiserror", "dep:ordered-float", "dep:lalrpop-util"]
-
-# Text parsing primitives used by stdlib functions that handle structured formats (JSON, XML, URLs, etc.).
-parsing = ["value", "compiler", "dep:url", "dep:nom", "dep:regex", "dep:roxmltree", "dep:rust_decimal"]
-
-# Various data structures and utility methods (these may be renamed / moved in the future).
-core = ["value", "dep:snafu", "dep:nom"]
-
-string_path = []
+# Contains the core functionality of VRL: compiling and running VRL programs, parser, and diagnostics.
+compiler = ["value", "dep:chrono-tz", "dep:thiserror", "dep:dyn-clone", "dep:indoc", "dep:lalrpop-util", "dep:codespan-reporting", "dep:termcolor"]
 
 # Enables all Datadog-specific features (filter, grok, search).
-datadog = ["datadog_filter", "datadog_grok", "datadog_search"]
-
-# Implements the Datadog log search query filter syntax.
-datadog_filter = ["path", "datadog_search", "dep:regex", "dep:dyn-clone"]
-
-# Implements the Datadog grok parser (used with `parse_grok` and `parse_groks` in the stdlib). Not supported on wasm32.
-datadog_grok = ["value", "parsing", "dep:nom", "dep:peeking_take_while", "dep:serde_json", "dep:onig", "dep:lalrpop-util", "dep:thiserror", "dep:chrono", "dep:chrono-tz", "dep:percent-encoding", "dep:fancy-regex"]
-
-# Implements the Datadog log search syntax.
-datadog_search = ["dep:pest", "dep:pest_derive", "dep:itertools", "dep:regex", "dep:serde"]
+datadog = ["compiler", "dep:regex", "dep:dyn-clone", "dep:nom", "dep:peeking_take_while", "dep:onig", "dep:percent-encoding", "dep:fancy-regex", "dep:pest", "dep:pest_derive", "dep:itertools", "dep:serde", "dep:url", "dep:roxmltree", "dep:rust_decimal"]
 
 # Contains functionality to create a CLI for VRL.
 cli = ["compiler", "dep:clap", "dep:serde_json", "dep:thiserror", "dep:exitcode", "dep:webbrowser", "dep:rustyline", "dep:prettytable-rs"]
@@ -81,9 +55,6 @@ lua = ["dep:mlua"]
 
 # Property-based testing support via proptest.
 proptest = ["dep:proptest", "dep:proptest-derive"]
-
-# Preserves float precision during JSON serialization/deserialization.
-float_roundtrip = ["dep:serde_json", "serde_json/float_roundtrip"]
 
 # Enables environment variable access functions (e.g. `get_env_var`).
 enable_env_functions = []
@@ -117,6 +88,11 @@ enable_crypto_functions = [
   "dep:crc",
 ]
 
+# Preserves float precision during JSON serialization/deserialization.
+float_roundtrip = ["dep:serde_json", "serde_json/float_roundtrip"]
+
+string_path = []
+
 # Testing Utilities. Enables additional tests, including those with external dependencies such as network calls.
 test = ["string_path"]
 
@@ -135,9 +111,7 @@ stdlib = [
 # Base stdlib functionality (without enable_* features)
 stdlib-base = [
   "compiler",
-  "core",
   "datadog",
-  "parsing",
   "dep:base16",
   "dep:base62",
   "dep:base64-simd",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Most stdlib functions are supported. The following functions compile but abort a
 - `reverse_dns`
 - `validate_json_schema`
 
-Note: the `datadog_grok` feature is excluded entirely when targeting wasm32.
+Note: the grok parser within the `datadog` feature is excluded entirely when targeting wasm32.
 
 [vector]: https://vector.dev
 [vrl]: https://vrl.dev

--- a/src/datadog/mod.rs
+++ b/src/datadog/mod.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "datadog_filter")]
+#[cfg(feature = "datadog")]
 pub mod filter;
 
-#[cfg(all(feature = "datadog_grok", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "datadog", not(target_arch = "wasm32")))]
 pub mod grok;
 
-#[cfg(feature = "datadog_search")]
+#[cfg(feature = "datadog")]
 pub mod search;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,25 +2,25 @@
 #![warn(clippy::all)]
 #![warn(clippy::arithmetic_side_effects)]
 
+#[cfg(feature = "value")]
+pub mod value;
+
+#[cfg(feature = "value")]
+pub mod path;
+
 #[cfg(feature = "compiler")]
 pub mod compiler;
 
 #[cfg(feature = "compiler")]
 pub use compiler::prelude;
 
-#[cfg(feature = "value")]
-pub mod value;
-
-#[cfg(feature = "diagnostic")]
+#[cfg(feature = "compiler")]
 pub mod diagnostic;
 
-#[cfg(feature = "path")]
-pub mod path;
-
-#[cfg(feature = "parser")]
+#[cfg(feature = "compiler")]
 pub mod parser;
 
-#[cfg(feature = "core")]
+#[cfg(feature = "stdlib-base")]
 pub mod core;
 
 #[cfg(feature = "stdlib-base")]
@@ -28,6 +28,9 @@ pub mod stdlib;
 
 #[cfg(feature = "stdlib-base")]
 pub mod protobuf;
+
+#[cfg(any(feature = "stdlib-base", feature = "datadog"))]
+pub mod parsing;
 
 #[cfg(feature = "docs")]
 pub mod docs;
@@ -38,16 +41,13 @@ pub mod cli;
 #[cfg(feature = "test_framework")]
 pub mod test;
 
-#[cfg(feature = "parsing")]
-pub mod parsing;
-
 mod datadog;
 
-#[cfg(feature = "datadog_filter")]
+#[cfg(feature = "datadog")]
 pub use datadog::filter as datadog_filter;
 
-#[cfg(all(feature = "datadog_grok", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "datadog", not(target_arch = "wasm32")))]
 pub use datadog::grok as datadog_grok;
 
-#[cfg(feature = "datadog_search")]
+#[cfg(feature = "datadog")]
 pub use datadog::search as datadog_search_syntax;


### PR DESCRIPTION
## Summary

Fewer features = faster powerset checks in CI and less noise for contributors. None of the removed features are used by Vector or OPW directly.

- `value` is kept as a standalone feature — crates that only need the `Value` type without the full compiler should be able to import it independently. `path` types are folded into `value` since the two were mutually dependent.
- `diagnostic` and `parser` → folded into `compiler` (no external consumer uses them individually)
- `parsing`, `core` → folded into `stdlib-base` (their deps were already listed explicitly there)
- `datadog_filter`, `datadog_grok`, `datadog_search` → collapsed into a single `datadog` feature (sub-features were never requested directly by any consumer)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

`cargo check`, `cargo fmt`, `make clippy` — all clean.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.