### PR TITLE
fix(release): describe release PRs as post-release

### DIFF
--- a/release/src/main.rs
+++ b/release/src/main.rs
@@ -205,9 +205,9 @@ fn release(version_arg: Option<&str>, dry_run: bool, issue: Option<&str>) -> Res
     run("git", &["push", "origin", &tag], &root)?;
 
     println!("Creating pull request...");
-    let title = format!("chore(releasing): Prepare {new_version} release");
+    let title = format!("chore(releasing): Post-release {new_version}");
     let mut body = formatdoc! {"
-        Release {new_version}
+        Post-release update for VRL {new_version}
 
         Published to crates.io: https://crates.io/crates/vrl/{new_version}
         Tag: `{tag}`"


### PR DESCRIPTION
## Summary

Make the release tool label its generated PR as a post-release update, since the crate is already published and tagged before the PR is opened.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- `cargo check -p release`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vrl/blob/main/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [ ] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please run `dd-rust-license-tool write` and commit the changes.

## References

None.