### PR TITLE
fix(ci): install protoc from Ubuntu packages

### DIFF
--- a/.github/workflows/vector_integration_check.yaml
+++ b/.github/workflows/vector_integration_check.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-vector:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout VRL
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -17,9 +17,6 @@ jobs:
           path: vrl
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
 
       - name: Install system packages
         run: |
@@ -31,7 +28,10 @@ jobs:
             libsasl2-dev \
             libssl-dev \
             llvm \
-            pkg-config
+            pkg-config \
+            protobuf-compiler
+
+          protoc --version
 
       - name: Clone Vector repo and update VRL dependency
         env:


### PR DESCRIPTION
## Motivation

The Vector integration workflow installs `protoc` with `arduino/setup-protoc@v3`. That action still targets Node.js 20 and queries the GitHub releases API without authentication, which caused the integration check to fail after the shared API rate limit was exhausted.

## Changes

- pin the integration runner to Ubuntu 24.04
- remove the Node-based `setup-protoc` action
- install `protobuf-compiler` through the existing apt package step
- print the installed `protoc` version in the job log

This uses Ubuntu's signed package repositories and keeps the compiler environment tied to a stable runner image without depending on GitHub release discovery.

## Validation

- parsed `.github/workflows/vector_integration_check.yaml` successfully as YAML
- ran `git diff --check`
- compared `yamllint` results with `origin/main`; the change introduces no new findings

The full Vector integration build will be exercised by this PR's GitHub Actions run.