### PR TITLE
chore(compiler): perf speedup through type-state sharing

### DIFF
--- a/src/compiler/expression/assignment.rs
+++ b/src/compiler/expression/assignment.rs
@@ -311,7 +311,15 @@ impl Expression for Assignment {
     }
 
     fn type_info(&self, state: &TypeState) -> TypeInfo {
-        self.variant.type_info(state)
+        let mut state = state.clone();
+        let result = self.apply_type_info(&mut state);
+        TypeInfo::new(state, result)
+    }
+
+    /// Mutate `state` in place. The default `apply_type_info` clones via `type_info`;
+    /// assignments are dense in remap programs so avoid that full `TypeState` clone.
+    fn apply_type_info(&self, state: &mut TypeState) -> TypeDef {
+        self.variant.apply_type_info(state)
     }
 }
 
@@ -353,33 +361,30 @@ impl Target {
         match self {
             Self::Noop => {}
             Self::Internal(ident, path) => {
-                let type_def = match state.local.variable(ident) {
-                    None => TypeDef::never().with_type_inserted(path, new_type_def),
-                    Some(Details { type_def, .. }) => {
-                        type_def.clone().with_type_inserted(path, new_type_def)
-                    }
-                };
-
-                let details = Details { type_def, value };
-                state.local.insert_variable(ident.clone(), details);
+                if let Some(details) = state.local.variable_mut(ident) {
+                    details.type_def.insert_type(path, new_type_def);
+                    details.value = value;
+                } else {
+                    let type_def = TypeDef::never().with_type_inserted(path, new_type_def);
+                    state
+                        .local
+                        .insert_variable(ident.clone(), Details { type_def, value });
+                }
             }
 
             Self::External(target_path) => match target_path.prefix {
                 PathPrefix::Event => {
-                    state.external.update_target(Details {
-                        type_def: state
-                            .external
-                            .target()
-                            .type_def
-                            .clone()
-                            .with_type_inserted(&target_path.path, new_type_def),
-                        value,
-                    });
+                    let details = state.external.target_mut();
+                    details
+                        .type_def
+                        .insert_type(&target_path.path, new_type_def);
+                    details.value = value;
                 }
                 PathPrefix::Metadata => {
-                    let mut kind = state.external.metadata_kind().clone();
-                    kind.insert(&target_path.path, new_type_def.kind().clone());
-                    state.external.update_metadata(kind);
+                    state
+                        .external
+                        .metadata_kind_mut()
+                        .insert(&target_path.path, new_type_def.kind().clone());
                 }
             },
         }
@@ -551,15 +556,14 @@ where
         Ok(value)
     }
 
-    fn type_info(&self, state: &TypeState) -> TypeInfo {
-        let mut state = state.clone();
+    fn apply_type_info(&self, state: &mut TypeState) -> TypeDef {
         match &self {
             Variant::Single { target, expr } => {
-                let expr_result = expr.apply_type_info(&mut state).impure();
+                let expr_result = expr.apply_type_info(state).impure();
 
-                let const_value = expr.resolve_constant(&state);
-                target.insert_type_def(&mut state, expr_result.clone(), const_value);
-                TypeInfo::new(state, expr_result)
+                let const_value = expr.resolve_constant(state);
+                target.insert_type_def(state, expr_result.clone(), const_value);
+                expr_result
             }
             Variant::Infallible {
                 ok,
@@ -567,7 +571,7 @@ where
                 expr,
                 default,
             } => {
-                let expr_result = expr.apply_type_info(&mut state);
+                let expr_result = expr.apply_type_info(state);
 
                 // The "ok" type is either the result of the expression, or a "default" value when the expression fails.
                 let ok_type = expr_result
@@ -575,19 +579,23 @@ where
                     .union(TypeDef::from(default.kind()))
                     .infallible();
 
-                let const_value = expr.resolve_constant(&state);
-                ok.insert_type_def(&mut state, ok_type, const_value);
+                let const_value = expr.resolve_constant(state);
+                ok.insert_type_def(state, ok_type, const_value);
 
                 // The "err" type is either the error message "bytes" or "null" (not undefined).
                 let err_type = TypeDef::from(Kind::bytes().or_null());
-                err.insert_type_def(&mut state, err_type, None);
+                err.insert_type_def(state, err_type, None);
 
                 // Return type of the assignment expression itself is either the "expr" type or "bytes (the error message).
-                let assignment_result = expr_result.infallible().impure().or_bytes();
-
-                TypeInfo::new(state, assignment_result)
+                expr_result.infallible().impure().or_bytes()
             }
         }
+    }
+
+    fn type_info(&self, state: &TypeState) -> TypeInfo {
+        let mut state = state.clone();
+        let result = self.apply_type_info(&mut state);
+        TypeInfo::new(state, result)
     }
 }
 

--- a/src/compiler/state.rs
+++ b/src/compiler/state.rs
@@ -1,8 +1,32 @@
 use crate::path::PathPrefix;
 use crate::value::{Kind, Value};
 use std::collections::{HashMap, hash_map::Entry};
+use std::ops::Deref;
+use std::sync::Arc;
 
 use super::{TypeDef, parser::ast::Ident, type_def::Details, value::Collection};
+
+/// Shared local bindings: `TypeState` clones share until a write via [`Self::make_mut`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct SharedBindings(Arc<HashMap<Ident, Details>>);
+
+impl SharedBindings {
+    fn make_mut(&mut self) -> &mut HashMap<Ident, Details> {
+        Arc::make_mut(&mut self.0)
+    }
+
+    fn into_map(self) -> HashMap<Ident, Details> {
+        Arc::try_unwrap(self.0).unwrap_or_else(|arc| (*arc).clone())
+    }
+}
+
+impl Deref for SharedBindings {
+    type Target = HashMap<Ident, Details>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct TypeInfo {
@@ -54,7 +78,7 @@ impl TypeState {
 /// Local environment, limited to a given scope.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct LocalEnv {
-    pub(crate) bindings: HashMap<Ident, Details>,
+    pub(crate) bindings: SharedBindings,
 }
 
 impl LocalEnv {
@@ -67,21 +91,21 @@ impl LocalEnv {
     }
 
     pub(crate) fn variable_mut(&mut self, ident: &Ident) -> Option<&mut Details> {
-        self.bindings.get_mut(ident)
+        self.bindings.make_mut().get_mut(ident)
     }
 
     pub(crate) fn insert_variable(&mut self, ident: Ident, details: Details) {
-        self.bindings.insert(ident, details);
+        self.bindings.make_mut().insert(ident, details);
     }
 
     pub(crate) fn remove_variable(&mut self, ident: &Ident) -> Option<Details> {
-        self.bindings.remove(ident)
+        self.bindings.make_mut().remove(ident)
     }
 
     /// Any state the child scope modified that was part of the parent is copied to the parent scope
     pub(crate) fn apply_child_scope(mut self, child: Self) -> Self {
-        for (ident, child_details) in child.bindings {
-            if let Some(self_details) = self.bindings.get_mut(&ident) {
+        for (ident, child_details) in child.bindings.into_map() {
+            if let Some(self_details) = self.bindings.make_mut().get_mut(&ident) {
                 *self_details = child_details;
             }
         }
@@ -93,11 +117,12 @@ impl LocalEnv {
     /// where different `LocalEnv`'s can be created, and the result is decided at runtime.
     /// The compile-time type must be the union of the options.
     pub(crate) fn merge(mut self, other: Self) -> Self {
-        for (ident, other_details) in other.bindings {
-            if let Some(self_details) = self.bindings.get_mut(&ident) {
+        for (ident, other_details) in other.bindings.into_map() {
+            let bindings = self.bindings.make_mut();
+            if let Some(self_details) = bindings.get_mut(&ident) {
                 *self_details = self_details.clone().merge(other_details);
             } else {
-                self.bindings.insert(ident, other_details);
+                bindings.insert(ident, other_details);
             }
         }
         self

--- a/src/compiler/state.rs
+++ b/src/compiler/state.rs
@@ -66,6 +66,10 @@ impl LocalEnv {
         self.bindings.get(ident)
     }
 
+    pub(crate) fn variable_mut(&mut self, ident: &Ident) -> Option<&mut Details> {
+        self.bindings.get_mut(ident)
+    }
+
     pub(crate) fn insert_variable(&mut self, ident: Ident, details: Details) {
         self.bindings.insert(ident, details);
     }
@@ -145,6 +149,10 @@ impl ExternalEnv {
         &self.target
     }
 
+    pub(crate) fn target_mut(&mut self) -> &mut Details {
+        &mut self.target
+    }
+
     pub fn target_kind(&self) -> &Kind {
         self.target().type_def.kind()
     }
@@ -159,6 +167,10 @@ impl ExternalEnv {
 
     pub fn metadata_kind(&self) -> &Kind {
         &self.metadata
+    }
+
+    pub(crate) fn metadata_kind_mut(&mut self) -> &mut Kind {
+        &mut self.metadata
     }
 
     pub(crate) fn update_target(&mut self, details: Details) {

--- a/src/compiler/type_def.rs
+++ b/src/compiler/type_def.rs
@@ -497,14 +497,16 @@ impl TypeDef {
 
     #[must_use]
     pub fn with_type_inserted<'a>(self, path: impl ValuePath<'a>, other: Self) -> Self {
-        let mut kind = self.kind;
-        kind.insert(path, other.kind);
-        Self {
-            fallibility: Fallibility::merge(&self.fallibility, &other.fallibility),
-            kind,
-            purity: Purity::merge(&self.purity, &other.purity),
-            returns: self.returns.clone(),
-        }
+        let mut this = self;
+        this.insert_type(path, other);
+        this
+    }
+
+    /// Insert `other`'s kind at `path` within `self`, mutating in place.
+    pub fn insert_type<'a>(&mut self, path: impl ValuePath<'a>, other: Self) {
+        self.fallibility = Fallibility::merge(&self.fallibility, &other.fallibility);
+        self.kind.insert(path, other.kind);
+        self.purity = Purity::merge(&self.purity, &other.purity);
     }
 
     #[must_use]

--- a/src/value/kind/collection.rs
+++ b/src/value/kind/collection.rs
@@ -4,7 +4,10 @@ mod field;
 mod index;
 mod unknown;
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::path::OwnedSegment;
 use crate::path::OwnedValuePath;
@@ -18,13 +21,48 @@ pub trait CollectionKey {
     fn to_segment(&self) -> OwnedSegment;
 }
 
+/// Shared known-key map for [`Collection`].
+///
+/// `Kind` / `TypeState` clones (e.g. forking at `if` arms) share the map until a write goes through
+/// [`Self::make_mut`]. Private so callers cannot mutate the `Arc` without copy-on-write.
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct SharedMap<T: Ord>(Arc<BTreeMap<T, Kind>>);
+
+impl<T: Ord> SharedMap<T> {
+    fn new(map: BTreeMap<T, Kind>) -> Self {
+        Self(Arc::new(map))
+    }
+
+    fn empty() -> Self {
+        Self::new(BTreeMap::new())
+    }
+}
+
+impl<T: Ord + Clone> SharedMap<T> {
+    fn make_mut(&mut self) -> &mut BTreeMap<T, Kind> {
+        Arc::make_mut(&mut self.0)
+    }
+
+    fn into_map(self) -> BTreeMap<T, Kind> {
+        Arc::try_unwrap(self.0).unwrap_or_else(|arc| (*arc).clone())
+    }
+}
+
+impl<T: Ord> Deref for SharedMap<T> {
+    type Target = BTreeMap<T, Kind>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// The kinds of a collection (e.g. array or object).
 ///
 /// A collection contains one or more kinds for known positions within the collection (e.g. indices
 /// or fields), and contains a global "unknown" state that applies to all unknown paths.
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Collection<T: Ord> {
-    known: BTreeMap<T, Kind>,
+    known: SharedMap<T>,
 
     /// The kind of other unknown fields.
     ///
@@ -34,12 +72,25 @@ pub struct Collection<T: Ord> {
     unknown: Unknown,
 }
 
+impl<T: Ord> PartialOrd for Collection<T>
+where
+    T: PartialOrd,
+    BTreeMap<T, Kind>: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.known.deref().partial_cmp(other.known.deref()) {
+            Some(Ordering::Equal) => self.unknown.partial_cmp(&other.unknown),
+            non_eq => non_eq,
+        }
+    }
+}
+
 impl<T: Ord + Clone> Collection<T> {
     /// Create a new collection from its parts.
     #[must_use]
     pub fn from_parts(known: BTreeMap<T, Kind>, unknown: impl Into<Kind>) -> Self {
         Self {
-            known,
+            known: SharedMap::new(known),
             unknown: unknown.into().into(),
         }
     }
@@ -60,7 +111,7 @@ impl<T: Ord + Clone> Collection<T> {
     #[must_use]
     pub fn from_unknown(unknown: impl Into<Kind>) -> Self {
         Self {
-            known: BTreeMap::default(),
+            known: SharedMap::empty(),
             unknown: unknown.into().into(),
         }
     }
@@ -69,7 +120,7 @@ impl<T: Ord + Clone> Collection<T> {
     #[must_use]
     pub fn empty() -> Self {
         Self {
-            known: BTreeMap::default(),
+            known: SharedMap::empty(),
             unknown: Kind::undefined().into(),
         }
     }
@@ -78,7 +129,7 @@ impl<T: Ord + Clone> Collection<T> {
     #[must_use]
     pub fn any() -> Self {
         Self {
-            known: BTreeMap::default(),
+            known: SharedMap::empty(),
             unknown: Unknown::any(),
         }
     }
@@ -87,7 +138,7 @@ impl<T: Ord + Clone> Collection<T> {
     #[must_use]
     pub fn json() -> Self {
         Self {
-            known: BTreeMap::default(),
+            known: SharedMap::empty(),
             unknown: Unknown::json(),
         }
     }
@@ -107,9 +158,11 @@ impl<T: Ord + Clone> Collection<T> {
     }
 
     /// Get a mutable reference to the "known" elements in the collection.
+    ///
+    /// Clones the map if other `Kind` values still share it.
     #[must_use]
     pub fn known_mut(&mut self) -> &mut BTreeMap<T, Kind> {
-        &mut self.known
+        self.known.make_mut()
     }
 
     /// Gets the type of "unknown" elements in the collection.
@@ -172,17 +225,19 @@ impl<T: Ord + Clone> Collection<T> {
     /// has an object with a field "bar" results in a collection of which any field can have an
     /// object that has a field "bar".
     pub fn anonymize(&mut self) {
-        let known_unknown = self
-            .known
-            .values_mut()
-            .reduce(|lhs, rhs| {
-                lhs.merge_keep(rhs.clone(), false);
-                lhs
-            })
-            .cloned()
-            .unwrap_or(Kind::never());
-
-        self.known.clear();
+        let known_unknown = {
+            let known = self.known_mut();
+            let known_unknown = known
+                .values_mut()
+                .reduce(|lhs, rhs| {
+                    lhs.merge_keep(rhs.clone(), false);
+                    lhs
+                })
+                .cloned()
+                .unwrap_or(Kind::never());
+            known.clear();
+            known_unknown
+        };
         self.unknown = self.unknown.to_kind().union(known_unknown).into();
     }
 
@@ -201,23 +256,26 @@ impl<T: Ord + Clone> Collection<T> {
     /// For *unknown fields or indices*:
     ///
     /// - Both `Unknown`s are merged, similar to merging two `Kind`s.
-    pub fn merge(&mut self, mut other: Self, overwrite: bool) {
-        for (key, self_kind) in &mut self.known {
-            if let Some(other_kind) = other.known.remove(key) {
+    pub fn merge(&mut self, other: Self, overwrite: bool) {
+        let mut other_known = other.known.into_map();
+        let other_unknown = other.unknown;
+
+        for (key, self_kind) in self.known_mut() {
+            if let Some(other_kind) = other_known.remove(key) {
                 if overwrite {
                     *self_kind = other_kind;
                 } else {
                     self_kind.merge_keep(other_kind, overwrite);
                 }
-            } else if other.unknown_kind().contains_any_defined() {
+            } else if other_unknown.to_kind().contains_any_defined() {
                 if overwrite {
                     // the specific field being merged isn't guaranteed to exist, so merge it with the known type of self
-                    *self_kind = other
-                        .unknown_kind()
+                    *self_kind = other_unknown
+                        .to_kind()
                         .without_undefined()
                         .union(self_kind.clone());
                 } else {
-                    self_kind.merge_keep(other.unknown_kind(), overwrite);
+                    self_kind.merge_keep(other_unknown.to_kind(), overwrite);
                 }
             } else if !overwrite {
                 // other is missing this field, which returns null
@@ -227,21 +285,21 @@ impl<T: Ord + Clone> Collection<T> {
 
         let self_unknown_kind = self.unknown_kind();
         if self_unknown_kind.contains_any_defined() {
-            for (key, mut other_kind) in other.known {
+            for (key, mut other_kind) in other_known {
                 if !overwrite {
                     other_kind.merge_keep(self_unknown_kind.clone(), overwrite);
                 }
                 self.known_mut().insert(key, other_kind);
             }
         } else if overwrite {
-            self.known.extend(other.known);
+            self.known_mut().extend(other_known);
         } else {
-            for (key, other_kind) in other.known {
+            for (key, other_kind) in other_known {
                 // self is missing this field, which returns null
-                self.known.insert(key, other_kind.or_undefined());
+                self.known_mut().insert(key, other_kind.or_undefined());
             }
         }
-        self.unknown.merge(other.unknown, overwrite);
+        self.unknown.merge(other_unknown, overwrite);
     }
 
     /// Return the reduced `Kind` of the items within the collection.
@@ -281,7 +339,7 @@ impl<T: Ord + Clone + CollectionKey> Collection<T> {
 
         // All known fields in `other` need to either be a subset of a matching known field in
         // `self`, or a subset of self's `unknown` type state.
-        for (key, other_kind) in &other.known {
+        for (key, other_kind) in other.known.iter() {
             match self.known.get(key) {
                 Some(self_kind) => {
                     self_kind
@@ -298,7 +356,7 @@ impl<T: Ord + Clone + CollectionKey> Collection<T> {
 
         // All known fields in `self` not known in `other` need to be a superset of other's
         // `unknown` type state.
-        for (key, self_kind) in &self.known {
+        for (key, self_kind) in self.known.iter() {
             if !other.known.contains_key(key) {
                 self_kind
                     .is_superset(&other.unknown_kind())
@@ -332,7 +390,7 @@ pub enum EmptyState {
 impl<T: Ord> From<BTreeMap<T, Kind>> for Collection<T> {
     fn from(known: BTreeMap<T, Kind>) -> Self {
         Self {
-            known,
+            known: SharedMap::new(known),
             unknown: Kind::undefined().into(),
         }
     }

--- a/src/value/kind/collection.rs
+++ b/src/value/kind/collection.rs
@@ -78,7 +78,7 @@ where
     BTreeMap<T, Kind>: PartialOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match self.known.deref().partial_cmp(other.known.deref()) {
+        match (*self.known).partial_cmp(&*other.known) {
             Some(Ordering::Equal) => self.unknown.partial_cmp(&other.unknown),
             non_eq => non_eq,
         }

--- a/src/value/kind/collection/field.rs
+++ b/src/value/kind/collection/field.rs
@@ -31,7 +31,7 @@ impl CollectionRemove for Collection<Field> {
     type Key = Field;
 
     fn remove_known(&mut self, key: &Field) {
-        self.known.remove(key);
+        self.known_mut().remove(key);
     }
 }
 

--- a/src/value/kind/collection/unknown.rs
+++ b/src/value/kind/collection/unknown.rs
@@ -1,5 +1,4 @@
 use crate::path::OwnedValuePath;
-use std::collections::BTreeMap;
 
 use super::Collection;
 use crate::value::Kind;
@@ -346,7 +345,7 @@ impl From<Infinite> for Kind {
 impl<T: Ord> From<Infinite> for Collection<T> {
     fn from(infinite: Infinite) -> Self {
         Self {
-            known: BTreeMap::default(),
+            known: super::SharedMap::empty(),
             unknown: Unknown::infinite(infinite),
         }
     }

--- a/src/value/kind/crud/insert.rs
+++ b/src/value/kind/crud/insert.rs
@@ -42,10 +42,15 @@ impl Kind {
             match segment {
                 BorrowedSegment::Field(field) => {
                     // Field insertion converts the value to an object, so remove all other types.
-                    *self =
-                        Self::object(self.as_object().cloned().unwrap_or_else(Collection::empty));
+                    // If already an exact object, mutate in place: cloning the Collection on every
+                    // nested field write makes progressive event typing O(known²).
+                    if !(self.is_object() && self.object.is_some()) {
+                        *self = Self::object(
+                            self.as_object().cloned().unwrap_or_else(Collection::empty),
+                        );
+                    }
 
-                    let collection = self.object.as_mut().expect("object was just inserted");
+                    let collection = self.object.as_mut().expect("object present after coerce");
                     let unknown_kind = collection.unknown_kind();
 
                     collection
@@ -56,8 +61,12 @@ impl Kind {
                 }
                 BorrowedSegment::Index(mut index) => {
                     // Array insertion converts the value to an array, so remove all other types.
-                    *self = Self::array(self.as_array().cloned().unwrap_or_else(Collection::empty));
-                    let collection = self.array.as_mut().expect("array was just inserted");
+                    // Same in-place fast path as objects when already an exact array.
+                    if !(self.is_array() && self.array.is_some()) {
+                        *self =
+                            Self::array(self.as_array().cloned().unwrap_or_else(Collection::empty));
+                    }
+                    let collection = self.array.as_mut().expect("array present after coerce");
 
                     if index < 0 {
                         let largest_known_index = collection.largest_known_index();


### PR DESCRIPTION
## Summary

Implements type-state sharing: three independent optimizations that make the compiler's type state cheaper to clone and merge:
* In-place `Kind` inserts and assignment types
* `Arc`-shared `Collection` known maps
* `Arc`-shared `LocalEnv` bindings

Why? our production VRL programs take 20-30 seconds to compile (and thus for vector to start), and profiling demonstrated this as a top hot spot.

Split out of #1865 at @pront's request (the two are dijoint but greatly complement each other).

Using the synthetic ladder test that exercises this hot spot in the compiler (using `--warmup 2 --repeat 5`, medians) gives:

| shape | base | this PR | speedup |
|---|---|---|---|
| 20 arms, 40 fields | 330 ms | 92 ms | 3.6x |
| 80 arms | 4502 ms | 2450 ms | 1.8x |
| wide arm body (82 arms, 8 coalesce, chain 3) | 16095 ms | 6229 ms | 2.6x |
| growing event Kind (`--fields-disjoint`) | 13975 ms | 9713 ms | 1.4x |

This is a constant-factor win, not the asymptotic win of #1865... it lowers the cost of each type-state operation but does not change the complexity class, which is why the speedup shrinks as arm count grows and the quadratic term fixed by #1865 still takes over.

Once #1865 fixes the quadratic work, this optimization cuts a larger slice of the remaining overhead, so further observed speedups with this on top of #1865 was a further 2.0x to 3.3x (521 ms to 174 ms at 160 arms; 1395 ms to 427 ms on the wide-arm shape).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

Full unit test coverage from the existing suite, plus the additional unit tests added in #1865 that further cover if-else ladder cases. The 26 complex production VRL programs also were shown to identical typing outputs before/after.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Split off of #1865.