### PR TITLE
chore: remove string_path feature and bare `&str` path impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,10 +91,8 @@ enable_crypto_functions = [
 # Preserves float precision during JSON serialization/deserialization.
 float_roundtrip = ["dep:serde_json", "serde_json/float_roundtrip"]
 
-string_path = []
-
 # Testing Utilities. Enables additional tests, including those with external dependencies such as network calls.
-test = ["string_path"]
+test = []
 
 # Documentation generation support.
 docs = ["stdlib", "indexmap/serde", "serde_json/preserve_order", "dep:clap", "dep:thiserror", "dep:exitcode"]

--- a/src/path/jit.rs
+++ b/src/path/jit.rs
@@ -238,7 +238,7 @@ impl<'a> Iterator for JitValuePathIter<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::{BorrowedSegment, ValuePath};
+    use super::{BorrowedSegment, JitValuePath, ValuePath};
 
     #[test]
     fn parsing() {
@@ -368,12 +368,13 @@ mod test {
         ];
 
         for (path, expected) in test_cases {
-            if !ValuePath::eq(&path, &expected) {
+            let jit = JitValuePath::new(path);
+            if !ValuePath::eq(&jit, &expected) {
                 panic!(
                     "Not equal. Input={:?}\nExpected: {:?}\nActual: {:?}",
                     path,
                     (&expected).segment_iter().collect::<Vec<_>>(),
-                    path.segment_iter().collect::<Vec<_>>()
+                    jit.segment_iter().collect::<Vec<_>>()
                 );
             }
         }

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -62,15 +62,6 @@
 //!
 //! To convert a string into an owned path, use either [parse_value_path] or [parse_target_path].
 //!
-//! # String Paths
-//! [ValuePath] and [TargetPath] are implemented for [&str]. That means a raw / unparsed string can
-//! be used as a path. This use is discouraged, and may be removed in the future. It mostly
-//! exists for backwards compatibility in places where String paths are used instead of owned paths.
-//! Using string paths is slightly slower than using an owned path. It's still very fast
-//! but it is easy to introduce bugs since some compile-time type information is missing -
-//! such as whether it is a target vs value path, or if the entire string is meant
-//! to be treated as a single segment vs being parsed as a path.
-//!
 //! # Macros
 //! Several macros exist to make creating paths easier. These are used if the structure of the
 //! path being created is already known. <strong>The macros do not parse paths</strong>. Use
@@ -252,28 +243,6 @@ pub trait ValuePath<'a>: Clone {
     }
 }
 
-#[cfg(any(feature = "string_path", test))]
-impl<'a> ValuePath<'a> for &'a str {
-    type Iter = jit::JitValuePathIter<'a>;
-
-    fn segment_iter(&self) -> Self::Iter {
-        JitValuePath::new(self).segment_iter()
-    }
-}
-
-#[cfg(any(feature = "string_path", test))]
-impl<'a> TargetPath<'a> for &'a str {
-    type ValuePath = &'a str;
-
-    fn prefix(&self) -> PathPrefix {
-        get_target_prefix(self).0
-    }
-
-    fn value_path(&self) -> Self::ValuePath {
-        get_target_prefix(self).1
-    }
-}
-
 impl<'a> TargetPath<'a> for &'a OwnedTargetPath {
     type ValuePath = &'a OwnedValuePath;
 
@@ -340,6 +309,7 @@ mod test {
     use crate::path::TargetPath;
     use crate::path::ValuePath;
     use crate::path::parse_target_path;
+    use crate::path::parse_value_path;
 
     #[test]
     fn test_parse_target_path() {
@@ -348,27 +318,29 @@ mod test {
 
     #[test]
     fn test_path_macro() {
-        assert!(ValuePath::eq(&path!("a", "b"), "a.b"))
+        let expected = parse_value_path("a.b").unwrap();
+        assert!(ValuePath::eq(&path!("a", "b"), &expected))
     }
 
     #[test]
     fn test_event_path_macro() {
         let path = event_path!("a", "b");
-        let expected = "a.b";
-        assert!(ValuePath::eq(&path.value_path(), expected));
+        let expected = parse_value_path("a.b").unwrap();
+        assert!(ValuePath::eq(&path.value_path(), &expected));
         assert_eq!(path.prefix(), PathPrefix::Event);
     }
 
     #[test]
     fn test_metadata_path_macro() {
         let path = metadata_path!("a", "b");
-        let expected = "a.b";
-        assert!(ValuePath::eq(&path.value_path(), expected));
+        let expected = parse_value_path("a.b").unwrap();
+        assert!(ValuePath::eq(&path.value_path(), &expected));
         assert_eq!(path.prefix(), PathPrefix::Metadata);
     }
 
     #[test]
     fn test_owned_value_path_macro() {
-        assert!(ValuePath::eq(&&owned_value_path!("a", "b"), "a.b"))
+        let expected = parse_value_path("a.b").unwrap();
+        assert!(ValuePath::eq(&&owned_value_path!("a", "b"), &expected))
     }
 }

--- a/src/stdlib/encode_key_value.rs
+++ b/src/stdlib/encode_key_value.rs
@@ -240,7 +240,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use crate::{
-        btreemap,
+        btreemap, path,
         stdlib::parse_key_value::{Whitespace, parse_key_value},
         value,
     };
@@ -251,7 +251,7 @@ mod tests {
     fn test_encode_decode_cycle() {
         let before: Value = {
             let mut map = Value::from(BTreeMap::default());
-            map.insert("key", r#"this has a " quote"#);
+            map.insert(path!("key"), r#"this has a " quote"#);
             map
         };
 

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -225,7 +225,7 @@ mod test {
     use quickcheck::{QuickCheck, TestResult};
 
     use crate::path;
-    use crate::path::BorrowedSegment;
+    use crate::path::{BorrowedSegment, parse_value_path};
 
     use super::*;
 
@@ -235,44 +235,44 @@ mod test {
         #[test]
         fn remove_prune_map_with_map() {
             let mut value = Value::from(BTreeMap::default());
-            let key = "foo.bar";
+            let key = parse_value_path("foo.bar").unwrap();
             let marker = Value::from(true);
-            assert_eq!(value.insert(key, marker.clone()), None);
+            assert_eq!(value.insert(&key, marker.clone()), None);
             // Since the `foo` map is now empty, this should get cleaned.
-            assert_eq!(value.remove(key, true), Some(marker));
-            assert!(!value.contains("foo"));
+            assert_eq!(value.remove(&key, true), Some(marker));
+            assert!(!value.contains(path!("foo")));
         }
 
         #[test]
         fn remove_prune_map_with_array() {
             let mut value = Value::from(BTreeMap::default());
-            let key = "foo[0]";
+            let key = parse_value_path("foo[0]").unwrap();
             let marker = Value::from(true);
-            assert_eq!(value.insert(key, marker.clone()), None);
+            assert_eq!(value.insert(&key, marker.clone()), None);
             // Since the `foo` map is now empty, this should get cleaned.
-            assert_eq!(value.remove(key, true), Some(marker));
-            assert!(!value.contains("foo"));
+            assert_eq!(value.remove(&key, true), Some(marker));
+            assert!(!value.contains(path!("foo")));
         }
 
         #[test]
         fn remove_prune_array_with_map() {
             let mut value = Value::from(Vec::<Value>::default());
-            let key = "[0].bar";
+            let key = parse_value_path("[0].bar").unwrap();
             let marker = Value::from(true);
-            assert_eq!(value.insert(key, marker.clone()), None);
+            assert_eq!(value.insert(&key, marker.clone()), None);
             // Since the `foo` map is now empty, this should get cleaned.
-            assert_eq!(value.remove(key, true), Some(marker));
+            assert_eq!(value.remove(&key, true), Some(marker));
             assert!(!value.contains(path!(0)));
         }
 
         #[test]
         fn remove_prune_array_with_array() {
             let mut value = Value::from(Vec::<Value>::default());
-            let key = "[0][0]";
+            let key = parse_value_path("[0][0]").unwrap();
             let marker = Value::from(true);
-            assert_eq!(value.insert(key, marker.clone()), None);
+            assert_eq!(value.insert(&key, marker.clone()), None);
             // Since the `foo` map is now empty, this should get cleaned.
-            assert_eq!(value.remove(key, true), Some(marker));
+            assert_eq!(value.remove(&key, true), Some(marker));
             assert!(!value.contains(path!(0)));
         }
     }

--- a/src/value/value/crud/get.rs
+++ b/src/value/value/crud/get.rs
@@ -33,14 +33,22 @@ pub fn get<'a>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::path;
     use serde_json::json;
 
     #[test]
     fn test_negative_index() {
         assert_eq!(
-            Value::from(json!([0, 1, 2, 3])).get("[-1]").cloned(),
+            Value::from(json!([0, 1, 2, 3]))
+                .get(path!(-1_isize))
+                .cloned(),
             Some(Value::from(3))
         );
-        assert_eq!(Value::from(json!([0, 1, 2, 3])).get("[-5]").cloned(), None);
+        assert_eq!(
+            Value::from(json!([0, 1, 2, 3]))
+                .get(path!(-5_isize))
+                .cloned(),
+            None
+        );
     }
 }

--- a/src/value/value/crud/insert.rs
+++ b/src/value/value/crud/insert.rs
@@ -45,12 +45,13 @@ pub fn insert<'a, T: ValueCollection>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::path;
     use serde_json::json;
 
     #[test]
     fn test_insert_nested() {
         let mut value = Value::Null;
-        value.insert("a.b.c", 3);
+        value.insert(path!("a", "b", "c"), 3);
         let expected = Value::from(json!({
             "a": {
                 "b":{
@@ -64,8 +65,8 @@ mod test {
     #[test]
     fn test_insert_array() {
         let mut value = Value::Null;
-        value.insert("a.b[0].c[2]", 10);
-        value.insert("a.b[0].c[0]", 5);
+        value.insert(path!("a", "b", 0_isize, "c", 2_isize), 10);
+        value.insert(path!("a", "b", 0_isize, "c", 0_isize), 5);
 
         let expected = Value::from(json!({
             "a": {
@@ -80,10 +81,10 @@ mod test {
     #[test]
     fn test_insert_negative_index() {
         let mut value = Value::Null;
-        assert_eq!(value.insert("[-2]", 10), None);
-        assert_eq!(value.insert("[-1]", 5), Some(Value::Null));
-        assert_eq!(value.insert("[-2]", 2), Some(Value::Integer(10)));
-        assert_eq!(value.insert("[-1][1]", 3), None);
+        assert_eq!(value.insert(path!(-2_isize), 10), None);
+        assert_eq!(value.insert(path!(-1_isize), 5), Some(Value::Null));
+        assert_eq!(value.insert(path!(-2_isize), 2), Some(Value::Integer(10)));
+        assert_eq!(value.insert(path!(-1_isize, 1_isize), 3), None);
         assert_eq!(value, Value::from(json!([2, [null, 3]])));
     }
 }

--- a/src/value/value/crud/mod.rs
+++ b/src/value/value/crud/mod.rs
@@ -146,147 +146,151 @@ impl ValueCollection for Vec<Value> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::path::parse_value_path;
 
     #[test]
     fn single_field() {
         let mut value = Value::from(ObjectMap::default());
-        let key = "root";
+        let key = parse_value_path("root").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
-        assert_eq!(value.as_object().unwrap()[key], marker);
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.insert(&key, marker.clone()), None);
+        assert_eq!(value.as_object().unwrap()["root"], marker);
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn nested_field() {
         let mut value = Value::from(ObjectMap::default());
-        let key = "root.doot";
+        let key = parse_value_path("root.doot").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(
             value.as_object().unwrap()["root"].as_object().unwrap()["doot"],
             marker
         );
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn double_nested_field() {
         let mut value = Value::from(ObjectMap::default());
-        let key = "root.doot.toot";
+        let key = parse_value_path("root.doot.toot").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(
             value.as_object().unwrap()["root"].as_object().unwrap()["doot"]
                 .as_object()
                 .unwrap()["toot"],
             marker
         );
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn single_index() {
         let mut value = Value::from(Vec::<Value>::default());
-        let key = "[0]";
+        let key = parse_value_path("[0]").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(value.as_array_unwrap()[0], marker);
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn nested_index() {
         let mut value = Value::from(Vec::<Value>::default());
-        let key = "[0][0]";
+        let key = parse_value_path("[0][0]").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(value.as_array_unwrap()[0].as_array_unwrap()[0], marker);
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn field_index() {
         let mut value = Value::from(ObjectMap::default());
-        let key = "root[0]";
+        let key = parse_value_path("root[0]").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(
             value.as_object().unwrap()["root"].as_array_unwrap()[0],
             marker
         );
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn index_field() {
         let mut value = Value::from(Vec::<Value>::default());
-        let key = "[0].boot";
+        let key = parse_value_path("[0].boot").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(
             value.as_array_unwrap()[0].as_object().unwrap()["boot"],
             marker
         );
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn nested_index_field() {
         let mut value = Value::from(Vec::<Value>::default());
-        let key = "[0][0].boot";
+        let key = parse_value_path("[0][0].boot").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(
             value.as_array_unwrap()[0].as_array_unwrap()[0]
                 .as_object()
                 .unwrap()["boot"],
             marker
         );
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn field_with_nested_index_field() {
         let mut value = Value::from(ObjectMap::default());
-        let key = "root[0][0].boot";
+        let key = parse_value_path("root[0][0].boot").unwrap();
         let mut marker = Value::from(true);
-        assert_eq!(value.insert(key, marker.clone()), None);
+        assert_eq!(value.insert(&key, marker.clone()), None);
         assert_eq!(
             value.as_object().unwrap()["root"].as_array_unwrap()[0].as_array_unwrap()[0]
                 .as_object()
                 .unwrap()["boot"],
             marker
         );
-        assert_eq!(value.get(key), Some(&marker));
-        assert_eq!(value.get_mut(key), Some(&mut marker));
-        assert_eq!(value.remove(key, false), Some(marker));
+        assert_eq!(value.get(&key), Some(&marker));
+        assert_eq!(value.get_mut(&key), Some(&mut marker));
+        assert_eq!(value.remove(&key, false), Some(marker));
     }
 
     #[test]
     fn populated_field() {
         let mut value = Value::from(ObjectMap::default());
         let marker = Value::from(true);
-        assert_eq!(value.insert("a[2]", marker.clone()), None);
+        assert_eq!(
+            value.insert(&parse_value_path("a[2]").unwrap(), marker.clone()),
+            None
+        );
 
-        let key = "a[0]";
-        assert_eq!(value.insert(key, marker.clone()), Some(Value::Null));
+        let key = parse_value_path("a[0]").unwrap();
+        assert_eq!(value.insert(&key, marker.clone()), Some(Value::Null));
 
         assert_eq!(value.as_object().unwrap()["a"].as_array_unwrap().len(), 3);
         assert_eq!(value.as_object().unwrap()["a"].as_array_unwrap()[0], marker);
@@ -298,7 +302,7 @@ mod test {
 
         // Replace the value at 0.
         let marker = Value::from(false);
-        assert_eq!(value.insert(key, marker.clone()), Some(Value::from(true)));
+        assert_eq!(value.insert(&key, marker.clone()), Some(Value::from(true)));
         assert_eq!(value.as_object().unwrap()["a"].as_array_unwrap()[0], marker);
     }
 }

--- a/src/value/value/crud/remove.rs
+++ b/src/value/value/crud/remove.rs
@@ -31,15 +31,17 @@ pub fn remove<'a, T: ValueCollection>(
 
 #[cfg(test)]
 mod test {
+    use crate::path;
+    use crate::path::parse_value_path;
     use crate::value::Value;
     use serde_json::json;
 
     #[test]
     fn array_remove_from_middle() {
         let mut value = Value::Array(vec![Value::Null, Value::Integer(3)]);
-        assert_eq!(value.remove("[0]", false), Some(Value::Null));
-        assert_eq!(value.remove("[0]", false), Some(Value::Integer(3)));
-        assert_eq!(value.remove("[0]", false), None);
+        assert_eq!(value.remove(path!(0_isize), false), Some(Value::Null));
+        assert_eq!(value.remove(path!(0_isize), false), Some(Value::Integer(3)));
+        assert_eq!(value.remove(path!(0_isize), false), None);
     }
 
     #[test]
@@ -47,8 +49,11 @@ mod test {
         let mut value = Value::from(json!({
             "field": 123
         }));
-        assert_eq!(value.remove("field", false), Some(Value::Integer(123)));
-        assert_eq!(value.remove("field", false), None);
+        assert_eq!(
+            value.remove(path!("field"), false),
+            Some(Value::Integer(123))
+        );
+        assert_eq!(value.remove(path!("field"), false), None);
     }
 
     #[test]
@@ -76,8 +81,9 @@ mod test {
         ];
 
         for (query, expected_first, expected_second) in &queries {
-            assert_eq!(value.remove(*query, false), *expected_first, "{query}");
-            assert_eq!(value.remove(*query, false), *expected_second, "{query}");
+            let parsed = parse_value_path(query).unwrap();
+            assert_eq!(value.remove(&parsed, false), *expected_first, "{query}");
+            assert_eq!(value.remove(&parsed, false), *expected_second, "{query}");
         }
 
         assert_eq!(
@@ -95,9 +101,9 @@ mod test {
             }))
         );
 
-        value.remove(".", false);
+        value.remove(&parse_value_path(".").unwrap(), false);
         assert_eq!(value, Value::from(json!({})));
-        value.remove(".", true);
+        value.remove(&parse_value_path(".").unwrap(), true);
         assert_eq!(value, Value::from(json!({})));
     }
 
@@ -112,7 +118,7 @@ mod test {
             }
         }));
 
-        assert_eq!(value.remove("a.d", true), Some(Value::Integer(4)));
+        assert_eq!(value.remove(path!("a", "d"), true), Some(Value::Integer(4)));
         assert_eq!(
             value,
             Value::from(json!({
@@ -124,7 +130,10 @@ mod test {
             }))
         );
 
-        assert_eq!(value.remove("a.b.c[0]", true), Some(Value::Integer(5)));
+        assert_eq!(
+            value.remove(path!("a", "b", "c", 0_isize), true),
+            Some(Value::Integer(5))
+        );
         assert_eq!(value, Value::from(json!({})));
     }
 }


### PR DESCRIPTION
## Summary

Deletes the `string_path` feature and the corresponding `impl ValuePath<'a> for &'a str` / `impl TargetPath<'a> for &'a str` blocks. These implementations existed as a backwards-compatibility shim so callers could pass raw strings where a typed path was required, but they hide compile-time information (target vs. value, literal segment vs. parsed path) and are easy to misuse.

Callers should use `event_path!`, `metadata_path!`, or `path!` for compile-time known paths, or `parse_value_path` / `parse_target_path` for runtime-dynamic strings.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

External callers currently relying on `&str: ValuePath` / `&str: TargetPath` will fail to compile after this change and must migrate to the typed macros or the `parse_*_path` helpers.

## How did you test this PR?

- `make all` on this branch: `fmt-check`, `clippy` (workspace, all targets, all features, -D warnings), `cargo test` (1850 passed), and `vrl-test` (937 passed) all succeed. Only `check-wasm32` fails locally due to a `zstd-sys`/clang wasm-sysroot environment issue unrelated to this change.
- Downstream Vector was migrated in vectordotdev/vector#25778 and empirically verified against this branch — Vector's `cargo check --workspace --all-targets --all-features` and `make check-clippy` both pass.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Related

- Paired downstream migration: vectordotdev/vector#25778
- Closes https://github.com/vectordotdev/vrl/issues/1330