### PR TITLE
chore(ci): group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,3 +77,7 @@ updates:
       - "no-changelog"
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      github_actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

### Motivation

Keep GitHub Actions dependency updates together so Dependabot opens one maintenance PR.

### Changes

- Add a `github_actions` group that matches every GitHub Actions dependency.

### Validation

- Parsed `.github/dependabot.yml` with the Ruby YAML loader.
- Ran `git diff --check` for the configuration change.