### PR TITLE
enhancement(stdlib): optimise md5

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -1335,6 +1335,16 @@ bench_function! {
         args: func_args![value: "foo"],
         want: Ok("acbd18db4cc2f85cedef654fccc4a4d8"),
     }
+
+    medium_256b {
+        args: func_args![value: "a".repeat(256)],
+        want: Ok("81109eec5aa1a284fb5327b10e9c16b9"),
+    }
+
+    large_4kb {
+        args: func_args![value: "a".repeat(4096)],
+        want: Ok("21a199c53f422a380e20b162fb6ebe9c"),
+    }
 }
 
 bench_function! {

--- a/changelog.d/optimize-md5.enhancement.md
+++ b/changelog.d/optimize-md5.enhancement.md
@@ -1,0 +1,3 @@
+Optimize `md5` runtime performance with stack-buffered hex encoding and compile-time constant evaluation for literals.
+
+authors: [jimmystewpot]

--- a/src/stdlib/md5.rs
+++ b/src/stdlib/md5.rs
@@ -48,11 +48,22 @@ impl Function for Md5 {
 
     fn compile(
         &self,
-        _state: &state::TypeState,
+        state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
+
+        if let Some(val) = value.resolve_constant(state)
+            && let Ok(bytes) = val.try_bytes()
+        {
+            let digest = md5::Md5::digest(&bytes);
+            let mut buf = [0u8; 32];
+            hex::encode_to_slice(digest, &mut buf).expect("32 bytes");
+            return Ok(Box::new(crate::compiler::expression::Literal::String(
+                Bytes::copy_from_slice(&buf),
+            )));
+        }
 
         Ok(Md5Fn { value }.as_expr())
     }
@@ -100,4 +111,48 @@ mod tests {
             tdef: TypeDef::bytes().infallible(),
         }
     ];
+
+    #[test]
+    fn test_md5_compiles_to_literal() {
+        use crate::compiler::CompileConfig;
+
+        let state = state::TypeState::default();
+        let mut ctx =
+            FunctionCompileContext::new(Span::default(), CompileConfig::default());
+        let mut args = ArgumentList::default();
+        args.insert("value", Value::from("foo").into());
+
+        let expr = Md5.compile(&state, &mut ctx, args).unwrap();
+        assert!(expr.resolve_constant(&state).is_some());
+        assert_eq!(
+            expr.resolve_constant(&state),
+            Some(Value::from("acbd18db4cc2f85cedef654fccc4a4d8"))
+        );
+    }
+
+    #[test]
+    fn test_md5_compiles_dynamic() {
+        use crate::compiler::CompileConfig;
+        use crate::compiler::expression::Variable;
+        use crate::compiler::parser::Ident;
+
+        let mut state = state::TypeState::default();
+        state.local.insert_variable(
+            Ident::new("foo"),
+            type_def::Details {
+                type_def: TypeDef::bytes(),
+                value: None,
+            },
+        );
+
+        let mut ctx =
+            FunctionCompileContext::new(Span::default(), CompileConfig::default());
+        let var = Variable::new((0, 0).into(), Ident::new("foo"), &state.local).unwrap();
+
+        let mut args = ArgumentList::default();
+        args.insert("value", var.into());
+
+        let expr = Md5.compile(&state, &mut ctx, args).unwrap();
+        assert!(expr.resolve_constant(&state).is_none());
+    }
 }

--- a/src/stdlib/md5.rs
+++ b/src/stdlib/md5.rs
@@ -3,7 +3,10 @@ use md5::Digest;
 
 fn md5(value: Value) -> Resolved {
     let value = value.try_bytes()?;
-    Ok(hex::encode(md5::Md5::digest(&value)).into())
+    let digest = md5::Md5::digest(&value);
+    let mut buf = [0u8; 32];
+    hex::encode_to_slice(digest, &mut buf).expect("32 bytes");
+    Ok(Value::Bytes(Bytes::copy_from_slice(&buf)))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -82,6 +85,18 @@ mod tests {
         md5 {
             args: func_args![value: "foo"],
             want: Ok(value!("acbd18db4cc2f85cedef654fccc4a4d8")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        md5_empty {
+            args: func_args![value: ""],
+            want: Ok(value!("d41d8cd98f00b204e9800998ecf8427e")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+        md5_sentence {
+            args: func_args![value: "The quick brown fox jumps over the lazy dog"],
+            want: Ok(value!("9e107d9d372bb6826bd81d3542a419d6")),
             tdef: TypeDef::bytes().infallible(),
         }
     ];


### PR DESCRIPTION
## Summary

Optimises `md5` runtime by replacing intermediate heap-allocated `String` hex encoding with zero-allocation stack formatting (`[u8; 32]` + `hex::encode_to_slice` + `Bytes::copy_from_slice`), and adds compile-time constant evaluation for static literal inputs.

## Benchmarks

- Runtime dynamic inputs (e.g. `.field`):
  - Small (3B): 240.1 ns -> 190.6 ns (-20.6% latency, +26.0% throughput)
  - Medium (256B): 526.4 ns -> 479.1 ns (-9.0% latency, +9.7% throughput)
- Compile-time folded literals:
  - Small (3B): 185.4 ns -> 22.5 ns (+724% throughput, ~8.2x faster)
  - Medium (256B): 473.0 ns -> 22.6 ns (+1,993% throughput, ~21x faster)
  - Large (4KB): 4,810.0 ns -> 22.5 ns (+21,277% throughput, ~214x faster)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Ran `cargo test --lib -- "stdlib::md5"`, `cargo test --workspace`, and `cargo bench --bench stdlib --features="default test" -- "functions/md5"`.

## Does this PR include user-facing changes?

- [x] Yes. Changelog fragment added at `changelog.d/optimize-md5.enhancement.md`.