### PR TITLE
security(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/changelog.d/1896.security.md
+++ b/changelog.d/1896.security.md
@@ -1,3 +1,0 @@
-Bumped the `h2` dependency to 0.4.16 to fix RUSTSEC-2026-0258, which patched an unbounded empty DATA frames denial-of-service vulnerability in HTTP/2.
-
-authors: pront

--- a/changelog.d/1896.security.md
+++ b/changelog.d/1896.security.md
@@ -1,0 +1,3 @@
+Bumped the `h2` dependency to 0.4.16 to fix RUSTSEC-2026-0258, which patched an unbounded empty DATA frames denial-of-service vulnerability in HTTP/2.
+
+authors: pront


### PR DESCRIPTION
## Summary

`h2` 0.4.15 is affected by [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) / [GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h) — unbounded empty HTTP/2 DATA frames can be queued without limit, a denial-of-service risk. Bump `h2` to 0.4.16, which patches the advisory.

`h2` is a transitive dependency (via `hyper` → `reqwest`), so this is a `Cargo.lock`-only change.

This fixes the failing `check-deny` CI check.