### PR TITLE
chore: bump MSRV from 1.90 to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/vectordotdev/vrl"
 readme = "README.md"
 keywords = ["vector", "dsl", "processing", "observability", "datadog"]
 categories = ["compilers"]
-rust-version = "1.90" # msrv
+rust-version = "1.95" # msrv
 
 [workspace]
 members = [


### PR DESCRIPTION
## Summary

Bump the Minimum Supported Rust Version (MSRV) in `Cargo.toml` from `1.90` to `1.95` to match the toolchain channel already specified in `rust-toolchain.toml`.

## Changes

- `Cargo.toml`: `rust-version` bumped from `1.90` → `1.95`

## Context

The `rust-toolchain.toml` was already pinned to `1.95`, but the MSRV in `Cargo.toml` was lagging behind at `1.90`. This aligns them.