### PR TITLE
chore(releasing): 0.35.0 post-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Changelog is generated from fragments in `changelog.d/` by the `release` crate.
 
 <!-- changelog start -->
 
+## [0.35.0 (2026-08-20)](https://github.com/vectordotdev/vrl/releases/tag/v0.35.0)
+
+### Enhancements
+
+- The `parse_aws_vpc_flow_log` function now recognizes all fields introduced in AWS VPC Flow Logs versions 7 through 11, including the v7 ECS metadata fields, v8 `reject_reason`, v9 `resource_id`, v10 `encryption_status`, and the v11 tag/interface/next-hop fields.
+
+  [PR #1879](https://github.com/vectordotdev/vrl/pull/1879) by [@avestuk](https://github.com/avestuk)
+
+### Fixes
+
+- Fixed `round`'s type definition, which previously always claimed to return an integer even though it returns a float for float inputs.
+
+  [PR #1862](https://github.com/vectordotdev/vrl/pull/1862) by [@thomasqueirozb](https://github.com/thomasqueirozb)
+- Prevent float arithmetic that produces NaN from panicking or silently returning zero. Such operations now return a runtime error.
+
+  [PR #1890](https://github.com/vectordotdev/vrl/pull/1890) by [@pront](https://github.com/pront)
+
+
 ## [0.34.0 (2026-07-13)](https://github.com/vectordotdev/vrl/releases/tag/v0.34.0)
 
 ### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,7 +4503,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrl"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "aes 0.9.2",
  "aes-siv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrl"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 license = "MPL-2.0"

--- a/changelog.d/1862.fix.md
+++ b/changelog.d/1862.fix.md
@@ -1,3 +1,0 @@
-Fixed `round`'s type definition, which previously always claimed to return an integer even though it returns a float for float inputs.
-
-authors: thomasqueirozb

--- a/changelog.d/1879.enhancement.md
+++ b/changelog.d/1879.enhancement.md
@@ -1,3 +1,0 @@
-The `parse_aws_vpc_flow_log` function now recognizes all fields introduced in AWS VPC Flow Logs versions 7 through 11, including the v7 ECS metadata fields, v8 `reject_reason`, v9 `resource_id`, v10 `encryption_status`, and the v11 tag/interface/next-hop fields.
-
-authors: avestuk

--- a/changelog.d/1890.fix.md
+++ b/changelog.d/1890.fix.md
@@ -1,3 +1,0 @@
-Prevent float arithmetic that produces NaN from panicking or silently returning zero. Such operations now return a runtime error.
-
-authors: pront


### PR DESCRIPTION
Release 0.35.0

Published to crates.io: https://crates.io/crates/vrl/0.35.0
Tag: `v0.35.0`

Related issue: https://github.com/vectordotdev/vector/issues/26136