### PR TITLE
chore(compiler): speed up typecheck for deep else-if ladders (remove quadratic complexity)

### DIFF
--- a/changelog.d/1865.breaking.md
+++ b/changelog.d/1865.breaking.md
@@ -1,0 +1,3 @@
+`IfStatement` now represents `else if` chains as a flat `arms: Vec<IfArm>` instead of nested `IfStatement` values in `else_block`; the public `predicate` and `if_block` fields are replaced by `arms`. Code that constructs or pattern-matches `IfStatement` must switch to the arms form. Programs and the `compile()` API are unaffected.
+
+authors: klondikedragon

--- a/changelog.d/1865.enhancement.md
+++ b/changelog.d/1865.enhancement.md
@@ -1,3 +1,3 @@
-Improve VRL compile time for programs with deep `else if` chains (`O(n^2)` to `O(n)` complexity over number of arms). Locals assigned in an `else if` **predicate** now remain visible after the chain (same as assignments in the first `if` predicate).
+Improve VRL compile time for programs with deep `else if` chains (`O(n^2)` to `O(n)` complexity over number of arms).
 
 authors: klondikedragon

--- a/changelog.d/1865.enhancement.md
+++ b/changelog.d/1865.enhancement.md
@@ -1,0 +1,3 @@
+Improve VRL compile time for programs with deep `else if` chains (`O(n^2)` to `O(n)` complexity over number of arms). Locals assigned in an `else if` **predicate** now remain visible after the chain (same as assignments in the first `if` predicate).
+
+authors: klondikedragon

--- a/examples/else_if_ladder_compile.rs
+++ b/examples/else_if_ladder_compile.rs
@@ -12,6 +12,8 @@
 //! `--env-width` / `--env-depth` / `--env-seed-fields` shape the starting event `Kind`
 //! (incoming schema), independent of the program text.
 
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
@@ -186,7 +188,10 @@ fn build_env_event_kind(width: usize, depth: usize, seed_limit: usize) -> Kind {
                 known.insert(Field::from("n"), kind);
             }
         } else {
-            known.insert(Field::from("n"), level(width, depth_left - 1, counter, limit));
+            known.insert(
+                Field::from("n"),
+                level(width, depth_left - 1, counter, limit),
+            );
         }
         Kind::object(Collection::from_parts(known, Kind::any()))
     }

--- a/examples/else_if_ladder_compile.rs
+++ b/examples/else_if_ladder_compile.rs
@@ -1,0 +1,357 @@
+//! VRL compile timing: synthetic else-if ladder and/or a real program file.
+//!
+//! ```text
+//! cargo run --release --example else_if_ladder_compile -- \
+//!   --arms 10,20,40,60 --fields 40
+//!
+//! cargo run --release --example else_if_ladder_compile -- \
+//!   --program PATH --env-width 8 --env-depth 4 --warmup 2 --repeat 7
+//! ```
+//!
+//! `--fields` is assigns per synthetic ladder arm.
+//! `--env-width` / `--env-depth` / `--env-seed-fields` shape the starting event `Kind`
+//! (incoming schema), independent of the program text.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+use std::time::Instant;
+
+use vrl::compiler::CompileConfig;
+use vrl::compiler::state::ExternalEnv;
+use vrl::value::Kind;
+use vrl::value::kind::{Collection, Field};
+
+fn usage() -> ! {
+    eprintln!(
+        "Usage:
+  else_if_ladder_compile [--arms N,N,...] [--fields F] [env opts] [--warmup W] [--repeat R]
+  else_if_ladder_compile --program PATH [env opts] [--warmup W] [--repeat R]
+
+  --arms             comma-separated else-if arm counts (default: 10,20,40,60,80)
+  --fields           assigns per synthetic ladder arm (default: 40)
+  --program          time compile of a VRL source file (skips synthetic ladder)
+  --env-width W      known siblings per spine level (default: 0 = ExternalEnv::default())
+  --env-depth D      spine nesting depth when width > 0 (default: 1)
+  --env-seed-fields N  max typed known slots along spine+stubs (default: all)
+  --warmup           discarded compiles before timing (default: 1)
+  --repeat           timed compiles; report min/median/max ms (default: 3)
+
+  Env Kind shape (width W, depth D): one spine path `.n.n.…` of length D; at each
+  level, W-1 sibling stubs `.s0…`. Cost O(D*W). Types cycle a fixed palette by index.
+"
+    );
+    process::exit(2);
+}
+
+fn parse_csv_usize(s: &str) -> Result<Vec<usize>, String> {
+    s.split(',')
+        .map(|p| {
+            p.trim()
+                .parse::<usize>()
+                .map_err(|_| format!("invalid usize in list: {p:?}"))
+        })
+        .collect()
+}
+
+struct Args {
+    arms: Vec<usize>,
+    fields: usize,
+    warmup: usize,
+    repeat: usize,
+    program: Option<PathBuf>,
+    env_width: usize,
+    env_depth: usize,
+    /// `None` = type every stub/leaf slot.
+    env_seed_fields: Option<usize>,
+}
+
+fn parse_args() -> Args {
+    let mut arms = vec![10, 20, 40, 60, 80];
+    let mut fields = 40;
+    let mut warmup = 1;
+    let mut repeat = 3;
+    let mut program = None;
+    let mut env_width = 0;
+    let mut env_depth = 1;
+    let mut env_seed_fields = None;
+
+    let mut argv = env::args().skip(1);
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--arms" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                arms = parse_csv_usize(&v).unwrap_or_else(|e| {
+                    eprintln!("{e}");
+                    usage();
+                });
+            }
+            "--fields" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                fields = v.parse().unwrap_or_else(|_| usage());
+            }
+            "--program" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                program = Some(PathBuf::from(v));
+            }
+            "--env-width" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                env_width = v.parse().unwrap_or_else(|_| usage());
+            }
+            "--env-depth" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                env_depth = v.parse().unwrap_or_else(|_| usage());
+            }
+            "--env-seed-fields" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                env_seed_fields = Some(v.parse().unwrap_or_else(|_| usage()));
+            }
+            "--warmup" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                warmup = v.parse().unwrap_or_else(|_| usage());
+            }
+            "--repeat" => {
+                let v = argv.next().unwrap_or_else(|| usage());
+                repeat = v.parse().unwrap_or_else(|_| usage());
+            }
+            "-h" | "--help" => usage(),
+            other => {
+                eprintln!("unknown arg: {other}");
+                usage();
+            }
+        }
+    }
+
+    if program.is_none() && (arms.is_empty() || fields == 0) {
+        eprintln!("--arms/--fields must be non-empty, or pass --program");
+        usage();
+    }
+    if repeat == 0 {
+        eprintln!("--repeat must be > 0");
+        usage();
+    }
+    if env_width > 0 && env_depth == 0 {
+        eprintln!("--env-depth must be > 0 when --env-width > 0");
+        usage();
+    }
+
+    Args {
+        arms,
+        fields,
+        warmup,
+        repeat,
+        program,
+        env_width,
+        env_depth,
+        env_seed_fields,
+    }
+}
+
+/// Deterministic leaf kinds for seeded env fields.
+fn palette_kind(index: usize) -> Kind {
+    match index % 6 {
+        0 => Kind::bytes(),
+        1 => Kind::integer(),
+        2 => Kind::float(),
+        3 => Kind::boolean(),
+        4 => Kind::null(),
+        _ => Kind::timestamp(),
+    }
+}
+
+fn take_typed(counter: &mut usize, limit: usize) -> Option<Kind> {
+    if *counter >= limit {
+        return None;
+    }
+    let kind = palette_kind(*counter);
+    *counter += 1;
+    Some(kind)
+}
+
+/// Spine `.n.n.…` of length `depth`, with `width - 1` sibling stubs `.s0…` at each level.
+/// Unknown fields remain `any`. Slot count is O(depth * width).
+fn build_env_event_kind(width: usize, depth: usize, seed_limit: usize) -> Kind {
+    fn level(width: usize, depth_left: usize, counter: &mut usize, limit: usize) -> Kind {
+        let mut known: BTreeMap<Field, Kind> = BTreeMap::new();
+        let stubs = width.saturating_sub(1);
+        for s in 0..stubs {
+            if let Some(kind) = take_typed(counter, limit) {
+                known.insert(Field::from(format!("s{s}")), kind);
+            }
+        }
+        if depth_left <= 1 {
+            if let Some(kind) = take_typed(counter, limit) {
+                known.insert(Field::from("n"), kind);
+            }
+        } else {
+            known.insert(Field::from("n"), level(width, depth_left - 1, counter, limit));
+        }
+        Kind::object(Collection::from_parts(known, Kind::any()))
+    }
+
+    level(width, depth, &mut 0, seed_limit)
+}
+
+fn build_external(args: &Args) -> ExternalEnv {
+    if args.env_width == 0 {
+        return ExternalEnv::default();
+    }
+    let seed_limit = args.env_seed_fields.unwrap_or(usize::MAX);
+    let event = build_env_event_kind(args.env_width, args.env_depth, seed_limit);
+    ExternalEnv::new_with_kind(event, Kind::object(Collection::any()))
+}
+
+fn env_label(args: &Args) -> String {
+    if args.env_width == 0 {
+        return "env=default".to_owned();
+    }
+    let seed = match args.env_seed_fields {
+        None => "all".to_owned(),
+        Some(n) => n.to_string(),
+    };
+    format!(
+        "env-width={} env-depth={} env-seed-fields={seed}",
+        args.env_width, args.env_depth
+    )
+}
+
+/// Nested `if / else if` ladder with the same field set on every arm.
+fn build_ladder(arm_count: usize, fields_per_arm: usize) -> String {
+    let mut out = String::with_capacity(arm_count * (80 + fields_per_arm * 40));
+    out.push_str("eid = int!(.eid)\n");
+
+    for i in 0..arm_count {
+        if i == 0 {
+            out.push_str(&format!("if eid == {i} {{\n"));
+        } else {
+            out.push_str(&format!("}} else if eid == {i} {{\n"));
+        }
+        for f in 0..fields_per_arm {
+            out.push_str(&format!("  ._itl.f{f} = \"a{i}_f{f}\"\n"));
+        }
+        out.push_str("  ._itl.class = \"NOTABLE\"\n");
+        out.push_str(&format!("  ._itl.arm = {i}\n"));
+    }
+    out.push_str("} else {\n");
+    for f in 0..fields_per_arm {
+        out.push_str(&format!("  ._itl.f{f} = \"else_f{f}\"\n"));
+    }
+    out.push_str("  ._itl.class = \"CONTEXT\"\n");
+    out.push_str("  ._itl.arm = -1\n");
+    out.push_str("}\n");
+    out.push_str(".\n");
+    out
+}
+
+fn compile_once(src: &str, fns: &[Box<dyn vrl::compiler::Function>], external: &ExternalEnv) {
+    match vrl::compiler::compile_with_external(src, fns, external, CompileConfig::default()) {
+        Ok(_) => {}
+        Err(diags) => {
+            eprintln!("compile failed:\n{diags:?}");
+            process::exit(1);
+        }
+    }
+}
+
+fn median_ms(samples: &mut [f64]) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = samples.len();
+    if n % 2 == 1 {
+        samples[n / 2]
+    } else {
+        (samples[n / 2 - 1] + samples[n / 2]) / 2.0
+    }
+}
+
+fn time_src(
+    label: &str,
+    src: &str,
+    warmup: usize,
+    repeat: usize,
+    fns: &[Box<dyn vrl::compiler::Function>],
+    external: &ExternalEnv,
+) {
+    let src_bytes = src.len();
+    let else_ifs = src.matches("else if").count();
+
+    for _ in 0..warmup {
+        compile_once(src, fns, external);
+    }
+
+    let mut samples = Vec::with_capacity(repeat);
+    for _ in 0..repeat {
+        let t0 = Instant::now();
+        compile_once(src, fns, external);
+        samples.push(t0.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    let min = samples.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = samples.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let med = median_ms(&mut samples);
+
+    println!(
+        "{label}  src_bytes={src_bytes}  else_if≈{else_ifs}  warmup={warmup}  repeat={repeat}"
+    );
+    println!("  min_ms={min:.1}  med_ms={med:.1}  max_ms={max:.1}");
+}
+
+fn main() {
+    let args = parse_args();
+    let fns = vrl::stdlib::all();
+    let external = build_external(&args);
+    let env = env_label(&args);
+
+    if let Some(path) = &args.program {
+        let src = fs::read_to_string(path).unwrap_or_else(|e| {
+            eprintln!("read {}: {e}", path.display());
+            process::exit(1);
+        });
+        time_src(
+            &format!("program {}  {env}", path.display()),
+            &src,
+            args.warmup,
+            args.repeat,
+            &fns,
+            &external,
+        );
+        return;
+    }
+
+    println!(
+        "else-if ladder compile (fields/arm={}, {env}, warmup={}, repeat={})",
+        args.fields, args.warmup, args.repeat
+    );
+    println!(
+        "{:>6}  {:>10}  {:>10}  {:>10}  {:>10}  {:>12}",
+        "arms", "src_bytes", "min_ms", "med_ms", "max_ms", "ms/arm^2"
+    );
+
+    for &n in &args.arms {
+        let src = build_ladder(n, args.fields);
+        let src_bytes = src.len();
+
+        for _ in 0..args.warmup {
+            compile_once(&src, &fns, &external);
+        }
+
+        let mut samples = Vec::with_capacity(args.repeat);
+        for _ in 0..args.repeat {
+            let t0 = Instant::now();
+            compile_once(&src, &fns, &external);
+            samples.push(t0.elapsed().as_secs_f64() * 1000.0);
+        }
+
+        let min = samples.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max = samples.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let med = median_ms(&mut samples);
+        let per_n2 = if n > 0 {
+            med / ((n as f64) * (n as f64))
+        } else {
+            0.0
+        };
+
+        println!("{n:>6}  {src_bytes:>10}  {min:>10.1}  {med:>10.1}  {max:>10.1}  {per_n2:>12.4}");
+    }
+}

--- a/lib/tests/tests/expressions/if_statement/else_braced_if_predicate_local_escape.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_braced_if_predicate_local_escape.vrl
@@ -1,0 +1,23 @@
+# result:
+#
+# error[E701]: call to undefined variable
+#    ┌─ :10:1
+#    │
+# 10 │ x
+#    │ ^
+#    │ │
+#    │ undefined variable
+#    │ did you mean "null"?
+#    │
+#    = see language documentation at https://vrl.dev
+#    = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+# Sole-stmt else { if } peels to the same multi-arm shape as else if; lock peel + non-escape together.
+if false {
+  null
+} else {
+  if (x = 1; true) {
+    null
+  }
+}
+x

--- a/lib/tests/tests/expressions/if_statement/else_if_body_local_escape.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_if_body_local_escape.vrl
@@ -12,11 +12,11 @@
 #   = see language documentation at https://vrl.dev
 #   = try your code in the VRL REPL, learn more at https://vrl.dev/examples
 
-# Locals first assigned in an else-if predicate must not escape the chain
-# (same as nested else { if } Block scope before flatten).
+# Else-if body-only local must not escape (merged arm state must not leak body bindings after flatten).
 if false {
   null
-} else if (x = 1; true) {
+} else if (true) {
+  x = 1
   null
 }
 x

--- a/lib/tests/tests/expressions/if_statement/else_if_body_local_in_later_predicate.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_if_body_local_in_later_predicate.vrl
@@ -1,0 +1,22 @@
+# result:
+#
+# error[E701]: call to undefined variable
+#   ┌─ :6:12
+#   │
+# 6 │ } else if (x > 0) {
+#   │            ^
+#   │            │
+#   │            undefined variable
+#   │            did you mean "null"?
+#   │
+#   = see language documentation at https://vrl.dev
+#   = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+# Body locals stay in arm scope (flatten control: fails typing the later pred, not via post-chain strip).
+if false {
+  x = 1
+  null
+} else if (x > 0) {
+  null
+}
+null

--- a/lib/tests/tests/expressions/if_statement/else_if_predicate_local_escape.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_if_predicate_local_escape.vrl
@@ -1,0 +1,10 @@
+# result: 1
+
+# Locals assigned in an else-if predicate are visible after the chain
+# (same as the first if predicate; flatten peels nested else { if }).
+if false {
+  null
+} else if (x = 1; true) {
+  null
+}
+x

--- a/lib/tests/tests/expressions/if_statement/else_if_predicate_locals.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_if_predicate_locals.vrl
@@ -1,0 +1,124 @@
+# result: true
+
+# Flattened else-if local semantics (compile-success cases).
+# Complements if_predicate_local_escape / else_if_predicate_local_escape
+# and body-assign coverage in if_else_local_assignment / if_local_assignment.
+
+# Later predicate reads a local introduced in an earlier predicate.
+r_pred = if false {
+  null
+} else if (x = 5; x < 0) {
+  x
+} else if (y = 6; y > x) {
+  y
+} else {
+  10
+}
+assert!(r_pred == 6)
+
+# Later arm body reads a local introduced in an earlier predicate.
+r_body = if false {
+  null
+} else if (x = 5; false) {
+  null
+} else if (true) {
+  x
+} else {
+  10
+}
+assert!(r_body == 5)
+
+# Final else reads a local introduced in a prior predicate
+# (all predicates ran and were false).
+r_else = if false {
+  null
+} else if (x = 5; false) {
+  null
+} else {
+  x
+}
+assert!(r_else == 5)
+
+# Third arm body uses locals from two earlier predicates.
+r_third = if false {
+  null
+} else if (x = 1; false) {
+  null
+} else if (y = 2; false) {
+  null
+} else if (true) {
+  x + y
+} else {
+  0
+}
+assert!(r_third == 3)
+
+# Peeled sole-stmt else { if } matches else if for cross-arm predicate locals.
+r_braced = if false {
+  null
+} else {
+  if (x = 5; x < 0) {
+    x
+  } else if (y = 6; y > x) {
+    y
+  } else {
+    10
+  }
+}
+assert!(r_braced == 6)
+
+# Multi-stmt else (not peeled): predicate local usable later in the same else block.
+r_mid_else = if false {
+  null
+} else {
+  if (x = 7; false) {
+    null
+  }
+  x
+}
+assert!(r_mid_else == 7)
+
+# First-predicate local remains visible after an else-if chain
+# (first predicate always runs; also guards against stripping too early).
+if (z = 1; false) {
+  null
+} else if (false) {
+  null
+} else {
+  null
+}
+assert!(z == 1)
+
+# Pre-existing local reassigned in else-if predicate: different type, arm taken.
+b = 1
+if false {
+  null
+} else if (b = 0.5; true) {
+  null
+}
+assert!(b == 0.5)
+assert!(type_def(b) == {"integer": true, "float": true})
+
+# Pre-existing local reassigned in else-if predicate: different type, arm not taken.
+# c == 1: skipped predicate is not evaluated at runtime.
+# type_def union: that predicate is still typechecked (side effects in the type env).
+c = 1
+if true {
+  null
+} else if (c = "x"; true) {
+  null
+}
+assert!(c == 1)
+assert!(type_def(c) == {"integer": true, "bytes": true})
+
+# Pre-existing local updated in first pred and again in else-if pred.
+e = 1
+if (e = 2; false) {
+  null
+} else if (e = "hi"; true) {
+  null
+}
+assert!(e == "hi")
+assert!(type_def(e) == {"integer": true, "bytes": true})
+
+true

--- a/lib/tests/tests/expressions/if_statement/else_if_third_pred_local_escape.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_if_third_pred_local_escape.vrl
@@ -1,0 +1,25 @@
+# result:
+#
+# error[E701]: call to undefined variable
+#    ┌─ :12:1
+#    │
+# 12 │ x
+#    │ ^
+#    │ │
+#    │ undefined variable
+#    │ did you mean "null"?
+#    │
+#    = see language documentation at https://vrl.dev
+#    = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+# Third-or-later pred local must not escape, with a final else (2nd-arm/no-else: else_if_predicate_local_escape).
+if false {
+  null
+} else if (false) {
+  null
+} else if (x = 1; true) {
+  null
+} else {
+  null
+}
+x

--- a/lib/tests/tests/expressions/if_statement/else_multistmt_predicate_local_escape.vrl
+++ b/lib/tests/tests/expressions/if_statement/else_multistmt_predicate_local_escape.vrl
@@ -1,0 +1,24 @@
+# result:
+#
+# error[E701]: call to undefined variable
+#    ┌─ :11:1
+#    │
+# 11 │ x
+#    │ ^
+#    │ │
+#    │ undefined variable
+#    │ did you mean "null"?
+#    │
+#    = see language documentation at https://vrl.dev
+#    = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+# Multi-stmt else is not peeled: mid-else x OK; after outer if fails via Block scope (not flatten strip).
+if false {
+  null
+} else {
+  if (x = 1; false) {
+    null
+  }
+  x
+}
+x

--- a/lib/tests/tests/expressions/if_statement/if_predicate_local_escape.vrl
+++ b/lib/tests/tests/expressions/if_statement/if_predicate_local_escape.vrl
@@ -1,0 +1,7 @@
+# result: 1
+
+# Locals assigned in an if predicate are visible after the if.
+if (x = 1; true) {
+  null
+}
+x

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -4,7 +4,7 @@ use crate::compiler::{
     CompileConfig, Function, Program, TypeDef,
     expression::{
         Abort, Array, Assignment, Block, Container, Expr, Expression, FunctionArgument,
-        FunctionCall, Group, IfStatement, Literal, Noop, Not, Object, Op, Predicate, Query, Return,
+        FunctionCall, Group, IfArm, IfStatement, Literal, Noop, Not, Object, Op, Predicate, Query, Return,
         Target, Unary, Variable, assignment, function_call, literal, predicate, query,
     },
     parser::ast::RootExpr,
@@ -384,32 +384,37 @@ impl<'a> Compiler<'a> {
             else_node,
         } = node.into_inner();
 
+        // Peel parser-emitted `else { if ... }` chains into a flat arm list so
+        // typecheck visits each arm once (nested form re-walked suffixes).
+        let (ast_arms, final_else) = flatten_ast_else_if_chain(predicate, if_node, else_node);
+
         let original_state = state.clone();
+        let mut pred_state = original_state.clone();
+        let mut arms = Vec::with_capacity(ast_arms.len());
 
-        let predicate = self
-            .compile_predicate(predicate, state)?
-            .map_err(|err| self.diagnostics.push(Box::new(err)))
-            .ok()?;
+        for (predicate, if_node) in ast_arms {
+            *state = pred_state.clone();
 
-        let after_predicate_state = state.clone();
+            let predicate = self
+                .compile_predicate(predicate, state)?
+                .map_err(|err| self.diagnostics.push(Box::new(err)))
+                .ok()?;
 
-        let if_block = self.compile_block(if_node, state)?;
+            pred_state = state.clone();
+            let block = self.compile_block(if_node, state)?;
+            arms.push(IfArm { predicate, block });
+        }
 
-        let else_block = if let Some(else_node) = else_node {
-            *state = after_predicate_state;
+        let else_block = if let Some(else_node) = final_else {
+            *state = pred_state;
             Some(self.compile_block(else_node, state)?)
         } else {
             None
         };
 
-        let if_statement = IfStatement {
-            predicate,
-            if_block,
-            else_block,
-        };
+        let if_statement = IfStatement::new(arms, else_block);
 
-        // The current state is from one of the branches. Restore it and calculate
-        // the type state from the full "if statement" expression.
+        // Restore and calculate type state from the full flat if expression once.
         *state = original_state;
         if_statement.apply_type_info(state);
         Some(if_statement)
@@ -944,5 +949,45 @@ impl<'a> Compiler<'a> {
         };
 
         self.skip_missing_query_target.push(query);
+    }
+}
+
+/// Peel parser `else { if ... }` nesting into a flat list of arms.
+///
+/// The VRL parser builds `else if` as `else` wrapping a block that contains a
+/// single nested `if`. Walking that nest during compile/typecheck re-visits
+/// suffixes and is quadratic in arm count.
+fn flatten_ast_else_if_chain(
+    predicate: Node<ast::Predicate>,
+    if_node: Node<ast::Block>,
+    mut else_node: Option<Node<ast::Block>>,
+) -> (
+    Vec<(Node<ast::Predicate>, Node<ast::Block>)>,
+    Option<Node<ast::Block>>,
+) {
+    let mut arms = vec![(predicate, if_node)];
+
+    loop {
+        let Some(else_block) = else_node.take() else {
+            return (arms, None);
+        };
+
+        let is_else_if = matches!(
+            else_block.inner().0.as_slice(),
+            [stmt] if matches!(stmt.inner(), ast::Expr::IfStatement(_))
+        );
+
+        if !is_else_if {
+            return (arms, Some(else_block));
+        }
+
+        let mut stmts = else_block.into_inner().into_inner();
+        let only = stmts.pop().expect("checked single stmt");
+        let ast::Expr::IfStatement(inner) = only.into_inner() else {
+            unreachable!("checked IfStatement");
+        };
+        let inner = inner.into_inner();
+        arms.push((inner.predicate, inner.if_node));
+        else_node = inner.else_node;
     }
 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -4,8 +4,8 @@ use crate::compiler::{
     CompileConfig, Function, Program, TypeDef,
     expression::{
         Abort, Array, Assignment, Block, Container, Expr, Expression, FunctionArgument,
-        FunctionCall, Group, IfArm, IfStatement, Literal, Noop, Not, Object, Op, Predicate, Query, Return,
-        Target, Unary, Variable, assignment, function_call, literal, predicate, query,
+        FunctionCall, Group, IfArm, IfStatement, Literal, Noop, Not, Object, Op, Predicate, Query,
+        Return, Target, Unary, Variable, assignment, function_call, literal, predicate, query,
     },
     parser::ast::RootExpr,
     program::ProgramInfo,
@@ -952,6 +952,11 @@ impl<'a> Compiler<'a> {
     }
 }
 
+type FlattenedElseIfChain = (
+    Vec<(Node<ast::Predicate>, Node<ast::Block>)>,
+    Option<Node<ast::Block>>,
+);
+
 /// Peel parser `else { if ... }` nesting into a flat list of arms.
 ///
 /// The VRL parser builds `else if` as `else` wrapping a block that contains a
@@ -961,10 +966,7 @@ fn flatten_ast_else_if_chain(
     predicate: Node<ast::Predicate>,
     if_node: Node<ast::Block>,
     mut else_node: Option<Node<ast::Block>>,
-) -> (
-    Vec<(Node<ast::Predicate>, Node<ast::Block>)>,
-    Option<Node<ast::Block>>,
-) {
+) -> FlattenedElseIfChain {
     let mut arms = vec![(predicate, if_node)];
 
     loop {

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -12,7 +12,7 @@ pub use function::FunctionExpression;
 pub use function_argument::FunctionArgument;
 pub use function_call::FunctionCall;
 pub use group::Group;
-pub use if_statement::IfStatement;
+pub use if_statement::{IfArm, IfStatement};
 pub use literal::Literal;
 pub use noop::Noop;
 pub use not::Not;

--- a/src/compiler/expression/if_statement.rs
+++ b/src/compiler/expression/if_statement.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::value::Value;
+use crate::value::{Kind, Value};
 
 use crate::compiler::state::{TypeInfo, TypeState};
 use crate::compiler::{
@@ -10,69 +10,103 @@ use crate::compiler::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct IfStatement {
+pub struct IfArm {
     pub predicate: Predicate,
-    pub if_block: Block,
+    pub block: Block,
+}
+
+/// `if` / `else if` / `else` as a flat multi-arm node.
+///
+/// The parser still emits nested `else { if ... }` for `else if`, but the compiler
+/// peels that chain into [`IfStatement::arms`] so typecheck is O(arms) instead of
+/// re-walking nested suffixes (quadratic in arm count).
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfStatement {
+    pub arms: Vec<IfArm>,
     pub else_block: Option<Block>,
+}
+
+impl IfStatement {
+    #[must_use]
+    pub fn new(arms: Vec<IfArm>, else_block: Option<Block>) -> Self {
+        assert!(!arms.is_empty(), "if statement requires at least one arm");
+        Self { arms, else_block }
+    }
 }
 
 impl Expression for IfStatement {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let predicate = self.predicate.resolve(ctx)?.try_boolean()?;
-
-        if predicate {
-            self.if_block.resolve(ctx)
-        } else {
-            self.else_block
-                .as_ref()
-                .map_or(Ok(Value::Null), |block| block.resolve(ctx))
+        for arm in &self.arms {
+            let predicate = arm.predicate.resolve(ctx)?.try_boolean()?;
+            if predicate {
+                return arm.block.resolve(ctx);
+            }
         }
+
+        self.else_block
+            .as_ref()
+            .map_or(Ok(Value::Null), |block| block.resolve(ctx))
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {
-        let mut state = state.clone();
-        let predicate_info = self.predicate.apply_type_info(&mut state);
+        // Match nested else-if semantics: arm i is typed after predicates 0..=i
+        // have been applied (previous predicates ran and were false at runtime,
+        // but their type-level side effects still apply).
+        let mut running = state.clone();
+        let mut returns = Kind::never();
+        let mut arm_states: Vec<TypeState> = Vec::with_capacity(self.arms.len());
+        let mut result_def: Option<crate::compiler::TypeDef> = None;
 
-        let if_info = self.if_block.type_info(&state);
+        for arm in &self.arms {
+            let predicate_info = arm.predicate.apply_type_info(&mut running);
+            returns.merge_keep(predicate_info.returns().clone(), false);
 
-        if let Some(else_block) = &self.else_block {
-            let else_info = else_block.type_info(&state);
-
-            // final state will be from either the "if" or "else" block, but not the original
-            let final_state = if_info.state.merge(else_info.state);
-
-            // result is from either "if" or the "else" block
-            let mut result = if_info.result.union(else_info.result);
-
-            // predicate can also return
-            result
-                .returns_mut()
-                .merge_keep(predicate_info.returns().clone(), false);
-
-            TypeInfo::new(final_state, result)
-        } else {
-            // state changes from the "if block" are optional, so merge it with the original
-            let final_state = if_info.state.merge(state);
-
-            // if the predicate is false, "null" is returned.
-            let mut result = if_info.result.or_null();
-
-            // predicate can also return
-            result
-                .returns_mut()
-                .merge_keep(predicate_info.returns().clone(), false);
-
-            TypeInfo::new(final_state, result)
+            let arm_info = arm.block.type_info(&running);
+            result_def = Some(match result_def {
+                None => arm_info.result,
+                Some(prev) => prev.union(arm_info.result),
+            });
+            arm_states.push(arm_info.state);
         }
+
+        let mut result = result_def.expect("at least one arm");
+
+        let final_state = if let Some(else_block) = &self.else_block {
+            let else_info = else_block.type_info(&running);
+            result = result.union(else_info.result);
+
+            arm_states
+                .into_iter()
+                .fold(else_info.state, |acc, arm_state| acc.merge(arm_state))
+        } else {
+            // All predicates false → null, and state is the post-predicate state
+            // merged with every arm (same as nested `if` without `else`).
+            result = result.or_null();
+            arm_states
+                .into_iter()
+                .fold(running, |acc, arm_state| acc.merge(arm_state))
+        };
+
+        result.returns_mut().merge_keep(returns, false);
+        TypeInfo::new(final_state, result)
     }
 }
 
 impl fmt::Display for IfStatement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut arms = self.arms.iter();
+        let first = arms.next().expect("at least one arm");
         f.write_str("if ")?;
-        self.predicate.fmt(f)?;
+        first.predicate.fmt(f)?;
         f.write_str(" ")?;
-        self.if_block.fmt(f)?;
+        first.block.fmt(f)?;
+
+        for arm in arms {
+            f.write_str(" else if ")?;
+            arm.predicate.fmt(f)?;
+            f.write_str(" ")?;
+            arm.block.fmt(f)?;
+        }
 
         if let Some(alt) = &self.else_block {
             f.write_str(" else")?;

--- a/src/compiler/expression/if_statement.rs
+++ b/src/compiler/expression/if_statement.rs
@@ -27,6 +27,9 @@ pub struct IfStatement {
 }
 
 impl IfStatement {
+    /// # Panics
+    ///
+    /// Panics if `arms` is empty.
     #[must_use]
     pub fn new(arms: Vec<IfArm>, else_block: Option<Block>) -> Self {
         assert!(!arms.is_empty(), "if statement requires at least one arm");
@@ -84,14 +87,12 @@ impl Expression for IfStatement {
 
             arm_states
                 .into_iter()
-                .fold(else_info.state, |acc, arm_state| acc.merge(arm_state))
+                .fold(else_info.state, TypeState::merge)
         } else {
             // All predicates false → null, and state is the post-predicate state
             // merged with every arm (same as nested `if` without `else`).
             result = result.or_null();
-            arm_states
-                .into_iter()
-                .fold(running, |acc, arm_state| acc.merge(arm_state))
+            arm_states.into_iter().fold(running, TypeState::merge)
         };
 
         // Flattened else-if peels parser `else { if }` wrappers. Those Blocks

--- a/src/compiler/expression/if_statement.rs
+++ b/src/compiler/expression/if_statement.rs
@@ -56,10 +56,17 @@ impl Expression for IfStatement {
         let mut returns = Kind::never();
         let mut arm_states: Vec<TypeState> = Vec::with_capacity(self.arms.len());
         let mut result_def: Option<crate::compiler::TypeDef> = None;
+        // Locals present after arm 0's predicate (inbound + first-pred assigns).
+        // Used below to drop bindings first introduced by later predicates.
+        let mut locals_after_first_predicate = None;
 
         for arm in &self.arms {
             let predicate_info = arm.predicate.apply_type_info(&mut running);
             returns.merge_keep(predicate_info.returns().clone(), false);
+
+            if locals_after_first_predicate.is_none() {
+                locals_after_first_predicate = Some(running.local.clone());
+            }
 
             let arm_info = arm.block.type_info(&running);
             result_def = Some(match result_def {
@@ -71,7 +78,7 @@ impl Expression for IfStatement {
 
         let mut result = result_def.expect("at least one arm");
 
-        let final_state = if let Some(else_block) = &self.else_block {
+        let mut final_state = if let Some(else_block) = &self.else_block {
             let else_info = else_block.type_info(&running);
             result = result.union(else_info.result);
 
@@ -86,6 +93,16 @@ impl Expression for IfStatement {
                 .into_iter()
                 .fold(running, |acc, arm_state| acc.merge(arm_state))
         };
+
+        // Flattened else-if peels parser `else { if }` wrappers. Those Blocks
+        // used `apply_child_scope`, so locals first assigned in a later
+        // predicate did not escape the chain. Re-apply that rule: keep/merge
+        // updates to locals that already existed after arm 0's predicate;
+        // drop bindings introduced only by later predicates (they are not
+        // definite when an earlier arm matched).
+        if let Some(baseline) = locals_after_first_predicate {
+            final_state.local = baseline.apply_child_scope(final_state.local);
+        }
 
         result.returns_mut().merge_keep(returns, false);
         TypeInfo::new(final_state, result)

--- a/src/compiler/expression/op.rs
+++ b/src/compiler/expression/op.rs
@@ -443,7 +443,7 @@ mod tests {
         Opcode::{Add, And, Div, Eq, Err, Ge, Gt, Le, Lt, Mul, Ne, Or, Sub},
     };
 
-    use crate::compiler::expression::{Block, IfStatement, Literal, Predicate, Variable};
+    use crate::compiler::expression::{Block, IfArm, IfStatement, Literal, Predicate, Variable};
     use crate::test_type_def;
 
     use super::*;
@@ -843,11 +843,13 @@ mod tests {
         or_nullable {
             expr: |_| Op {
                 lhs: Box::new(
-                    IfStatement {
-                        predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
-                        if_block: Block::new_scoped(vec![Literal::from("string").into()]),
-                        else_block: None,
-                    }.into()),
+                    IfStatement::new(
+                        vec![IfArm {
+                            predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
+                            block: Block::new_scoped(vec![Literal::from("string").into()]),
+                        }],
+                        None,
+                    ).into()),
                 rhs: Box::new(Literal::from("another string").into()),
                 opcode: Or,
             },
@@ -857,11 +859,13 @@ mod tests {
         or_not_nullable {
             expr: |_| Op {
                 lhs: Box::new(
-                    IfStatement {
-                        predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
-                        if_block: Block::new_scoped(vec![Literal::from("string").into()]),
-                        else_block:  Some(Block::new_scoped(vec![Literal::from(42).into()]))
-                }.into()),
+                    IfStatement::new(
+                        vec![IfArm {
+                            predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
+                            block: Block::new_scoped(vec![Literal::from("string").into()]),
+                        }],
+                        Some(Block::new_scoped(vec![Literal::from(42).into()])),
+                    ).into()),
                 rhs: Box::new(Literal::from("another string").into()),
                 opcode: Or,
             },


### PR DESCRIPTION
## Summary

Hi! I 💖 vector and have been using it for many years. thank you!

This PR speeds up VRL **compile / typecheck** for programs with long nested `else if` chains by removing O(n^2) behavior for this case.

**How we discovered it**: We're using VRL to classify events in complex ways, which means some of our VRL has long else-if chains (40-60+ arms in several places). Our test suite (which runs validate over each VRL file + exercises data flow) went from a few seconds total to minutes as we've developed more VRL files. We found vector taking a long time (8+ seconds) to validate/compile some of our VRL files. Profiling pointed at `Expression::apply_type_info` / `IfStatement` / `Kind` / `TypeState` / `LocalEnv` clone and merge.

After these changes, these same VRL files validate/compile an order of magnitude faster (**~8s to ~0.8s**), taking our overall test suite run back from minutes to seconds.

While VRL compile-time is a one-time cost at startup, it's single-threaded and with our VRL, machines were taking 30+ seconds from vector startup before processing events. This removes that long delay.

I've contributed a smaller PR in the past, but this is my first time digging in to the compiler in VRL... I'm happy to adjust and discuss!

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No (no longer breaking after made further updates to PR)

## Semantics note

After some updates to the PR, there are no changes to semantics. Additional tests were added to increase coverage of semantics for edge cases around if-else-if chains and related.

## Problem

* The parser converts `else if` to nested `else { if ... }`.
* `IfStatement::type_info` clones `TypeState`, typechecks both sides, then merges.
* Each nest re-walks the remaining ladder and deep-clones / merges large `Kind` trees and local bindings, so cost grows O(n^2) rather than a single linear pass over arms (O(n)).
* Clones of certain large structures in the type check phase are expensive, causing further slowdown.

## Approach

Ordered commits:

1. **Tests** for if / else-if **predicate local escape** (documents intended semantics; else-if test alone is red until flatten).
2. **Flatten** parser `else { if ... }` into a multi-arm `IfStatement` at compile so each arm is typechecked once. Main benefit that solves quadratic behavior.
3. **In-place** exact object/array `Kind` inserts and assignment type updates (avoid deep-clone on every nested write).
4. **`Arc` + COW** for `Collection` known maps.
5. Compile **timing example** (`examples/else_if_ladder_compile.rs`) with ladder + `--program` and `--env-width` / `--env-depth` knobs.
6. **`Arc` + COW** for `LocalEnv` bindings (this commit further speeds up ~2.7× on a large `--program` workload in that example driver, on top of the earlier commits).
7. (pr fragment)
8. **Fix to make semantics the same as before**: strip later else-if predicate-assigned locals after chain. After flattening, re-apply `apply_child_scope` from the post-arm-0 local env so bindings first introduced in later predicates are not definite after the chain (restoring nested `else { if }` Block semantics).

## Benchmarks

Timings below are from my local release builds of `examples/else_if_ladder_compile`

### Synthetic benchmark

```bash
cargo run --release --example else_if_ladder_compile -- \
  --arms 5,10,20,40,60 --fields 40 --warmup 1 --repeat 3
```

Performance after primary fix of removing quadratic complexity:

| arms | med_ms before any fix | med_ms after flatten | speedup |
|-----:|----------------------:|---------------------:|--------:|
| 5 | 27 | 13 | ~2× |
| 10 | 73 | 25 | ~3× |
| 20 | 251 | 46 | ~5× |
| 40 | 890 | 94 | ~9× |
| 60 | **2003** | **147** | **~13×** |

After doing in-place mutations of `Kind` plus cheap clones of `Collection` and `LocalEnv` (via `Arc`), the 60 arm test drops to **med_ms=49.4**:

```text
$ cargo run --release --example else_if_ladder_compile -- --arms 5,10,20,40,60 --fields 40 --warmup 1 --repeat 3
else-if ladder compile (fields/arm=40, env=default, warmup=1, repeat=3)
  arms   src_bytes      min_ms      med_ms      max_ms      ms/arm^2
     5        5861         3.5         3.6         6.1        0.1449
    10       10676         6.5         8.1         8.3        0.0811
    20       20726        12.9        15.0        15.1        0.0376
    40       40826        33.4        34.4        36.0        0.0215
    60       60926        47.4        49.4        50.0        0.0137
```

So approximately a 40x speedup for the 60-arm case before to final after. The performance is also the same after the 8th commit.

Synthentic benchmarks are interesting, but how about a real-world case...

### End-to-end Vector validate (`bench-vrl-runtime.py`)

Our CI harness in one of its steps uses vector validate over all of VRL scripts. We exposed this piece of it to benchmark this piece (with our large VRL it was causing big slowdowns). We built vector 0.57 with our branch cherry-picked to the version of VRL paired with 0.57, and compared it to stock vector on my Linux system (was version 0.56, sorry it's not quite the same, I could re-run if you want; other systems where I'm running 0.57 show almost identical behavior though, and the profiling data showed the hotspot was the type checking and VRL synthetic benchmarks confirm that):

Our bench-vrl-runtime.py isn't part of the PR, it's something we wrote to interface with our VRL CI.

Same harness flags; PATH selects the Vector binary.

**Stock** (`/usr/bin/vector` **0.56.0** release on this machine):

```bash
PATH=/usr/bin:$PATH python3 tools/bench-vrl-runtime.py \
  --scenario mix --events 1 --arms full --work /tmp/sl-vrl-runtime-bench
```

```text
corpus /tmp/sl-vrl-runtime-bench/mix-1.ndjson lines=1 bytes=548 from security-mix.ndjson
validate cfg-no_vrl.yaml: 0.07s
validate cfg-thin_sec.yaml: 8.13s
validate cfg-full.yaml: 8.07s
```

**Patched** (workspace Vector **0.57.0** release build pinned to this VRL):

```bash
PATH=~/itl/workspace/vector/target/release:$PATH python3 tools/bench-vrl-runtime.py \
  --scenario mix --events 1 --arms full --work /tmp/sl-bench-patched-rel
```

```text
corpus /tmp/sl-bench-patched-rel/mix-1.ndjson lines=1 bytes=548 from security-mix.ndjson
validate cfg-no_vrl.yaml: 0.17s
validate cfg-thin_sec.yaml: 0.97s
validate cfg-full.yaml: 0.79s
```

So `cfg-full` validate **~8.07s → ~0.79s** on that A/B.

## How did you test this PR?

- [x] `make all` green
- [x] New unit tests:  eight `expressions/if_statement` files: first-`if` predicate escape, an assert-heavy success file for cross-arm / type-merge / short-circuit cases, and E701 goldens for else-if pred escape, braced `else { if }`, else-if body escape, body-->later-pred isolation, multi-stmt else, and third-arm pred + final `else`
- [x] Synthetic benchmark driver `else_if_ladder_compile`
- [x] Benchmarks of VRL integrated into vector with our real-world VRL workload
- [x] Full CI suite with modified vector over our corpus of known-in--known-out --> no change

## Does this PR include user facing changes?

- [x] Yes (big perf speedup). Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## AI disclosure

I used Cursor Grok 4.5 to help develop this PR (understanding the compiler code base, developing a strategy, writing code and tests). I've personally reviewed the code and believe it's correct. This is my first time in the VRL compiler codebase though, so I greatly appreciate your expertise in reviewing!

## References

If you like this PR, consider reviewing my unrelated vector PRs I'm writing up for https://github.com/vectordotdev/vector/pull/25810 and https://github.com/vectordotdev/vector/issues/25815

