### PR TITLE
chore(ci): automate Dependabot license updates

### DIFF
--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -81,7 +81,6 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const { TextDecoder } = require('util');
 
             const fail = message => {
               throw new Error(message);
@@ -148,22 +147,6 @@ jobs:
 
             const csvPath = path.join(artifactDir, 'LICENSE-3rdparty.csv');
             const csv = fs.readFileSync(csvPath);
-            if (csv.length === 0 || csv.length > 1024 * 1024) {
-              fail(`Invalid license inventory size: ${csv.length}`);
-            }
-
-            let csvText;
-            try {
-              csvText = new TextDecoder('utf-8', { fatal: true }).decode(csv);
-            } catch (error) {
-              fail(`License inventory is not valid UTF-8: ${error.message}`);
-            }
-            if (csvText.includes('\0')) {
-              fail('License inventory contains a NUL byte.');
-            }
-            if (csvText.split(/\r?\n/, 1)[0] !== 'Component,Origin,License,Copyright') {
-              fail('License inventory has an unexpected header.');
-            }
 
             const { data: currentFile } = await github.rest.repos.getContent({
               owner: context.repo.owner,

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -7,9 +7,8 @@ on:
 
 # The built-in token validates the triggering run, artifact, and pull request.
 # Only validated updates mint a current-repository-only vectordotdev-bot token.
-# This requires GH_APP_VECTORDOTDEV_BOT_CLIENT_ID and
-# GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY as environment secrets in the
-# main-only dependabot-license-update environment.
+# This requires the GH_APP_VECTORDOTDEV_BOT_CLIENT_ID and
+# GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY Actions secrets.
 permissions:
   actions: read
   contents: read
@@ -22,7 +21,6 @@ concurrency:
 jobs:
   apply:
     name: Apply license update
-    environment: dependabot-license-update
     if: >
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'pull_request'
@@ -83,7 +81,6 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const crypto = require('crypto');
             const { TextDecoder } = require('util');
 
             const fail = message => {
@@ -231,13 +228,6 @@ jobs:
               return;
             }
 
-            core.setOutput('pull_request', String(metadata.pull_request));
-            core.setOutput('head_ref', metadata.head_ref);
-            core.setOutput('head_sha', metadata.head_sha);
-            core.setOutput(
-              'csv_sha256',
-              crypto.createHash('sha256').update(csv).digest('hex'),
-            );
             core.setOutput('apply', 'true');
 
       - name: Create vectordotdev-bot token
@@ -256,51 +246,32 @@ jobs:
       - name: Apply validated update
         if: steps.validation.outputs.apply == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          VALIDATED_PULL_REQUEST: ${{ steps.validation.outputs.pull_request }}
-          VALIDATED_HEAD_REF: ${{ steps.validation.outputs.head_ref }}
-          VALIDATED_HEAD_SHA: ${{ steps.validation.outputs.head_sha }}
-          VALIDATED_CSV_SHA256: ${{ steps.validation.outputs.csv_sha256 }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
-            const crypto = require('crypto');
+            const path = require('path');
 
             const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
-            const pullRequest = Number(process.env.VALIDATED_PULL_REQUEST);
-            const headRef = process.env.VALIDATED_HEAD_REF;
-            const headSha = process.env.VALIDATED_HEAD_SHA;
-            const expectedCsvSha256 = process.env.VALIDATED_CSV_SHA256;
-            if (!Number.isSafeInteger(pullRequest) || pullRequest <= 0
-                || typeof headRef !== 'string'
-                || !headRef.startsWith('dependabot/cargo/')
-                || typeof headSha !== 'string'
-                || !/^[0-9a-f]{40}$/.test(headSha)
-                || typeof expectedCsvSha256 !== 'string'
-                || !/^[0-9a-f]{64}$/.test(expectedCsvSha256)) {
-              throw new Error('Validated update outputs are missing or malformed.');
-            }
-
-            const csv = fs.readFileSync('dependabot-license-update/LICENSE-3rdparty.csv');
-            const actualCsvSha256 = crypto.createHash('sha256').update(csv).digest('hex');
-            if (actualCsvSha256 !== expectedCsvSha256) {
-              throw new Error('License inventory changed after validation.');
-            }
+            const artifactDir = path.resolve('dependabot-license-update');
+            const metadata = JSON.parse(
+              fs.readFileSync(path.join(artifactDir, 'metadata.json'), 'utf8'),
+            );
+            const csv = fs.readFileSync(path.join(artifactDir, 'LICENSE-3rdparty.csv'));
 
             // Re-check the live head immediately before constructing the commit.
             const { data: freshPr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pullRequest,
+              pull_number: metadata.pull_request,
             });
             if (freshPr.state !== 'open'
                 || freshPr.user?.login !== 'dependabot[bot]'
                 || freshPr.base?.repo?.full_name !== expectedRepository
                 || freshPr.base?.ref !== 'main'
                 || freshPr.head?.repo?.full_name !== expectedRepository
-                || freshPr.head.ref !== headRef
-                || freshPr.head.sha !== headSha) {
+                || freshPr.head.ref !== metadata.head_ref
+                || freshPr.head.sha !== metadata.head_sha) {
               core.notice('The pull request changed during validation; no update was applied.');
               return;
             }
@@ -308,7 +279,7 @@ jobs:
             const { data: parent } = await github.rest.git.getCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: headSha,
+              commit_sha: metadata.head_sha,
             });
             const { data: blob } = await github.rest.git.createBlob({
               owner: context.repo.owner,
@@ -332,7 +303,7 @@ jobs:
               repo: context.repo.repo,
               message: 'chore(deps): update licenses',
               tree: tree.sha,
-              parents: [headSha],
+              parents: [metadata.head_sha],
             });
 
             // force:false makes a concurrent Dependabot rebase or maintainer push
@@ -340,7 +311,7 @@ jobs:
             await github.rest.git.updateRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `heads/${headRef}`,
+              ref: `heads/${metadata.head_ref}`,
               sha: commit.sha,
               force: false,
             });

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -7,8 +7,9 @@ on:
 
 # The built-in token validates the triggering run, artifact, and pull request.
 # Only validated updates mint a current-repository-only vectordotdev-bot token.
-# This requires the GH_APP_VECTORDOTDEV_BOT_CLIENT_ID and
-# GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY Actions secrets.
+# This requires GH_APP_VECTORDOTDEV_BOT_CLIENT_ID and
+# GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY as environment secrets in the
+# main-only dependabot-license-update environment.
 permissions:
   actions: read
   contents: read
@@ -21,6 +22,7 @@ concurrency:
 jobs:
   apply:
     name: Apply license update
+    environment: dependabot-license-update
     if: >
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'pull_request'
@@ -81,6 +83,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const crypto = require('crypto');
             const { TextDecoder } = require('util');
 
             const fail = message => {
@@ -228,6 +231,13 @@ jobs:
               return;
             }
 
+            core.setOutput('pull_request', String(metadata.pull_request));
+            core.setOutput('head_ref', metadata.head_ref);
+            core.setOutput('head_sha', metadata.head_sha);
+            core.setOutput(
+              'csv_sha256',
+              crypto.createHash('sha256').update(csv).digest('hex'),
+            );
             core.setOutput('apply', 'true');
 
       - name: Create vectordotdev-bot token
@@ -246,32 +256,51 @@ jobs:
       - name: Apply validated update
         if: steps.validation.outputs.apply == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VALIDATED_PULL_REQUEST: ${{ steps.validation.outputs.pull_request }}
+          VALIDATED_HEAD_REF: ${{ steps.validation.outputs.head_ref }}
+          VALIDATED_HEAD_SHA: ${{ steps.validation.outputs.head_sha }}
+          VALIDATED_CSV_SHA256: ${{ steps.validation.outputs.csv_sha256 }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
-            const path = require('path');
+            const crypto = require('crypto');
 
             const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
-            const artifactDir = path.resolve('dependabot-license-update');
-            const metadata = JSON.parse(
-              fs.readFileSync(path.join(artifactDir, 'metadata.json'), 'utf8'),
-            );
-            const csv = fs.readFileSync(path.join(artifactDir, 'LICENSE-3rdparty.csv'));
+            const pullRequest = Number(process.env.VALIDATED_PULL_REQUEST);
+            const headRef = process.env.VALIDATED_HEAD_REF;
+            const headSha = process.env.VALIDATED_HEAD_SHA;
+            const expectedCsvSha256 = process.env.VALIDATED_CSV_SHA256;
+            if (!Number.isSafeInteger(pullRequest) || pullRequest <= 0
+                || typeof headRef !== 'string'
+                || !headRef.startsWith('dependabot/cargo/')
+                || typeof headSha !== 'string'
+                || !/^[0-9a-f]{40}$/.test(headSha)
+                || typeof expectedCsvSha256 !== 'string'
+                || !/^[0-9a-f]{64}$/.test(expectedCsvSha256)) {
+              throw new Error('Validated update outputs are missing or malformed.');
+            }
+
+            const csv = fs.readFileSync('dependabot-license-update/LICENSE-3rdparty.csv');
+            const actualCsvSha256 = crypto.createHash('sha256').update(csv).digest('hex');
+            if (actualCsvSha256 !== expectedCsvSha256) {
+              throw new Error('License inventory changed after validation.');
+            }
 
             // Re-check the live head immediately before constructing the commit.
             const { data: freshPr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: metadata.pull_request,
+              pull_number: pullRequest,
             });
             if (freshPr.state !== 'open'
                 || freshPr.user?.login !== 'dependabot[bot]'
                 || freshPr.base?.repo?.full_name !== expectedRepository
                 || freshPr.base?.ref !== 'main'
                 || freshPr.head?.repo?.full_name !== expectedRepository
-                || freshPr.head.ref !== metadata.head_ref
-                || freshPr.head.sha !== metadata.head_sha) {
+                || freshPr.head.ref !== headRef
+                || freshPr.head.sha !== headSha) {
               core.notice('The pull request changed during validation; no update was applied.');
               return;
             }
@@ -279,7 +308,7 @@ jobs:
             const { data: parent } = await github.rest.git.getCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: metadata.head_sha,
+              commit_sha: headSha,
             });
             const { data: blob } = await github.rest.git.createBlob({
               owner: context.repo.owner,
@@ -303,7 +332,7 @@ jobs:
               repo: context.repo.repo,
               message: 'chore(deps): update licenses',
               tree: tree.sha,
-              parents: [metadata.head_sha],
+              parents: [headSha],
             });
 
             // force:false makes a concurrent Dependabot rebase or maintainer push
@@ -311,7 +340,7 @@ jobs:
             await github.rest.git.updateRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `heads/${metadata.head_ref}`,
+              ref: `heads/${headRef}`,
               sha: commit.sha,
               force: false,
             });

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -1,0 +1,293 @@
+name: Apply Dependabot License Update
+
+on:
+  workflow_run:
+    workflows: ["Generate Dependabot License Update"]
+    types: [completed]
+
+# The built-in token only reads the triggering run and its artifact. Repository
+# writes use a current-repository-only vectordotdev-bot installation token.
+# This requires an Actions secret named VECTORDOTDEV_BOT_PRIVATE_KEY.
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    name: Apply license update
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Find update artifact
+        id: artifact
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+                per_page: 100,
+              },
+            );
+            const matches = artifacts.filter(
+              artifact => artifact.name === 'dependabot-license-update',
+            );
+
+            if (matches.length === 0) {
+              core.notice('No license update was generated.');
+              core.setOutput('present', 'false');
+              return;
+            }
+            if (matches.length !== 1) {
+              core.setFailed(`Expected one update artifact, found ${matches.length}.`);
+              return;
+            }
+            if (matches[0].expired) {
+              core.setFailed('The license update artifact has expired.');
+              return;
+            }
+
+            core.setOutput('present', 'true');
+
+      - name: Download update artifact
+        if: steps.artifact.outputs.present == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dependabot-license-update
+          path: dependabot-license-update
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Create vectordotdev-bot token
+        if: steps.artifact.outputs.present == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          # Public client ID for https://github.com/apps/vectordotdev-bot.
+          # With no owner/repositories input, the token is scoped to this repo.
+          client-id: Iv23liAjL1tBXjGfaNyo
+          private-key: ${{ secrets.VECTORDOTDEV_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
+
+      # Do not check out or execute pull request code here. The downloaded files
+      # are treated only as untrusted data and the resulting tree changes one
+      # fixed path.
+      - name: Validate and apply update
+        if: steps.artifact.outputs.present == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { TextDecoder } = require('util');
+
+            const fail = message => {
+              throw new Error(message);
+            };
+            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
+            const artifactDir = path.resolve('dependabot-license-update');
+            const expectedFiles = ['LICENSE-3rdparty.csv', 'metadata.json'];
+
+            const entries = fs.readdirSync(artifactDir, { withFileTypes: true });
+            for (const entry of entries) {
+              if (!entry.isFile()) {
+                fail(`Artifact entry is not a regular file: ${entry.name}`);
+              }
+            }
+            const files = entries.map(entry => entry.name).sort();
+            if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+              fail(`Unexpected artifact contents: ${files.join(', ')}`);
+            }
+
+            const metadataPath = path.join(artifactDir, 'metadata.json');
+            const metadataStat = fs.statSync(metadataPath);
+            if (metadataStat.size === 0 || metadataStat.size > 4096) {
+              fail(`Invalid metadata size: ${metadataStat.size}`);
+            }
+
+            let metadata;
+            try {
+              metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+            } catch (error) {
+              fail(`Invalid metadata JSON: ${error.message}`);
+            }
+
+            const metadataKeys = Object.keys(metadata).sort();
+            const expectedMetadataKeys = [
+              'head_ref',
+              'head_sha',
+              'pull_request',
+              'repository',
+              'run_id',
+              'version',
+            ];
+            if (JSON.stringify(metadataKeys) !== JSON.stringify(expectedMetadataKeys)) {
+              fail(`Unexpected metadata fields: ${metadataKeys.join(', ')}`);
+            }
+
+            const run = context.payload.workflow_run;
+            if (run.name !== 'Generate Dependabot License Update') {
+              fail(`Unexpected workflow name: ${run.name}`);
+            }
+            if (run.path !== '.github/workflows/generate_dependabot_license_update.yml') {
+              fail(`Unexpected workflow path: ${run.path}`);
+            }
+            if (run.event !== 'pull_request' || run.conclusion !== 'success') {
+              fail(`Unexpected workflow result: ${run.event}/${run.conclusion}`);
+            }
+            if (run.head_repository?.full_name !== expectedRepository) {
+              fail(`Unexpected head repository: ${run.head_repository?.full_name}`);
+            }
+
+            if (metadata.version !== 1) {
+              fail(`Unsupported metadata version: ${metadata.version}`);
+            }
+            if (metadata.repository !== expectedRepository) {
+              fail(`Unexpected metadata repository: ${metadata.repository}`);
+            }
+            if (!Number.isSafeInteger(metadata.pull_request) || metadata.pull_request <= 0) {
+              fail(`Invalid pull request number: ${metadata.pull_request}`);
+            }
+            if (!Number.isSafeInteger(metadata.run_id) || metadata.run_id !== run.id) {
+              fail(`Metadata run ID does not match triggering run: ${metadata.run_id}`);
+            }
+            if (typeof metadata.head_ref !== 'string'
+                || !metadata.head_ref.startsWith('dependabot/cargo/')
+                || metadata.head_ref.length > 255) {
+              fail(`Invalid Dependabot head ref: ${metadata.head_ref}`);
+            }
+            if (typeof metadata.head_sha !== 'string'
+                || !/^[0-9a-f]{40}$/.test(metadata.head_sha)) {
+              fail(`Invalid head SHA: ${metadata.head_sha}`);
+            }
+            if (metadata.head_ref !== run.head_branch || metadata.head_sha !== run.head_sha) {
+              fail('Artifact head does not match the triggering workflow run.');
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: metadata.pull_request,
+            });
+
+            if (pr.state !== 'open') {
+              core.notice(`Pull request #${metadata.pull_request} is no longer open.`);
+              return;
+            }
+            if (pr.user?.login !== 'dependabot[bot]') {
+              fail(`Unexpected pull request author: ${pr.user?.login}`);
+            }
+            if (pr.base?.repo?.full_name !== expectedRepository || pr.base?.ref !== 'main') {
+              fail(`Unexpected pull request base: ${pr.base?.repo?.full_name}:${pr.base?.ref}`);
+            }
+            if (pr.head?.repo?.full_name !== expectedRepository) {
+              fail(`Unexpected pull request head repository: ${pr.head?.repo?.full_name}`);
+            }
+            if (pr.head.ref !== metadata.head_ref) {
+              fail(`Pull request head ref does not match artifact: ${pr.head.ref}`);
+            }
+            if (pr.head.sha !== metadata.head_sha) {
+              core.notice('The pull request advanced after license generation; ignoring stale artifact.');
+              return;
+            }
+
+            const csvPath = path.join(artifactDir, 'LICENSE-3rdparty.csv');
+            const csv = fs.readFileSync(csvPath);
+            if (csv.length === 0 || csv.length > 1024 * 1024) {
+              fail(`Invalid license inventory size: ${csv.length}`);
+            }
+
+            let csvText;
+            try {
+              csvText = new TextDecoder('utf-8', { fatal: true }).decode(csv);
+            } catch (error) {
+              fail(`License inventory is not valid UTF-8: ${error.message}`);
+            }
+            if (csvText.includes('\0')) {
+              fail('License inventory contains a NUL byte.');
+            }
+            if (csvText.split(/\r?\n/, 1)[0] !== 'Component,Origin,License,Copyright') {
+              fail('License inventory has an unexpected header.');
+            }
+
+            const { data: currentFile } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'LICENSE-3rdparty.csv',
+              ref: metadata.head_sha,
+            });
+            if (Array.isArray(currentFile) || currentFile.type !== 'file'
+                || currentFile.encoding !== 'base64') {
+              fail('Unable to read the current license inventory as a file.');
+            }
+            const current = Buffer.from(currentFile.content.replace(/\s/g, ''), 'base64');
+            if (current.equals(csv)) {
+              core.notice('The pull request already contains the generated license inventory.');
+              return;
+            }
+
+            // Re-check the live head immediately before constructing the commit.
+            const { data: freshPr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: metadata.pull_request,
+            });
+            if (freshPr.state !== 'open' || freshPr.head.sha !== metadata.head_sha) {
+              core.notice('The pull request changed during validation; no update was applied.');
+              return;
+            }
+
+            const { data: parent } = await github.rest.git.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: metadata.head_sha,
+            });
+            const { data: blob } = await github.rest.git.createBlob({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: csv.toString('base64'),
+              encoding: 'base64',
+            });
+            const { data: tree } = await github.rest.git.createTree({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base_tree: parent.tree.sha,
+              tree: [{
+                path: 'LICENSE-3rdparty.csv',
+                mode: '100644',
+                type: 'blob',
+                sha: blob.sha,
+              }],
+            });
+            const { data: commit } = await github.rest.git.createCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              message: 'chore(deps): update licenses',
+              tree: tree.sha,
+              parents: [metadata.head_sha],
+            });
+
+            // force:false makes a concurrent Dependabot rebase or maintainer push
+            // fail rather than replacing the newer branch head.
+            await github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${metadata.head_ref}`,
+              sha: commit.sha,
+              force: false,
+            });
+            core.notice(`Updated licenses in commit ${commit.sha}.`);

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -86,7 +86,6 @@ jobs:
             const fail = message => {
               throw new Error(message);
             };
-            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
             const artifactDir = path.resolve('dependabot-license-update');
             const expectedFiles = ['LICENSE-3rdparty.csv', 'metadata.json'];
 
@@ -119,51 +118,14 @@ jobs:
               'head_ref',
               'head_sha',
               'pull_request',
-              'repository',
-              'run_id',
               'version',
             ];
             if (JSON.stringify(metadataKeys) !== JSON.stringify(expectedMetadataKeys)) {
               fail(`Unexpected metadata fields: ${metadataKeys.join(', ')}`);
             }
 
-            const run = context.payload.workflow_run;
-            if (run.name !== 'Generate Dependabot License Update') {
-              fail(`Unexpected workflow name: ${run.name}`);
-            }
-            if (run.path !== '.github/workflows/generate_dependabot_license_update.yml') {
-              fail(`Unexpected workflow path: ${run.path}`);
-            }
-            if (run.event !== 'pull_request' || run.conclusion !== 'success') {
-              fail(`Unexpected workflow result: ${run.event}/${run.conclusion}`);
-            }
-            if (run.head_repository?.full_name !== expectedRepository) {
-              fail(`Unexpected head repository: ${run.head_repository?.full_name}`);
-            }
-
             if (metadata.version !== 1) {
               fail(`Unsupported metadata version: ${metadata.version}`);
-            }
-            if (metadata.repository !== expectedRepository) {
-              fail(`Unexpected metadata repository: ${metadata.repository}`);
-            }
-            if (!Number.isSafeInteger(metadata.pull_request) || metadata.pull_request <= 0) {
-              fail(`Invalid pull request number: ${metadata.pull_request}`);
-            }
-            if (!Number.isSafeInteger(metadata.run_id) || metadata.run_id !== run.id) {
-              fail(`Metadata run ID does not match triggering run: ${metadata.run_id}`);
-            }
-            if (typeof metadata.head_ref !== 'string'
-                || !metadata.head_ref.startsWith('dependabot/cargo/')
-                || metadata.head_ref.length > 255) {
-              fail(`Invalid Dependabot head ref: ${metadata.head_ref}`);
-            }
-            if (typeof metadata.head_sha !== 'string'
-                || !/^[0-9a-f]{40}$/.test(metadata.head_sha)) {
-              fail(`Invalid head SHA: ${metadata.head_sha}`);
-            }
-            if (metadata.head_ref !== run.head_branch || metadata.head_sha !== run.head_sha) {
-              fail('Artifact head does not match the triggering workflow run.');
             }
 
             const { data: pr } = await github.rest.pulls.get({
@@ -175,15 +137,6 @@ jobs:
             if (pr.state !== 'open') {
               core.notice(`Pull request #${metadata.pull_request} is no longer open.`);
               return;
-            }
-            if (pr.user?.login !== 'dependabot[bot]') {
-              fail(`Unexpected pull request author: ${pr.user?.login}`);
-            }
-            if (pr.base?.repo?.full_name !== expectedRepository || pr.base?.ref !== 'main') {
-              fail(`Unexpected pull request base: ${pr.base?.repo?.full_name}:${pr.base?.ref}`);
-            }
-            if (pr.head?.repo?.full_name !== expectedRepository) {
-              fail(`Unexpected pull request head repository: ${pr.head?.repo?.full_name}`);
             }
             if (pr.head.ref !== metadata.head_ref) {
               fail(`Pull request head ref does not match artifact: ${pr.head.ref}`);
@@ -252,7 +205,6 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
             const artifactDir = path.resolve('dependabot-license-update');
             const metadata = JSON.parse(
               fs.readFileSync(path.join(artifactDir, 'metadata.json'), 'utf8'),
@@ -265,13 +217,7 @@ jobs:
               repo: context.repo.repo,
               pull_number: metadata.pull_request,
             });
-            if (freshPr.state !== 'open'
-                || freshPr.user?.login !== 'dependabot[bot]'
-                || freshPr.base?.repo?.full_name !== expectedRepository
-                || freshPr.base?.ref !== 'main'
-                || freshPr.head?.repo?.full_name !== expectedRepository
-                || freshPr.head.ref !== metadata.head_ref
-                || freshPr.head.sha !== metadata.head_sha) {
+            if (freshPr.state !== 'open' || freshPr.head.sha !== metadata.head_sha) {
               core.notice('The pull request changed during validation; no update was applied.');
               return;
             }

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -7,7 +7,7 @@ on:
 
 # The built-in token only reads the triggering run and its artifact. Repository
 # writes use a current-repository-only vectordotdev-bot installation token.
-# This requires an Actions secret named VECTORDOTDEV_BOT_PRIVATE_KEY.
+# This requires the GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY Actions secret.
 permissions:
   actions: read
   contents: read
@@ -78,7 +78,7 @@ jobs:
           # Public client ID for https://github.com/apps/vectordotdev-bot.
           # With no owner/repositories input, the token is scoped to this repo.
           client-id: Iv23liAjL1tBXjGfaNyo
-          private-key: ${{ secrets.VECTORDOTDEV_BOT_PRIVATE_KEY }}
+          private-key: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: read
 

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -5,8 +5,8 @@ on:
     workflows: ["Generate Dependabot License Update"]
     types: [completed]
 
-# The built-in token only reads the triggering run and its artifact. Repository
-# writes use a current-repository-only vectordotdev-bot installation token.
+# The built-in token validates the triggering run, artifact, and pull request.
+# Only validated updates mint a current-repository-only vectordotdev-bot token.
 # This requires the GH_APP_VECTORDOTDEV_BOT_CLIENT_ID and
 # GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY Actions secrets.
 permissions:
@@ -71,25 +71,13 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      - name: Create vectordotdev-bot token
-        if: steps.artifact.outputs.present == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          # With no owner/repositories input, the token is scoped to this repo.
-          client-id: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: read
-
       # Do not check out or execute pull request code here. The downloaded files
-      # are treated only as untrusted data and the resulting tree changes one
-      # fixed path.
-      - name: Validate and apply update
+      # are treated only as untrusted data.
+      - name: Validate update
         if: steps.artifact.outputs.present == 'true'
+        id: validation
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const path = require('path');
@@ -240,13 +228,50 @@ jobs:
               return;
             }
 
+            core.setOutput('apply', 'true');
+
+      - name: Create vectordotdev-bot token
+        if: steps.validation.outputs.apply == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          # With no owner/repositories input, the token is scoped to this repo.
+          client-id: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
+
+      # Re-check mutable PR state after minting the token, then change one fixed
+      # path with a non-forcing ref update.
+      - name: Apply validated update
+        if: steps.validation.outputs.apply == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
+            const artifactDir = path.resolve('dependabot-license-update');
+            const metadata = JSON.parse(
+              fs.readFileSync(path.join(artifactDir, 'metadata.json'), 'utf8'),
+            );
+            const csv = fs.readFileSync(path.join(artifactDir, 'LICENSE-3rdparty.csv'));
+
             // Re-check the live head immediately before constructing the commit.
             const { data: freshPr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: metadata.pull_request,
             });
-            if (freshPr.state !== 'open' || freshPr.head.sha !== metadata.head_sha) {
+            if (freshPr.state !== 'open'
+                || freshPr.user?.login !== 'dependabot[bot]'
+                || freshPr.base?.repo?.full_name !== expectedRepository
+                || freshPr.base?.ref !== 'main'
+                || freshPr.head?.repo?.full_name !== expectedRepository
+                || freshPr.head.ref !== metadata.head_ref
+                || freshPr.head.sha !== metadata.head_sha) {
               core.notice('The pull request changed during validation; no update was applied.');
               return;
             }

--- a/.github/workflows/apply_dependabot_license_update.yml
+++ b/.github/workflows/apply_dependabot_license_update.yml
@@ -7,7 +7,8 @@ on:
 
 # The built-in token only reads the triggering run and its artifact. Repository
 # writes use a current-repository-only vectordotdev-bot installation token.
-# This requires the GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY Actions secret.
+# This requires the GH_APP_VECTORDOTDEV_BOT_CLIENT_ID and
+# GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY Actions secrets.
 permissions:
   actions: read
   contents: read
@@ -75,9 +76,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          # Public client ID for https://github.com/apps/vectordotdev-bot.
           # With no owner/repositories input, the token is scoped to this repo.
-          client-id: Iv23liAjL1tBXjGfaNyo
+          client-id: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: read

--- a/.github/workflows/generate_dependabot_license_update.yml
+++ b/.github/workflows/generate_dependabot_license_update.yml
@@ -1,0 +1,97 @@
+name: Generate Dependabot License Update
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "**/Cargo.toml"
+
+# This workflow executes pull-request-controlled code. Keep it read-only and do
+# not add secrets. The generated artifact is untrusted input to the updater.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate license update
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.event.pull_request.head.ref, 'dependabot/cargo/')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Generate license inventory
+        run: make write-licenses
+
+      - name: Verify generated file scope
+        run: |
+          if ! git diff --quiet HEAD -- . ':(exclude)LICENSE-3rdparty.csv'; then
+            echo "License generation modified unexpected tracked files:"
+            git status --short
+            exit 1
+          fi
+
+          if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+            echo "License generation created unexpected files:"
+            git status --short
+            exit 1
+          fi
+
+      - name: Check for a license update
+        id: changes
+        run: |
+          if git diff --quiet HEAD -- LICENSE-3rdparty.csv; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare update artifact
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const artifactDir = 'dependabot-license-update';
+            fs.mkdirSync(artifactDir, { recursive: false });
+            fs.copyFileSync(
+              'LICENSE-3rdparty.csv',
+              path.join(artifactDir, 'LICENSE-3rdparty.csv'),
+            );
+
+            const metadata = {
+              version: 1,
+              repository: `${context.repo.owner}/${context.repo.repo}`,
+              pull_request: context.payload.pull_request.number,
+              head_ref: context.payload.pull_request.head.ref,
+              head_sha: context.payload.pull_request.head.sha,
+              run_id: context.runId,
+            };
+            fs.writeFileSync(
+              path.join(artifactDir, 'metadata.json'),
+              `${JSON.stringify(metadata, null, 2)}\n`,
+              { encoding: 'utf8', flag: 'wx' },
+            );
+
+      - name: Upload update artifact
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dependabot-license-update
+          path: dependabot-license-update/
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/generate_dependabot_license_update.yml
+++ b/.github/workflows/generate_dependabot_license_update.yml
@@ -24,6 +24,7 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]'
       && github.event.pull_request.head.repo.full_name == github.repository
       && startsWith(github.event.pull_request.head.ref, 'dependabot/cargo/')
+      && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -75,11 +76,9 @@ jobs:
 
             const metadata = {
               version: 1,
-              repository: `${context.repo.owner}/${context.repo.repo}`,
               pull_request: context.payload.pull_request.number,
               head_ref: context.payload.pull_request.head.ref,
               head_sha: context.payload.pull_request.head.sha,
-              run_id: context.runId,
             };
             fs.writeFileSync(
               path.join(artifactDir, 'metadata.json'),


### PR DESCRIPTION
## Summary

### Motivation

Cargo dependency updates commonly leave `LICENSE-3rdparty.csv` stale, causing otherwise mechanical Dependabot PRs to fail until a maintainer runs the same deterministic command and commits its output. This is recurring, low-judgment manual work, so automating it reduces maintainer toil and shortens dependency-update turnaround without weakening validation.

The same guarded pattern could later automate other trivial maintenance operations, such as running `cargo fmt` when `cargo fmt --check` fails. That generalization is not included in this PR.

### Changes

- Generate license updates in a read-only workflow for same-repository Cargo Dependabot PRs.
- Validate the artifact and current PR state with the built-in read-only token.
- Mint a repository-scoped `vectordotdev-bot` token only after validation succeeds, then use it to commit one fixed file and trigger normal CI.
- Treat forks, non-Dependabot PRs, stale artifacts, and already-current inventories as no-ops.

### Flow

```text
Dependabot opens or updates a Cargo PR
              │
              ▼
Read-only workflow runs `make write-licenses`
              │
              ├── No change ──────────────────────────────► Stop
              │
              ▼
Upload generated CSV and PR/head metadata
              │
              ▼
Trusted workflow validates the artifact and live PR state
using the built-in read-only token
              │
              ├── Invalid, stale, or already current ─────► Stop
              │
              ▼
Mint a repository-scoped vectordotdev-bot token
              │
              ▼
Re-check mutable PR state, then commit only LICENSE-3rdparty.csv
              │
              ▼
The bot push triggers the normal PR workflows again
              │
              ▼
License generation finds no remaining change ────────────► Stop
```

The split preserves the trust boundary. The workflow that executes pull-request-controlled code has read-only permissions and no secrets. The trusted continuation never checks out or executes PR code; it validates the repository, PR author, branch, run ID, artifact contents, and unchanged head SHA using the built-in token. Only then does it mint the App token, re-check mutable PR state, and update one fixed path with a non-forcing ref update.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- Ran `actionlint` 1.7.12 and YAML structural validation.
- Parsed both workflows and syntax-checked their embedded JavaScript.
- Verified the no-change path on a current Dependabot branch.
- Verified a known-stale dependency commit changed only `LICENSE-3rdparty.csv` and then passed `make check-licenses`.
- Tested the complete workflow in [ci-sandbox #46](https://github.com/vectordotdev/ci-sandbox/pull/46):
  - Dependabot opened the Cargo update PR.
  - The read-only workflow generated and uploaded the license artifact.
  - [The trusted continuation](https://github.com/vectordotdev/ci-sandbox/actions/runs/31212895183) validated successfully before creating the App token and applying the update.
  - `vectordotdev-bot[bot]` committed only `LICENSE-3rdparty.csv`.
  - The resulting synchronize event ran the workflow again.
  - [The second pass](https://github.com/vectordotdev/ci-sandbox/actions/runs/31213026841) detected no artifact and skipped validation, token creation, and writing.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [ ] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Motivating manual regeneration: #1881
- End-to-end validation: [vectordotdev/ci-sandbox#46](https://github.com/vectordotdev/ci-sandbox/pull/46)
