### PR TITLE
fix(tests): support Windows path separators in vrl-tests

### DIFF
--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -191,13 +191,13 @@ fn test_category(path: &Path) -> String {
 
     stripped_path
         .clone()
-        .rsplit_once('/')
+        .rsplit_once(['/', '\\'])
         .map_or(stripped_path, |x| x.0.to_owned())
 }
 
 fn test_name(path: &Path) -> String {
     path.to_string_lossy()
-        .rsplit_once('/')
+        .rsplit_once(['/', '\\'])
         .unwrap()
         .1
         .trim_end_matches(".vrl")


### PR DESCRIPTION
## Summary

`vrl-tests` splits paths on `/` only, so on Windows the test-name and test-category helpers fail to strip the prefix and the runner panics before running anything. Accept `\` as well.

Split out of #1865 to keep that PR focused.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Tests now run/pass on windows.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Split out from #1865.
