### PR TITLE
chore(release tool): pre-flight checks before mutating state

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -5,7 +5,6 @@ title: "VRL [version] release"
 labels: "domain: releasing"
 ---
 
-- [ ] Validate changelog fragments: `cargo run -p release -- check-changelog`.
 - [ ] (Optional) Preview the release: `cargo run -p release -- --dry-run`.
 - [ ] Run the release: `cargo run -p release` (defaults to a minor bump; pass `major`, `patch`, or an exact version to override). This bumps `Cargo.toml`, generates the changelog, publishes to crates.io, tags, and opens the merge PR. See [release/README.md](https://github.com/vectordotdev/vrl/blob/main/release/README.md) for details.
 - [ ] Review and merge the release PR opened by the tool.

--- a/release/src/changelog.rs
+++ b/release/src/changelog.rs
@@ -256,6 +256,24 @@ impl Changelog {
         Ok(new_content)
     }
 
+    /// Validate every fragment file currently on disk in `changelog.d/` —
+    /// what the release will consume. Unlike [`check_fragments`], this does
+    /// not diff against `origin/main`, so it works on a synced release branch
+    /// where no fragments are "newly added" but plenty exist to consume.
+    pub fn validate_fragments_on_disk(&self) -> Result<(), String> {
+        let paths = Self::read_fragment_dir(&self.changelog_dir())?;
+        if paths.is_empty() {
+            return Err(
+                "No changelog fragments found in changelog.d/ — nothing to release.".to_string(),
+            );
+        }
+        for path in &paths {
+            Self::parse_fragment(path)?;
+        }
+        println!("Validated {} changelog fragment(s).", paths.len());
+        Ok(())
+    }
+
     /// Validate changelog fragment filenames added on the current branch vs origin/main.
     pub fn check_fragments(&self) -> Result<(), String> {
         let output = std::process::Command::new("git")

--- a/release/src/main.rs
+++ b/release/src/main.rs
@@ -58,6 +58,74 @@ fn run(cmd: &str, args: &[&str], cwd: &Path) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+/// Check everything that can fail *before* we mutate git or files.
+///
+/// Any half-completed release run — commits made but publish/tag skipped — has to be
+/// unwound by hand, so it's cheap to be paranoid up front. Order the checks so the
+/// fastest / most likely to fail run first.
+fn preflight(root: &Path, new_version: &semver::Version) -> Result<(), String> {
+    println!("Running pre-flight checks...");
+
+    // Git: clean tree, on main, up-to-date with origin/main.
+    let status = run("git", &["status", "--porcelain"], root)?;
+    if !status.trim().is_empty() {
+        return Err(format!(
+            "Working tree is not clean. Commit or stash first:\n{status}"
+        ));
+    }
+    let branch = run("git", &["rev-parse", "--abbrev-ref", "HEAD"], root)?
+        .trim()
+        .to_string();
+    if branch != "main" {
+        return Err(format!(
+            "Must run release from `main` (currently on `{branch}`)."
+        ));
+    }
+    run("git", &["fetch", "origin", "main"], root)?;
+    let local = run("git", &["rev-parse", "main"], root)?.trim().to_string();
+    let remote = run("git", &["rev-parse", "origin/main"], root)?
+        .trim()
+        .to_string();
+    if local != remote {
+        return Err(format!(
+            "Local `main` ({local:.10}) is not in sync with `origin/main` ({remote:.10}). Pull first."
+        ));
+    }
+
+    // `gh` CLI authenticated (needed to open the PR).
+    run("gh", &["auth", "status"], root)
+        .map_err(|e| format!("`gh` is not authenticated. Run `gh auth login` first.\n{e}"))?;
+
+    // Every fragment currently in changelog.d/ must parse — that's what the
+    // release will consume. `check_fragments` is the PR-time validator that
+    // diffs against origin/main, so it would see zero additions on a synced
+    // release branch and abort here; don't use it for release-time validation.
+    changelog::Changelog::new(root).validate_fragments_on_disk()?;
+
+    // Version not already published.
+    crates_io::assert_not_published(new_version)?;
+
+    // Interactive `cargo login` runs last so the releaser only has to fetch a
+    // token once we know the automated checks pass. No crates.io endpoint
+    // accepts an API token in a non-mutating way, so we can't verify a stored
+    // token offline; refreshing it here guarantees the token about to be used
+    // is fresh and valid.
+    println!(
+        "\nGrab a token from https://crates.io/me — ensure the pasted token has publish permissions."
+    );
+    let status = Command::new("cargo")
+        .arg("login")
+        .current_dir(root)
+        .status()
+        .map_err(|e| format!("Failed to run `cargo login`: {e}"))?;
+    if !status.success() {
+        return Err(format!("`cargo login` failed (exit {status})."));
+    }
+
+    println!("\nPre-flight checks passed.\n");
+    Ok(())
+}
+
 fn repo_root() -> PathBuf {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     manifest_dir
@@ -92,7 +160,7 @@ fn release(version_arg: Option<&str>, dry_run: bool, issue: Option<&str>) -> Res
         return Ok(());
     }
 
-    crates_io::assert_not_published(&new_version)?;
+    preflight(&root, &new_version)?;
 
     let branch = format!("prepare-{new_version}-release");
     println!("\nCreating branch: {branch}");


### PR DESCRIPTION
## Summary

Move every "can this even work?" check to the top of the release flow so an aborted run never leaves a half-done state to unwind by hand.

### Motivation

The 0.34.0 release aborted at `cargo publish` because `cargo login` had not been run. By then the version bump and changelog commits were already made, and the remaining steps (tag, push, PR) had to be finished manually.

### New pre-flight flow

Automated checks first (fail fast on the cheap stuff), then the interactive login:

1. **Git state** — working tree clean, on `main`, in sync with `origin/main`.
2. **`gh auth status`** — PR creation depends on it.
3. **Changelog fragments on disk parse.**
4. **Target version is not already on crates.io.**
5. **Interactive `cargo login`** — releaser pastes a fresh publish-scoped token (see note below). Runs last so a wrong branch / dirty tree / bad fragment fails before the releaser has to fetch a token.

### On the auth step

Every crates.io endpoint that accepts an API token is either a mutation (publish, yank, owner add/remove) or a destructive delete (revoke). `/api/v1/me` and friends are `AuthCheck::only_cookie()` and reject tokens outright. So an offline "is my stored token still good" check isn't feasible. Instead, run `cargo login` interactively: releaser grabs a fresh publish-scoped token from https://crates.io/me and pastes it. Guarantees the token about to be used is valid; removes an entire class of "stored token expired / wrong scope" failures.

### Follow-up

- #1859 — checkpointing so a partial run (e.g. transient publish outage) can be resumed instead of unwound by hand.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## How did you test this PR?

- Built and clippy-clean on the release crate; existing tests pass.
- End-to-end run has to wait for the next release.

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## References

- Follow-up: #1859