### PR TITLE
chore(ci): reduce Dependabot Cargo PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,32 @@ updates:
         - "prost-*"
       rustcrypto-digest:
         patterns:
-        - "digest"
-        - "hmac"
-        - "md-5"
-        - "sha1"
-        - "sha2"
-        - "sha3"
+          - "digest"
+          - "hmac"
+          - "md-5"
+          - "sha1"
+          - "sha2"
+          - "sha3"
+      cargo-other:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      # Keep major bumps in one PR. Without this group, majors matching a
+      # dependency-specific group may be silently dropped instead of falling
+      # back to individual PRs (dependabot-core#14202).
+      cargo-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/scripts/npm-tools"
     schedule:


### PR DESCRIPTION
## Summary

Motivation: Cargo dependency updates currently create numerous individual PRs. Grouping related updates keeps the maintenance queue manageable while retaining dedicated groups for dependency families and security fixes.

Developer-facing impact: Dependabot will consolidate remaining Cargo patch/minor updates, major updates, and security updates into focused groups, reducing the number of dependency-maintenance PRs while keeping the existing limit of ten concurrent version-update PRs.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `git diff --check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- [vectordotdev/vector#25857](https://github.com/vectordotdev/vector/pull/25857)
