### PR TITLE
chore(dev): bump Rust toolchain to 1.96.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95"
+channel = "1.96.1"
 profile = "default"


### PR DESCRIPTION
## Summary

### Motivation

Rust 1.96.1 includes security fixes for the bundled libssh2 used by Cargo.

### Changes

- Bump the pinned Rust toolchain from 1.95 to 1.96.1.
- Keep the project MSRV at Rust 1.95.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

- `make check-clippy`
- `make fmt`
- `cargo test --workspace` (1,869 library tests passed; two pre-existing REPL output assertions also reproduce on Rust 1.95)
- `git diff --check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on
  our [guidelines](https://github.com/vectordotdev/vrl/blob/main/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Our [CONTRIBUTING.md](https://github.com/vectordotdev/vrl/blob/main/CONTRIBUTING.md) is a good starting place.
- [x] If this PR introduces changes to [LICENSE-3rdparty.csv](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv), please
  run `dd-rust-license-tool write` and commit the changes. More details [here](https://crates.io/crates/dd-rust-license-tool).

## References
