### PR TITLE
chore(releasing): 0.34.0 post-release merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 
 <!-- changelog start -->
 
+## [0.34.0 (2026-07-13)](https://github.com/vectordotdev/vrl/releases/tag/v0.34.0)
+
+### New Features
+
+- Added support for dynamic regex patterns in `parse_regex`, allowing variables and runtime expressions to be passed as the `pattern` argument.
+
+  [PR #1809](https://github.com/vectordotdev/vrl/pull/1809) by [@thomasqueirozb](https://github.com/thomasqueirozb)
+- Add `strict` parameter to `parse_cef` (default: `true`). When set to `false`, the function performs best-effort parsing of non-compliant CEF input, treating unescaped `=` characters within field values as literals rather than field delimiters. This improves compatibility with vendors such as Infoblox and Palo Alto Networks whose CEF output does not fully conform to the spec.
+
+  [PR #1821](https://github.com/vectordotdev/vrl/pull/1821) by [@jacklongsd](https://github.com/jacklongsd)
+
+### Enhancements
+
+- Improved performance of `parse_regex` and `parse_regex_all` by pre-computing capture group names and indices at compile time, replacing name-based hash lookups with direct index-based access at runtime.
+
+  [PR #1811](https://github.com/vectordotdev/vrl/pull/1811) by [@thomasqueirozb](https://github.com/thomasqueirozb)
+- Improved performance of `truncate` function if suffix parameter is provided.
+
+  [PR #1784](https://github.com/vectordotdev/vrl/pull/1784) by [@JakubOnderka](https://github.com/JakubOnderka)
+- Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads.
+
+  [PR #1798](https://github.com/vectordotdev/vrl/pull/1798) by [@thomasqueirozb](https://github.com/thomasqueirozb)
+
+### Fixes
+
+- Fixed a panic in `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines ≥ 65,535 bytes. This is a workaround until [rust-bakery/nom#1867](https://github.com/rust-bakery/nom/issues/1867) is fixed.
+
+  [PR #1848](https://github.com/vectordotdev/vrl/pull/1848) by [@pront](https://github.com/pront)
+- Fixed `find`’s type definition and documentation. Previously, the function advertised its return type as an integer, but never as nullable. Now it correctly states that the function returns `null` when `value` doesn’t match `pattern`.
+
+  [PR #1812](https://github.com/vectordotdev/vrl/pull/1812) by [@JakubOnderka](https://github.com/JakubOnderka)
+
+
 ## [0.33.1 (2026-06-02)](https://github.com/vectordotdev/vrl/releases/tag/v0.33.1)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,7 +4506,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrl"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "aes 0.9.1",
  "aes-siv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl"
-version = "0.33.1"
+version = "0.34.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 license = "MPL-2.0"

--- a/changelog.d/1784.enhancement.md
+++ b/changelog.d/1784.enhancement.md
@@ -1,3 +1,0 @@
-Improved performance of `truncate` function if suffix parameter is provided.
-
-authors: JakubOnderka

--- a/changelog.d/1798.enhancement.md
+++ b/changelog.d/1798.enhancement.md
@@ -1,3 +1,0 @@
-Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads.
-
-authors: thomasqueirozb

--- a/changelog.d/1809.feature.md
+++ b/changelog.d/1809.feature.md
@@ -1,3 +1,0 @@
-Added support for dynamic regex patterns in `parse_regex`, allowing variables and runtime expressions to be passed as the `pattern` argument.
-
-authors: thomasqueirozb

--- a/changelog.d/1811.enhancement.md
+++ b/changelog.d/1811.enhancement.md
@@ -1,3 +1,0 @@
-Improved performance of `parse_regex` and `parse_regex_all` by pre-computing capture group names and indices at compile time, replacing name-based hash lookups with direct index-based access at runtime.
-
-authors: thomasqueirozb

--- a/changelog.d/1812.fix.md
+++ b/changelog.d/1812.fix.md
@@ -1,3 +1,0 @@
-Fixed `find`’s type definition and documentation. Previously, the function advertised its return type as an integer, but never as nullable. Now it correctly states that the function returns `null` when `value` doesn’t match `pattern`.
-
-authors: JakubOnderka

--- a/changelog.d/1821.feature.md
+++ b/changelog.d/1821.feature.md
@@ -1,3 +1,0 @@
-Add `strict` parameter to `parse_cef` (default: `true`). When set to `false`, the function performs best-effort parsing of non-compliant CEF input, treating unescaped `=` characters within field values as literals rather than field delimiters. This improves compatibility with vendors such as Infoblox and Palo Alto Networks whose CEF output does not fully conform to the spec.
-
-authors: jacklongsd

--- a/changelog.d/1848.fix.md
+++ b/changelog.d/1848.fix.md
@@ -1,3 +1,0 @@
-Fixed a panic in `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines ≥ 65,535 bytes. This is a workaround until [rust-bakery/nom#1867](https://github.com/rust-bakery/nom/issues/1867) is fixed.
-
-authors: pront


### PR DESCRIPTION
## Summary

Post-release merge for VRL 0.34.0. The crate is already published and tagged; this PR merges the version bump and generated changelog back into `main`.

- `Cargo.toml` bumped to `0.34.0`.
- `CHANGELOG.md` regenerated from `changelog.d/` fragments.
- Published to crates.io: https://crates.io/crates/vrl/0.34.0
- Tag: `v0.34.0`

Note: this run of the release tool aborted at `cargo publish` because `cargo login` had not been run. `cargo publish` was re-invoked manually after logging in, then the remaining steps (tag, push, PR) were completed by hand. A follow-up will add pre-flight checks to prevent a half-done state.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## How did you test this PR?

Verified `vrl 0.34.0` is live on crates.io and the `v0.34.0` tag is pushed.

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the "no-changelog" label to this PR.