### PR TITLE
chore(deps): bump ordered-float to 5.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: "clippy"
-        run: make clippy
+        run: make check-clippy
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,9 +2504,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ itertools = { version = "0.14", default-features = false, features = ["use_std"]
 lalrpop-util = { version = "0.22", optional = true }
 mlua = { version = "0.11", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
 nom = { version = "8", default-features = false, features = ["std"], optional = true }
-ordered-float = { version = "4", default-features = false, optional = true }
+ordered-float = { version = "5", default-features = false, optional = true }
 md-5 = { version = "0.11", optional = true }
 parse-size = { version = "1.1.0",  optional = true }
 peeking_take_while = { version = "1", default-features = false, optional = true }

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,7 @@ endef
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-all: fmt-check clippy test vrl-test check-licenses check-wasm32 ## Run the common pre-PR checks
-
-clippy: ## Lint with clippy (workspace, all targets, all features)
-	cargo clippy --workspace --all-targets --all-features -- -D warnings
+all: fmt-check test vrl-test check-clippy check-licenses check-wasm32 ## Run the common pre-PR checks
 
 fmt: ## Format all code
 	cargo fmt --all
@@ -36,6 +33,9 @@ test: ## Run cargo tests
 
 vrl-test: ## Run VRL integration tests
 	cargo run --package vrl-tests --bin vrl-tests
+
+check-clippy: ## Lint with clippy (workspace, all targets, all features)
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 check-typos: ## Check spelling with `typos`
 	$(call ensure-cargo-tool,typos-cli,$(TYPOS_CLI_VERSION))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clippy fmt fmt-check test vrl-test \
+.PHONY: help all check-clippy fmt fmt-check test vrl-test \
 	check-typos check-features check-licenses write-licenses check-msrv check-deny check-wasm32 \
 	check-docs check-lockfile generate-docs
 

--- a/changelog.d/1890.fix.md
+++ b/changelog.d/1890.fix.md
@@ -1,0 +1,3 @@
+Prevent float arithmetic that produces NaN from panicking or silently returning zero. Such operations now return a runtime error.
+
+authors: pront

--- a/docs/generated/mod.json
+++ b/docs/generated/mod.json
@@ -32,7 +32,8 @@
   "internal_failure_reasons": [
     "`value` is not an integer or float.",
     "`modulus` is not an integer or float.",
-    "`modulus` is equal to 0."
+    "`modulus` is equal to 0.",
+    "The operation would produce NaN."
   ],
   "examples": [
     {

--- a/lib/tests/tests/expressions/arithmetic/addition/nan_result.vrl
+++ b/lib/tests/tests/expressions/arithmetic/addition/nan_result.vrl
@@ -1,0 +1,7 @@
+# result: operation would produce NaN
+
+large = to_float!("1.7976931348623157e+308")
+negative_large = to_float!("-1.7976931348623157e+308")
+positive_inf = large + large
+negative_inf = negative_large + negative_large
+positive_inf + negative_inf

--- a/lib/tests/tests/expressions/arithmetic/division/nan_result.vrl
+++ b/lib/tests/tests/expressions/arithmetic/division/nan_result.vrl
@@ -1,0 +1,5 @@
+# result: 0
+
+large = to_float!("1.7976931348623157e+308")
+inf_float = large + large
+(inf_float / inf_float) ?? 0

--- a/lib/tests/tests/expressions/arithmetic/multiplication/nan_result.vrl
+++ b/lib/tests/tests/expressions/arithmetic/multiplication/nan_result.vrl
@@ -1,0 +1,5 @@
+# result: operation would produce NaN
+
+large = to_float!("1.7976931348623157e+308")
+inf_float = large + large
+0 * inf_float

--- a/lib/tests/tests/expressions/arithmetic/remainder/nan_result.vrl
+++ b/lib/tests/tests/expressions/arithmetic/remainder/nan_result.vrl
@@ -1,0 +1,5 @@
+# result: function call error for "mod" at (72:91): operation would produce NaN
+
+large = to_float!("1.7976931348623157e+308")
+inf_float = large + large
+mod(inf_float, 1.0)

--- a/lib/tests/tests/expressions/arithmetic/subtraction/nan_result.vrl
+++ b/lib/tests/tests/expressions/arithmetic/subtraction/nan_result.vrl
@@ -1,4 +1,4 @@
-# result: can't subtract type float from float
+# result: operation would produce NaN
 
 large = to_float!("1.7976931348623157e+308")
 inf_float = large + large

--- a/src/compiler/expression/function.rs
+++ b/src/compiler/expression/function.rs
@@ -55,6 +55,10 @@ impl<T: FunctionExpression + Debug + Clone> Expression for FunctionExpressionAda
         self.inner.resolve(ctx)
     }
 
+    fn resolve_constant(&self, _state: &TypeState) -> Option<Value> {
+        self.inner.as_value()
+    }
+
     fn type_info(&self, state: &TypeState) -> TypeInfo {
         let result = self.inner.type_def(state);
         TypeInfo::new(state, result)

--- a/src/compiler/expression/function_call.rs
+++ b/src/compiler/expression/function_call.rs
@@ -18,6 +18,7 @@ use crate::compiler::{
 };
 use crate::diagnostic::{DiagnosticMessage, Label, Note, Severity, Urls};
 use crate::prelude::Note::SeeErrorDocs;
+use crate::value::Value;
 
 pub(crate) struct Builder<'a> {
     abort_on_error: bool,
@@ -682,6 +683,10 @@ impl Expression for FunctionCall {
                 }
             }
         })
+    }
+
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
+        self.expr.resolve_constant(state)
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/group.rs
+++ b/src/compiler/expression/group.rs
@@ -5,6 +5,7 @@ use crate::compiler::{
     Context, Expression,
     expression::{Expr, Resolved},
 };
+use crate::value::Value;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Group {
@@ -22,6 +23,10 @@ impl Group {
 impl Expression for Group {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         self.inner.resolve(ctx)
+    }
+
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
+        self.inner.resolve_constant(state)
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {

--- a/src/compiler/expression/op.rs
+++ b/src/compiler/expression/op.rs
@@ -18,6 +18,10 @@ pub struct Op {
     pub(crate) opcode: ast::Opcode,
 }
 
+fn is_number(value: &Value) -> bool {
+    value.is_integer() || value.is_float()
+}
+
 fn constant_arithmetic_produces_nan(
     opcode: ast::Opcode,
     lhs_value: Option<&Value>,
@@ -28,9 +32,7 @@ fn constant_arithmetic_produces_nan(
     let (Some(lhs), Some(rhs)) = (lhs_value, rhs_value) else {
         return false;
     };
-    let lhs_is_number = lhs.is_integer() || lhs.is_float();
-    let rhs_is_number = rhs.is_integer() || rhs.is_float();
-    if !lhs_is_number || !rhs_is_number || !(lhs.is_float() || rhs.is_float()) {
+    if !is_number(lhs) || !is_number(rhs) || !(lhs.is_float() || rhs.is_float()) {
         return false;
     }
 
@@ -169,6 +171,10 @@ impl Expression for Op {
 
         let lhs = self.lhs.resolve_constant(state)?;
         let rhs = self.rhs.resolve_constant(state)?;
+
+        if !is_number(&lhs) || !is_number(&rhs) {
+            return None;
+        }
 
         match self.opcode {
             Mul => lhs.try_mul(rhs),

--- a/src/compiler/expression/op.rs
+++ b/src/compiler/expression/op.rs
@@ -6,7 +6,7 @@ use crate::compiler::{
     Context, Expression, TypeDef,
     expression::{self, Expr, Resolved},
     parser::{Node, ast},
-    value::VrlValueArithmetic,
+    value::{ValueError, VrlValueArithmetic},
 };
 use crate::diagnostic::{DiagnosticMessage, Label, Note, Span, Urls};
 use crate::value::Value;
@@ -16,6 +16,32 @@ pub struct Op {
     pub(crate) lhs: Box<Expr>,
     pub(crate) rhs: Box<Expr>,
     pub(crate) opcode: ast::Opcode,
+}
+
+fn constant_arithmetic_produces_nan(
+    opcode: ast::Opcode,
+    lhs_value: Option<&Value>,
+    rhs_value: Option<&Value>,
+) -> bool {
+    use ast::Opcode::{Add, Mul, Sub};
+
+    let (Some(lhs), Some(rhs)) = (lhs_value, rhs_value) else {
+        return false;
+    };
+    let lhs_is_number = lhs.is_integer() || lhs.is_float();
+    let rhs_is_number = rhs.is_integer() || rhs.is_float();
+    if !lhs_is_number || !rhs_is_number || !(lhs.is_float() || rhs.is_float()) {
+        return false;
+    }
+
+    let result = match opcode {
+        Add => lhs.clone().try_add(rhs.clone()),
+        Sub => lhs.clone().try_sub(rhs.clone()),
+        Mul => lhs.clone().try_mul(rhs.clone()),
+        _ => unreachable!("only addition, subtraction, and multiplication are checked"),
+    };
+
+    matches!(result, Err(ValueError::NanFloat))
 }
 
 impl Op {
@@ -136,6 +162,22 @@ impl Expression for Op {
             And | Or | Err => unreachable!(),
         }
         .map_err(Into::into)
+    }
+
+    fn resolve_constant(&self, state: &TypeState) -> Option<Value> {
+        use ast::Opcode::{Add, Div, Mul, Sub};
+
+        let lhs = self.lhs.resolve_constant(state)?;
+        let rhs = self.rhs.resolve_constant(state)?;
+
+        match self.opcode {
+            Mul => lhs.try_mul(rhs),
+            Div => lhs.try_div(rhs),
+            Add => lhs.try_add(rhs),
+            Sub => lhs.try_sub(rhs),
+            _ => return None,
+        }
+        .ok()
     }
 
     #[allow(clippy::too_many_lines)]
@@ -262,7 +304,15 @@ impl Expression for Op {
 
             Add | Sub | Mul => {
                 // none of these operations short-circuit, so the type of RHS can be applied
+                let rhs_value = self.rhs.resolve_constant(&state);
                 let rhs_def = self.rhs.apply_type_info(&mut state);
+                // Preserve the existing infallible typing for dynamic arithmetic. Only a
+                // constant operation that is known to produce NaN becomes fallible.
+                let nan_fallible = constant_arithmetic_produces_nan(
+                    self.opcode,
+                    lhs_value.as_ref(),
+                    rhs_value.as_ref(),
+                );
 
                 match self.opcode {
                     // "bar" + ...
@@ -280,10 +330,18 @@ impl Expression for Op {
                     // 1.0 - ...
                     // 1.0 * ...
                     // 1.0 % ...
-                    Add | Sub | Mul if lhs_def.is_float() || rhs_def.is_float() => lhs_def
-                        .fallible_unless(K::integer().or_float())
-                        .union(rhs_def.fallible_unless(K::integer().or_float()))
-                        .with_kind(K::float()),
+                    Add | Sub | Mul if lhs_def.is_float() || rhs_def.is_float() => {
+                        let type_def = lhs_def
+                            .fallible_unless(K::integer().or_float())
+                            .union(rhs_def.fallible_unless(K::integer().or_float()))
+                            .with_kind(K::float());
+
+                        if nan_fallible {
+                            type_def.fallible()
+                        } else {
+                            type_def
+                        }
+                    }
 
                     // 1 + 1
                     // 1 - 1

--- a/src/compiler/value/arithmetic.rs
+++ b/src/compiler/value/arithmetic.rs
@@ -1,14 +1,10 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![allow(clippy::cast_precision_loss, clippy::module_name_repetitions)]
 
-use std::ops::{Add, Mul, Rem};
-
-use crate::compiler::{
-    ExpressionError,
-    value::{Kind, VrlValueConvert},
-};
+use crate::compiler::{ExpressionError, value::VrlValueConvert};
 use crate::value::{ObjectMap, Value};
 use bytes::{BufMut, Bytes, BytesMut};
+use ordered_float::NotNan;
 
 use super::ValueError;
 
@@ -61,44 +57,38 @@ pub trait VrlValueArithmetic: Sized {
     fn eq_lossy(&self, rhs: &Self) -> bool;
 }
 
-fn safe_sub(lhv: f64, rhv: f64) -> Option<Value> {
-    let result = lhv - rhv;
-    if result.is_nan() {
-        None
-    } else {
-        Some(Value::from_f64_or_zero(result))
-    }
+fn float_result(value: f64) -> Result<Value, ValueError> {
+    NotNan::new(value)
+        .map(Value::Float)
+        .map_err(|_| ValueError::NanFloat)
 }
 
 impl VrlValueArithmetic for Value {
     /// Similar to [`std::ops::Mul`], but fallible (e.g. `TryMul`).
     fn try_mul(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Mul(self.kind(), rhs.kind());
-
         // When multiplying a string by an integer, if the number is negative we set it to zero to
         // return an empty string.
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let as_usize = |num| if num < 0 { 0 } else { num as usize };
 
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_bytes() => {
-                Bytes::from(rhs.try_bytes()?.repeat(as_usize(lhv))).into()
+        let value = match (self, rhs) {
+            (Value::Integer(lhs), Value::Bytes(rhs)) => {
+                Bytes::from(rhs.repeat(as_usize(lhs))).into()
             }
-            Value::Integer(lhv) if rhs.is_float() => {
-                Value::from_f64_or_zero(lhv as f64 * rhs.try_float()?)
+            (Value::Integer(lhs), Value::Float(rhs)) => {
+                float_result(lhs as f64 * rhs.into_inner())?
             }
-            Value::Integer(lhv) => {
-                let rhv_i64 = rhs.try_into_i64().map_err(|_| err())?;
-                i64::wrapping_mul(lhv, rhv_i64).into()
+            (Value::Integer(lhs), Value::Integer(rhs)) => i64::wrapping_mul(lhs, rhs).into(),
+            (Value::Float(lhs), Value::Integer(rhs)) => {
+                float_result(lhs.into_inner() * rhs as f64)?
             }
-            Value::Float(lhv) => {
-                let rhs = rhs.try_into_f64().map_err(|_| err())?;
-                lhv.mul(rhs).into()
+            (Value::Float(lhs), Value::Float(rhs)) => {
+                float_result(lhs.into_inner() * rhs.into_inner())?
             }
-            Value::Bytes(lhv) if rhs.is_integer() => {
-                Bytes::from(lhv.repeat(as_usize(rhs.try_integer()?))).into()
+            (Value::Bytes(lhs), Value::Integer(rhs)) => {
+                Bytes::from(lhs.repeat(as_usize(rhs))).into()
             }
-            _ => return Err(err()),
+            (lhs, rhs) => return Err(ValueError::Mul(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -106,38 +96,31 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::ops::Div`], but fallible (e.g. `TryDiv`).
     fn try_div(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Div(self.kind(), rhs.kind());
-
-        let rhv_f64 = rhs.try_into_f64().map_err(|_| err())?;
-
-        if rhv_f64 == 0.0 {
-            return Err(ValueError::DivideByZero);
+        match (self, rhs) {
+            (_, Value::Integer(0)) => Err(ValueError::DivideByZero),
+            (_, Value::Float(rhs)) if rhs.into_inner() == 0.0 => Err(ValueError::DivideByZero),
+            (Value::Integer(lhs), Value::Integer(rhs)) => float_result(lhs as f64 / rhs as f64),
+            (Value::Integer(lhs), Value::Float(rhs)) => float_result(lhs as f64 / rhs.into_inner()),
+            (Value::Float(lhs), Value::Integer(rhs)) => float_result(lhs.into_inner() / rhs as f64),
+            (Value::Float(lhs), Value::Float(rhs)) => {
+                float_result(lhs.into_inner() / rhs.into_inner())
+            }
+            (lhs, rhs) => Err(ValueError::Div(lhs.kind(), rhs.kind())),
         }
-
-        let value = match self {
-            Value::Integer(lhv) => Value::from_f64_or_zero(lhv as f64 / rhv_f64),
-            Value::Float(lhv) => Value::from_f64_or_zero(lhv.into_inner() / rhv_f64),
-            _ => return Err(err()),
-        };
-
-        Ok(value)
     }
 
     /// Similar to [`std::ops::Add`], but fallible (e.g. `TryAdd`).
     fn try_add(self, rhs: Self) -> Result<Self, ValueError> {
         let value = match (self, rhs) {
-            (Value::Integer(lhs), Value::Float(rhs)) => Value::from_f64_or_zero(lhs as f64 + *rhs),
-            (Value::Integer(lhs), rhs) => {
-                let rhv_i64 = rhs
-                    .try_into_i64()
-                    .map_err(|_| ValueError::Add(Kind::integer(), rhs.kind()))?;
-                i64::wrapping_add(lhs, rhv_i64).into()
+            (Value::Integer(lhs), Value::Integer(rhs)) => i64::wrapping_add(lhs, rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => {
+                float_result(lhs as f64 + rhs.into_inner())?
             }
-            (Value::Float(lhs), rhs) => {
-                let rhs = rhs
-                    .try_into_f64()
-                    .map_err(|_| ValueError::Add(Kind::float(), rhs.kind()))?;
-                lhs.add(rhs).into()
+            (Value::Float(lhs), Value::Integer(rhs)) => {
+                float_result(lhs.into_inner() + rhs as f64)?
+            }
+            (Value::Float(lhs), Value::Float(rhs)) => {
+                float_result(lhs.into_inner() + rhs.into_inner())?
             }
             (lhs @ Value::Bytes(_), Value::Null) => lhs,
             (Value::Bytes(lhs), Value::Bytes(rhs)) => {
@@ -156,21 +139,18 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::ops::Sub`], but fallible (e.g. `TrySub`).
     fn try_sub(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Sub(self.kind(), rhs.kind());
-
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => {
-                Value::from_f64_or_zero(lhv as f64 - rhs.try_float()?)
+        let value = match (self, rhs) {
+            (Value::Integer(lhs), Value::Integer(rhs)) => i64::wrapping_sub(lhs, rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => {
+                float_result(lhs as f64 - rhs.into_inner())?
             }
-            Value::Integer(lhv) => {
-                let rhv_i64 = rhs.try_into_i64().map_err(|_| err())?;
-                i64::wrapping_sub(lhv, rhv_i64).into()
+            (Value::Float(lhs), Value::Integer(rhs)) => {
+                float_result(lhs.into_inner() - rhs as f64)?
             }
-            Value::Float(lhs) => {
-                let rhs = rhs.try_into_f64().map_err(|_| err())?;
-                safe_sub(*lhs, rhs).ok_or_else(err)?
+            (Value::Float(lhs), Value::Float(rhs)) => {
+                float_result(lhs.into_inner() - rhs.into_inner())?
             }
-            _ => return Err(err()),
+            (lhs, rhs) => return Err(ValueError::Sub(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -197,16 +177,10 @@ impl VrlValueArithmetic for Value {
     ///
     /// A lhs or rhs value of `Null` returns `false`.
     fn try_and(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::And(self.kind(), rhs.kind());
-
-        let value = match self {
-            Value::Null => false.into(),
-            Value::Boolean(left) => match rhs {
-                Value::Null => false.into(),
-                Value::Boolean(right) => (left && right).into(),
-                _ => return Err(err()),
-            },
-            _ => return Err(err()),
+        let value = match (self, rhs) {
+            (Value::Null, _) | (Value::Boolean(_), Value::Null) => false.into(),
+            (Value::Boolean(lhs), Value::Boolean(rhs)) => (lhs && rhs).into(),
+            (lhs, rhs) => return Err(ValueError::And(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -214,27 +188,22 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::ops::Rem`], but fallible (e.g. `TryRem`).
     fn try_rem(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Rem(self.kind(), rhs.kind());
-
-        let rhv_f64 = rhs.try_into_f64().map_err(|_| err())?;
-
-        if rhv_f64 == 0.0 {
-            return Err(ValueError::DivideByZero);
-        }
-
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => {
-                Value::from_f64_or_zero(lhv as f64 % rhs.try_float()?)
+        let value = match (self, rhs) {
+            (_, Value::Integer(0)) => return Err(ValueError::DivideByZero),
+            (_, Value::Float(rhs)) if rhs.into_inner() == 0.0 => {
+                return Err(ValueError::DivideByZero);
             }
-            Value::Integer(left) => {
-                let right = rhs.try_into_i64().map_err(|_| err())?;
-                i64::wrapping_rem(left, right).into()
+            (Value::Integer(lhs), Value::Integer(rhs)) => i64::wrapping_rem(lhs, rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => {
+                float_result(lhs as f64 % rhs.into_inner())?
             }
-            Value::Float(left) => {
-                let right = rhs.try_into_f64().map_err(|_| err())?;
-                left.rem(right).into()
+            (Value::Float(lhs), Value::Integer(rhs)) => {
+                float_result(lhs.into_inner() % rhs as f64)?
             }
-            _ => return Err(err()),
+            (Value::Float(lhs), Value::Float(rhs)) => {
+                float_result(lhs.into_inner() % rhs.into_inner())?
+            }
+            (lhs, rhs) => return Err(ValueError::Rem(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -242,15 +211,14 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::cmp::Ord`], but fallible (e.g. `TryOrd`).
     fn try_gt(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Rem(self.kind(), rhs.kind());
-
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 > rhs.try_float()?).into(),
-            Value::Integer(lhv) => (lhv > rhs.try_into_i64().map_err(|_| err())?).into(),
-            Value::Float(lhv) => (lhv.into_inner() > rhs.try_into_f64().map_err(|_| err())?).into(),
-            Value::Bytes(lhv) => (lhv > rhs.try_bytes()?).into(),
-            Value::Timestamp(lhv) => (lhv > rhs.try_timestamp()?).into(),
-            _ => return Err(err()),
+        let value = match (self, rhs) {
+            (Value::Integer(lhs), Value::Integer(rhs)) => (lhs > rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => (lhs as f64 > rhs.into_inner()).into(),
+            (Value::Float(lhs), Value::Integer(rhs)) => (lhs.into_inner() > rhs as f64).into(),
+            (Value::Float(lhs), Value::Float(rhs)) => (lhs > rhs).into(),
+            (Value::Bytes(lhs), rhs) => (lhs > rhs.try_bytes()?).into(),
+            (Value::Timestamp(lhs), rhs) => (lhs > rhs.try_timestamp()?).into(),
+            (lhs, rhs) => return Err(ValueError::Rem(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -258,17 +226,14 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::cmp::Ord`], but fallible (e.g. `TryOrd`).
     fn try_ge(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Ge(self.kind(), rhs.kind());
-
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 >= rhs.try_float()?).into(),
-            Value::Integer(lhv) => (lhv >= rhs.try_into_i64().map_err(|_| err())?).into(),
-            Value::Float(lhv) => {
-                (lhv.into_inner() >= rhs.try_into_f64().map_err(|_| err())?).into()
-            }
-            Value::Bytes(lhv) => (lhv >= rhs.try_bytes()?).into(),
-            Value::Timestamp(lhv) => (lhv >= rhs.try_timestamp()?).into(),
-            _ => return Err(err()),
+        let value = match (self, rhs) {
+            (Value::Integer(lhs), Value::Integer(rhs)) => (lhs >= rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => (lhs as f64 >= rhs.into_inner()).into(),
+            (Value::Float(lhs), Value::Integer(rhs)) => (lhs.into_inner() >= rhs as f64).into(),
+            (Value::Float(lhs), Value::Float(rhs)) => (lhs >= rhs).into(),
+            (Value::Bytes(lhs), rhs) => (lhs >= rhs.try_bytes()?).into(),
+            (Value::Timestamp(lhs), rhs) => (lhs >= rhs.try_timestamp()?).into(),
+            (lhs, rhs) => return Err(ValueError::Ge(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -276,15 +241,14 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::cmp::Ord`], but fallible (e.g. `TryOrd`).
     fn try_lt(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Ge(self.kind(), rhs.kind());
-
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => ((lhv as f64) < rhs.try_float()?).into(),
-            Value::Integer(lhv) => (lhv < rhs.try_into_i64().map_err(|_| err())?).into(),
-            Value::Float(lhv) => (lhv.into_inner() < rhs.try_into_f64().map_err(|_| err())?).into(),
-            Value::Bytes(lhv) => (lhv < rhs.try_bytes()?).into(),
-            Value::Timestamp(lhv) => (lhv < rhs.try_timestamp()?).into(),
-            _ => return Err(err()),
+        let value = match (self, rhs) {
+            (Value::Integer(lhs), Value::Integer(rhs)) => (lhs < rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => ((lhs as f64) < rhs.into_inner()).into(),
+            (Value::Float(lhs), Value::Integer(rhs)) => (lhs.into_inner() < rhs as f64).into(),
+            (Value::Float(lhs), Value::Float(rhs)) => (lhs < rhs).into(),
+            (Value::Bytes(lhs), rhs) => (lhs < rhs.try_bytes()?).into(),
+            (Value::Timestamp(lhs), rhs) => (lhs < rhs.try_timestamp()?).into(),
+            (lhs, rhs) => return Err(ValueError::Ge(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
@@ -292,36 +256,26 @@ impl VrlValueArithmetic for Value {
 
     /// Similar to [`std::cmp::Ord`], but fallible (e.g. `TryOrd`).
     fn try_le(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Ge(self.kind(), rhs.kind());
-
-        let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 <= rhs.try_float()?).into(),
-            Value::Integer(lhv) => (lhv <= rhs.try_into_i64().map_err(|_| err())?).into(),
-            Value::Float(lhv) => {
-                (lhv.into_inner() <= rhs.try_into_f64().map_err(|_| err())?).into()
-            }
-            Value::Bytes(lhv) => (lhv <= rhs.try_bytes()?).into(),
-            Value::Timestamp(lhv) => (lhv <= rhs.try_timestamp()?).into(),
-            _ => return Err(err()),
+        let value = match (self, rhs) {
+            (Value::Integer(lhs), Value::Integer(rhs)) => (lhs <= rhs).into(),
+            (Value::Integer(lhs), Value::Float(rhs)) => (lhs as f64 <= rhs.into_inner()).into(),
+            (Value::Float(lhs), Value::Integer(rhs)) => (lhs.into_inner() <= rhs as f64).into(),
+            (Value::Float(lhs), Value::Float(rhs)) => (lhs <= rhs).into(),
+            (Value::Bytes(lhs), rhs) => (lhs <= rhs.try_bytes()?).into(),
+            (Value::Timestamp(lhs), rhs) => (lhs <= rhs.try_timestamp()?).into(),
+            (lhs, rhs) => return Err(ValueError::Ge(lhs.kind(), rhs.kind())),
         };
 
         Ok(value)
     }
 
     fn try_merge(self, rhs: Self) -> Result<Self, ValueError> {
-        let err = || ValueError::Merge(self.kind(), rhs.kind());
-
-        let value = match (&self, &rhs) {
-            (Value::Object(lhv), Value::Object(right)) => lhv
-                .iter()
-                .chain(right.iter())
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect::<ObjectMap>()
-                .into(),
-            _ => return Err(err()),
-        };
-
-        Ok(value)
+        match (self, rhs) {
+            (Value::Object(lhs), Value::Object(rhs)) => {
+                Ok(lhs.into_iter().chain(rhs).collect::<ObjectMap>().into())
+            }
+            (lhs, rhs) => Err(ValueError::Merge(lhs.kind(), rhs.kind())),
+        }
     }
 
     /// Similar to [`std::cmp::Eq`], but does a lossless comparison for integers
@@ -336,5 +290,137 @@ impl VrlValueArithmetic for Value {
 
             _ => self == rhs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn float(value: f64) -> Value {
+        Value::Float(NotNan::new(value).expect("test value must not be NaN"))
+    }
+
+    #[test]
+    fn float_arithmetic_returns_an_error_for_nan_results() {
+        assert_eq!(
+            float(f64::INFINITY).try_mul(float(0.0)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            float(0.0).try_mul(float(f64::INFINITY)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            Value::Integer(0).try_mul(float(f64::INFINITY)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            float(f64::INFINITY).try_add(float(f64::NEG_INFINITY)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            float(f64::NEG_INFINITY).try_add(float(f64::INFINITY)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            float(f64::INFINITY).try_sub(float(f64::INFINITY)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            float(f64::INFINITY).try_div(float(f64::INFINITY)),
+            Err(ValueError::NanFloat)
+        );
+        assert_eq!(
+            float(f64::INFINITY).try_rem(float(1.0)),
+            Err(ValueError::NanFloat)
+        );
+    }
+
+    #[test]
+    fn nan_arithmetic_errors_can_be_coalesced() {
+        let sources = [
+            r#"(parse_float!("inf") + parse_float!("-inf")) ?? 0"#,
+            r#"(parse_float!("-inf") + parse_float!("inf")) ?? 0"#,
+            r#"(parse_float!("inf") * 0) ?? 0"#,
+            r#"(0 * parse_float!("inf")) ?? 0"#,
+            r#"(parse_float!("inf") - parse_float!("inf")) ?? 0"#,
+            r#"(parse_float!("inf") / parse_float!("inf")) ?? 0"#,
+            r#"mod(parse_float!("inf"), 1.0) ?? 0"#,
+        ];
+
+        for source in sources {
+            let compilation = crate::compiler::compile(source, &crate::stdlib::all())
+                .unwrap_or_else(|error| panic!("failed to compile `{source}`: {error:?}"));
+            let mut target = Value::Object(ObjectMap::new());
+            let result = crate::compiler::runtime::Runtime::default()
+                .resolve(
+                    &mut target,
+                    &compilation.program,
+                    &crate::compiler::TimeZone::default(),
+                )
+                .unwrap_or_else(|error| panic!("failed to run `{source}`: {error}"));
+
+            assert_eq!(result, Value::Integer(0), "source: `{source}`");
+        }
+    }
+
+    #[test]
+    fn dynamic_float_arithmetic_preserves_existing_infallible_typing() {
+        let sources = [
+            (
+                "lhs = parse_float!(.lhs); rhs = parse_float!(.rhs); lhs + rhs",
+                float(3.0),
+            ),
+            (
+                "lhs = parse_float!(.lhs); rhs = parse_float!(.rhs); lhs - rhs",
+                float(-1.0),
+            ),
+            (
+                "lhs = parse_float!(.lhs); rhs = parse_float!(.rhs); lhs * rhs",
+                float(2.0),
+            ),
+            ("lhs = parse_float!(.lhs); lhs / 2", float(0.5)),
+            ("lhs = parse_float!(.lhs); mod(lhs, 2.0)", float(1.0)),
+        ];
+        let target = ObjectMap::from([
+            ("lhs".into(), Value::from("1")),
+            ("rhs".into(), Value::from("2")),
+        ]);
+
+        for (source, expected) in sources {
+            let compilation = crate::compiler::compile(source, &crate::stdlib::all())
+                .unwrap_or_else(|error| panic!("failed to compile `{source}`: {error:?}"));
+            let mut target = Value::Object(target.clone());
+            let result = crate::compiler::runtime::Runtime::default()
+                .resolve(
+                    &mut target,
+                    &compilation.program,
+                    &crate::compiler::TimeZone::default(),
+                )
+                .unwrap_or_else(|error| panic!("failed to run `{source}`: {error}"));
+
+            assert_eq!(result, expected, "source: `{source}`");
+        }
+    }
+
+    #[test]
+    fn dynamic_nan_arithmetic_returns_a_runtime_error() {
+        let source = "lhs = parse_float!(.lhs); rhs = parse_float!(.rhs); lhs + rhs";
+        let compilation = crate::compiler::compile(source, &crate::stdlib::all())
+            .unwrap_or_else(|error| panic!("failed to compile `{source}`: {error:?}"));
+        let mut target = Value::Object(ObjectMap::from([
+            ("lhs".into(), Value::from("inf")),
+            ("rhs".into(), Value::from("-inf")),
+        ]));
+        let error = crate::compiler::runtime::Runtime::default()
+            .resolve(
+                &mut target,
+                &compilation.program,
+                &crate::compiler::TimeZone::default(),
+            )
+            .expect_err("NaN-producing arithmetic must fail");
+
+        assert!(error.to_string().contains("operation would produce NaN"));
     }
 }

--- a/src/compiler/value/error.rs
+++ b/src/compiler/value/error.rs
@@ -28,7 +28,7 @@ pub enum ValueError {
     #[error("can't divide by zero")]
     DivideByZero,
 
-    #[error("floats can't be NaN")]
+    #[error("operation would produce NaN")]
     NanFloat,
 
     #[error("can't add type {1} to {0}")]

--- a/src/stdlib/mod_func.rs
+++ b/src/stdlib/mod_func.rs
@@ -26,6 +26,7 @@ impl Function for Mod {
             "`value` is not an integer or float.",
             "`modulus` is not an integer or float.",
             "`modulus` is equal to 0.",
+            "The operation would produce NaN.",
         ]
     }
 
@@ -85,8 +86,14 @@ impl FunctionExpression for ModFn {
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
-        // Division is infallible if the rhs is a literal normal float or a literal non-zero integer.
-        match self.modulus.resolve_constant(state) {
+        let value_is_infinite = match self.value.resolve_constant(state) {
+            Some(Value::Float(value)) => value.is_infinite(),
+            _ => false,
+        };
+
+        // Preserve the existing infallible typing for a known-safe modulus, unless the
+        // dividend is a constant infinity that is known to produce NaN.
+        let type_def = match self.modulus.resolve_constant(state) {
             Some(value) if value.is_float() || value.is_integer() => match value {
                 Value::Float(v) if v.is_normal() => TypeDef::float().infallible(),
                 Value::Float(_) => TypeDef::float().fallible(),
@@ -95,6 +102,12 @@ impl FunctionExpression for ModFn {
                 _ => TypeDef::float().or_integer().fallible(),
             },
             _ => TypeDef::float().or_integer().fallible(),
+        };
+
+        if value_is_infinite {
+            type_def.fallible()
+        } else {
+            type_def
         }
     }
 }
@@ -117,6 +130,12 @@ mod tests {
             args: func_args![value: 5.0, modulus: 2.0],
             want: Ok(value!(1.0)),
             tdef: TypeDef::float().infallible(),
+        }
+
+        nan_mod {
+            args: func_args![value: f64::INFINITY, modulus: 1.0],
+            want: Err("operation would produce NaN"),
+            tdef: TypeDef::float().fallible(),
         }
 
         fallible_mod {

--- a/src/stdlib/parse_float.rs
+++ b/src/stdlib/parse_float.rs
@@ -60,19 +60,23 @@ impl Function for ParseFloat {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
+        let constant = value
+            .resolve_constant(state)
+            .and_then(|value| parse_float(value).ok());
 
-        Ok(ParseFloatFn { value }.as_expr())
+        Ok(ParseFloatFn { value, constant }.as_expr())
     }
 }
 
 #[derive(Debug, Clone)]
 struct ParseFloatFn {
     value: Box<dyn Expression>,
+    constant: Option<Value>,
 }
 
 impl FunctionExpression for ParseFloatFn {
@@ -84,6 +88,10 @@ impl FunctionExpression for ParseFloatFn {
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
         TypeDef::float().fallible()
+    }
+
+    fn as_value(&self) -> Option<Value> {
+        self.constant.clone()
     }
 }
 

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -40,6 +40,15 @@ fn test_abs_works() {
 }
 
 #[test]
+fn nan_arithmetic_error_can_be_coalesced() {
+    let stdout = run_vrl_repl(
+        Some(r#"(parse_float!("inf") + parse_float!("-inf")) ?? 0"#),
+        &["-q"],
+    );
+    assert_eq!(stdout, "0\n\n");
+}
+
+#[test]
 fn without_quiet_flag_prints_banner() {
     let stdout = run_vrl_repl(None, &[]);
     assert!(


### PR DESCRIPTION
## Summary

Bumps `ordered-float` from 4.6.0 to 5.3.0 and adapts VRL float arithmetic to the v5 API.

Operations that would produce NaN now return the existing operation-specific `ValueError` instead of relying on an infallible conversion. Regression coverage exercises multiplication, addition, and remainder.

This is coordinated with a companion Vector draft because Vector and VRL must use the same major `NotNan` type at their public boundary.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- `make check-lockfile`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p vrl float_arithmetic_returns_an_error_for_nan_results`
- `cargo run --package vrl-tests --bin vrl-tests` (937 passed)
- `make check-licenses`
- `make check-deny`
- `cargo check --target wasm32-unknown-unknown --no-default-features --features value,compiler`
- Full Vector workspace validation on the companion branch, including the web playground

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] `LICENSE-3rdparty.csv` remains current.

## References

- NaN handling tracking issue: https://github.com/vectordotdev/vrl/issues/1891
- Companion Vector draft: https://github.com/vectordotdev/vector/pull/26022
- Related: https://github.com/vectordotdev/vrl/pull/1291
- Follow-up to the compatibility revert: https://github.com/vectordotdev/vrl/pull/1338
- Unblocks the `ordered-float` update from https://github.com/vectordotdev/vrl/pull/1882
