### PR TITLE
fix(stdlib): fix inaccurate function documentation and round type_def

### DIFF
--- a/changelog.d/1862.fix.md
+++ b/changelog.d/1862.fix.md
@@ -1,0 +1,3 @@
+Fixed `round`'s type definition, which previously always claimed to return an integer even though it returns a float for float inputs.
+
+authors: thomasqueirozb

--- a/docs/generated/ceil.json
+++ b/docs/generated/ceil.json
@@ -29,7 +29,7 @@
       "float"
     ],
     "rules": [
-      "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise."
+      "Returns an integer if `value` is an integer. Returns a float otherwise, regardless of `precision`."
     ]
   },
   "examples": [

--- a/docs/generated/ceil.json
+++ b/docs/generated/ceil.json
@@ -29,7 +29,7 @@
       "float"
     ],
     "rules": [
-      "Returns an integer if `precision` is `0` (this is the default). Returns a float otherwise."
+      "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise."
     ]
   },
   "examples": [

--- a/docs/generated/floor.json
+++ b/docs/generated/floor.json
@@ -29,7 +29,7 @@
       "float"
     ],
     "rules": [
-      "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise."
+      "Returns an integer if `value` is an integer. Returns a float otherwise, regardless of `precision`."
     ]
   },
   "examples": [

--- a/docs/generated/floor.json
+++ b/docs/generated/floor.json
@@ -29,7 +29,7 @@
       "float"
     ],
     "rules": [
-      "Returns an integer if `precision` is `0` (this is the default). Returns a float otherwise."
+      "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise."
     ]
   },
   "examples": [

--- a/docs/generated/keys.json
+++ b/docs/generated/keys.json
@@ -18,7 +18,7 @@
       "array"
     ],
     "rules": [
-      "Returns an array of all the keys"
+      "Returns an array of all the keys."
     ]
   },
   "examples": [

--- a/docs/generated/parse_regex_all.json
+++ b/docs/generated/parse_regex_all.json
@@ -36,7 +36,7 @@
     ],
     "rules": [
       "Matches return all capture groups corresponding to the leftmost matches in the text.",
-      "Raises an error if no match is found."
+      "Returns an empty array if no matches are found."
     ]
   },
   "internal_failure_reasons": [

--- a/docs/generated/round.json
+++ b/docs/generated/round.json
@@ -29,7 +29,7 @@
       "float"
     ],
     "rules": [
-      "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise."
+      "Returns an integer if `value` is an integer. Returns a float otherwise, regardless of `precision`."
     ]
   },
   "examples": [

--- a/docs/generated/round.json
+++ b/docs/generated/round.json
@@ -29,7 +29,7 @@
       "float"
     ],
     "rules": [
-      "If `precision` is `0`, then an integer is returned, otherwise a float is returned."
+      "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise."
     ]
   },
   "examples": [

--- a/docs/generated/to_float.json
+++ b/docs/generated/to_float.json
@@ -22,7 +22,8 @@
       "If `value` is an integer, it will be returned as as a float.",
       "If `value` is a string, it must be the string representation of an float or else an error is raised.",
       "If `value` is a boolean, `0.0` is returned for `false` and `1.0` is returned for `true`.",
-      "If `value` is a timestamp, a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) with fractional seconds is returned."
+      "If `value` is a timestamp, a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) with fractional seconds is returned.",
+      "If `value` is null, `0.0` is returned."
     ]
   },
   "internal_failure_reasons": [

--- a/src/stdlib/ceil.rs
+++ b/src/stdlib/ceil.rs
@@ -57,7 +57,7 @@ impl Function for Ceil {
 
     fn return_rules(&self) -> &'static [&'static str] {
         &[
-            "Returns an integer if `precision` is `0` (this is the default). Returns a float otherwise.",
+            "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise.",
         ]
     }
 

--- a/src/stdlib/ceil.rs
+++ b/src/stdlib/ceil.rs
@@ -57,7 +57,7 @@ impl Function for Ceil {
 
     fn return_rules(&self) -> &'static [&'static str] {
         &[
-            "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise.",
+            "Returns an integer if `value` is an integer. Returns a float otherwise, regardless of `precision`.",
         ]
     }
 

--- a/src/stdlib/floor.rs
+++ b/src/stdlib/floor.rs
@@ -58,7 +58,7 @@ impl Function for Floor {
 
     fn return_rules(&self) -> &'static [&'static str] {
         &[
-            "Returns an integer if `precision` is `0` (this is the default). Returns a float otherwise.",
+            "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise.",
         ]
     }
 

--- a/src/stdlib/floor.rs
+++ b/src/stdlib/floor.rs
@@ -58,7 +58,7 @@ impl Function for Floor {
 
     fn return_rules(&self) -> &'static [&'static str] {
         &[
-            "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise.",
+            "Returns an integer if `value` is an integer. Returns a float otherwise, regardless of `precision`.",
         ]
     }
 

--- a/src/stdlib/keys.rs
+++ b/src/stdlib/keys.rs
@@ -27,7 +27,7 @@ impl Function for Keys {
     }
 
     fn return_rules(&self) -> &'static [&'static str] {
-        &["Returns an array of all the keys"]
+        &["Returns an array of all the keys."]
     }
 
     fn parameters(&self) -> &'static [Parameter] {

--- a/src/stdlib/parse_regex_all.rs
+++ b/src/stdlib/parse_regex_all.rs
@@ -67,7 +67,7 @@ impl Function for ParseRegexAll {
     fn return_rules(&self) -> &'static [&'static str] {
         &[
             "Matches return all capture groups corresponding to the leftmost matches in the text.",
-            "Raises an error if no match is found.",
+            "Returns an empty array if no matches are found.",
         ]
     }
 

--- a/src/stdlib/round.rs
+++ b/src/stdlib/round.rs
@@ -52,7 +52,9 @@ impl Function for Round {
     }
 
     fn return_rules(&self) -> &'static [&'static str] {
-        &["If `precision` is `0`, then an integer is returned, otherwise a float is returned."]
+        &[
+            "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise.",
+        ]
     }
 
     fn parameters(&self) -> &'static [Parameter] {

--- a/src/stdlib/round.rs
+++ b/src/stdlib/round.rs
@@ -53,7 +53,7 @@ impl Function for Round {
 
     fn return_rules(&self) -> &'static [&'static str] {
         &[
-            "Returns an integer if `value` is an integer or `precision` is `0`. Returns a float otherwise.",
+            "Returns an integer if `value` is an integer. Returns a float otherwise, regardless of `precision`.",
         ]
     }
 
@@ -115,8 +115,11 @@ impl FunctionExpression for RoundFn {
         round(precision, value)
     }
 
-    fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::integer().infallible()
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        match Kind::from(self.value.type_def(state)) {
+            v if v.is_float() || v.is_integer() => v.into(),
+            _ => Kind::integer().or_float().into(),
+        }
     }
 }
 
@@ -130,19 +133,19 @@ mod tests {
         down {
              args: func_args![value: 1234.2],
              want: Ok(1234.0),
-             tdef: TypeDef::integer().infallible(),
+             tdef: TypeDef::float(),
          }
 
         up {
              args: func_args![value: 1234.8],
              want: Ok(1235.0),
-             tdef: TypeDef::integer().infallible(),
+             tdef: TypeDef::float(),
          }
 
         integer {
              args: func_args![value: 1234],
              want: Ok(1234),
-             tdef: TypeDef::integer().infallible(),
+             tdef: TypeDef::integer(),
          }
 
         precision {
@@ -150,7 +153,7 @@ mod tests {
                               precision: 1
              ],
              want: Ok(1234.4),
-             tdef: TypeDef::integer().infallible(),
+             tdef: TypeDef::float(),
          }
 
         bigger_precision  {
@@ -158,7 +161,7 @@ mod tests {
                              precision: 4
             ],
             want: Ok(1234.5679),
-            tdef: TypeDef::integer().infallible(),
+            tdef: TypeDef::float(),
         }
 
         huge {
@@ -166,7 +169,7 @@ mod tests {
                               precision: 5
              ],
              want: Ok(9_876_543_210_123_456_789_098_765_432_101_234_567_890_987_654_321.987_65),
-             tdef: TypeDef::integer().infallible(),
+             tdef: TypeDef::float(),
          }
     ];
 }

--- a/src/stdlib/to_float.rs
+++ b/src/stdlib/to_float.rs
@@ -60,6 +60,7 @@ impl Function for ToFloat {
             "If `value` is a string, it must be the string representation of an float or else an error is raised.",
             "If `value` is a boolean, `0.0` is returned for `false` and `1.0` is returned for `true`.",
             "If `value` is a timestamp, a [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) with fractional seconds is returned.",
+            "If `value` is null, `0.0` is returned.",
         ]
     }
 


### PR DESCRIPTION
## Summary

Fixes several inaccurate or malformed doc strings in stdlib function definitions (ceil, floor, round, keys, parse_regex_all, to_float).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

NA

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

NA